### PR TITLE
Fix Range endDate

### DIFF
--- a/app/picker/js/range-picker.js
+++ b/app/picker/js/range-picker.js
@@ -140,6 +140,10 @@ RangePickerCtrl.prototype.startDateSelected = function(date){
   this.startDate = date;
   this.scope.$emit('range-picker:startDateSelected');
   this.setNextView();
+	
+  if (this.endDate && this.endDate.diff(this.startDay, 'ms') < 0) {
+    this.endDate = date;
+  }
 }
 
 RangePickerCtrl.prototype.startTimeSelected = function(time){


### PR DESCRIPTION
Does not allow startDate > endDate when user click 'OK' and don't select endDate (endDate always is 'Today').

Example (format **MM/DD/YYYY)**

**startDate: 12/13/2016
enDate: 12/11/2016**

If user click 'OK'

Range will be: **startDate greater than endDate**