### PR TITLE
Fixed bug on date range picker

### DIFF
--- a/app/picker/js/range-picker-input.js
+++ b/app/picker/js/range-picker-input.js
@@ -215,7 +215,11 @@ SMRangePickerCtrl.prototype.rangeSelected = function(range){
   var self = this;
   console.log(range);
   self.onRangeSelect({range: range});
-  self.value = range;
+	//give it a couple of ms for the $render method to finish.
+  setTimeout(function()
+  {
+	  self.value = range;
+  }, 50);
 }
 
 


### PR DESCRIPTION
When the same range picker option is clicked twice, the view is set as "[object Object]".