### PR TITLE
Fixed bug with "This month" predefined range

### DIFF
--- a/src/picker.js
+++ b/src/picker.js
@@ -1159,7 +1159,7 @@ function picker(){
             {
 				label:'Last Month',
 				startDate:moment().subtract(1,'month').startOf('month'),
-				endDate: moment()
+				endDate: moment().subtract(1,'month').endOf('month')
 			},
             {
 				label: 'This Quarter',


### PR DESCRIPTION
`endDate` should be the end of the previous month not the current one.