### PR TITLE
fix(moment): use UTC for moment()

### DIFF
--- a/app/picker/js/provider.js
+++ b/app/picker/js/provider.js
@@ -32,38 +32,38 @@ function picker(){
     var rangeDefaultList = [
         {
             label:'Today',
-            startDate:moment().startOf('day'),
-            endDate:moment().endOf('day')
+            startDate:moment().utc().startOf('day'),
+            endDate:moment().utc().endOf('day')
         },
         {
             label:'Last 7 Days',
-            startDate: moment().subtract(7, 'd'),
-            endDate:moment()
+            startDate: moment().utc().subtract(7, 'd').startOf('day'),
+            endDate:moment().utc().endOf('day')
         },
         {
             label:'This Month',
-            startDate:moment().startOf('month'),
-            endDate: moment().endOf('month')
+            startDate:moment().utc().startOf('month'),
+            endDate: moment().utc().endOf('month')
         },
         {
             label:'Last Month',
-            startDate:moment().subtract(1, 'month').startOf('month'),
-            endDate: moment().subtract(1, 'month').endOf('month')
+            startDate:moment().utc().subtract(1, 'month').startOf('month'),
+            endDate: moment().utc().subtract(1, 'month').endOf('month')
         },
         {
             label: 'This Quarter',
-            startDate: moment().startOf('quarter'),
-            endDate: moment().endOf('quarter')
+            startDate: moment().utc().startOf('quarter'),
+            endDate: moment().utc().endOf('quarter')
         },
         {
             label:  'Year To Date',
-            startDate:  moment().startOf('year'),
-            endDate:  moment()
+            startDate:  moment().utc().startOf('year'),
+            endDate:  moment().utc().endOf('day')
         },
         {
             label:  'This Year',
-            startDate:  moment().startOf('year'),
-            endDate:  moment().endOf('year')
+            startDate:  moment().utc().startOf('year'),
+            endDate:  moment().utc().endOf('year')
         }
     ];
 

--- a/dist/scripts/script.min.js
+++ b/dist/scripts/script.min.js
@@ -1384,38 +1384,38 @@ function picker(){
     var rangeDefaultList = [
         {
             label:'Today',
-            startDate:moment().startOf('day'),
-            endDate:moment().endOf('day')
+            startDate:moment().utc().startOf('day'),
+            endDate:moment().utc().endOf('day')
         },
         {
             label:'Last 7 Days',
-            startDate: moment().subtract(7, 'd'),
-            endDate:moment()
+            startDate: moment().utc().subtract(7, 'd').startOf('day'),
+            endDate:moment().utc().endOf('day')
         },
         {
             label:'This Month',
-            startDate:moment().startOf('month'),
-            endDate: moment().endOf('month')
+            startDate:moment().utc().startOf('month'),
+            endDate: moment().utc().endOf('month')
         },
         {
             label:'Last Month',
-            startDate:moment().subtract(1, 'month').startOf('month'),
-            endDate: moment().subtract(1, 'month').endOf('month')
+            startDate:moment().utc().subtract(1, 'month').startOf('month'),
+            endDate: moment().utc().subtract(1, 'month').endOf('month')
         },
         {
             label: 'This Quarter',
-            startDate: moment().startOf('quarter'),
-            endDate: moment().endOf('quarter')
+            startDate: moment().utc().startOf('quarter'),
+            endDate: moment().utc().endOf('quarter')
         },
         {
             label:  'Year To Date',
-            startDate:  moment().startOf('year'),
-            endDate:  moment()
+            startDate:  moment().utc().startOf('year'),
+            endDate:  moment().utc().endOf('day')
         },
         {
             label:  'This Year',
-            startDate:  moment().startOf('year'),
-            endDate:  moment().endOf('year')
+            startDate:  moment().utc().startOf('year'),
+            endDate:  moment().utc().endOf('year')
         }
     ];
 

--- a/dist/scripts/vendor.min.js
+++ b/dist/scripts/vendor.min.js
@@ -1,6 +1,6 @@
 /**
- * @license AngularJS v1.6.1
- * (c) 2010-2016 Google, Inc. http://angularjs.org
+ * @license AngularJS v1.6.3
+ * (c) 2010-2017 Google, Inc. http://angularjs.org
  * License: MIT
  */
 (function(window) {'use strict';
@@ -38,31 +38,29 @@
 function minErr(module, ErrorConstructor) {
   ErrorConstructor = ErrorConstructor || Error;
   return function() {
-    var SKIP_INDEXES = 2;
-
-    var templateArgs = arguments,
-      code = templateArgs[0],
+    var code = arguments[0],
+      template = arguments[1],
       message = '[' + (module ? module + ':' : '') + code + '] ',
-      template = templateArgs[1],
+      templateArgs = sliceArgs(arguments, 2).map(function(arg) {
+        return toDebugString(arg, minErrConfig.objectMaxDepth);
+      }),
       paramPrefix, i;
 
     message += template.replace(/\{\d+\}/g, function(match) {
-      var index = +match.slice(1, -1),
-        shiftedIndex = index + SKIP_INDEXES;
+      var index = +match.slice(1, -1);
 
-      if (shiftedIndex < templateArgs.length) {
-        return toDebugString(templateArgs[shiftedIndex]);
+      if (index < templateArgs.length) {
+        return templateArgs[index];
       }
 
       return match;
     });
 
-    message += '\nhttp://errors.angularjs.org/1.6.1/' +
+    message += '\nhttp://errors.angularjs.org/1.6.3/' +
       (module ? module + '/' : '') + code;
 
-    for (i = SKIP_INDEXES, paramPrefix = '?'; i < templateArgs.length; i++, paramPrefix = '&') {
-      message += paramPrefix + 'p' + (i - SKIP_INDEXES) + '=' +
-        encodeURIComponent(toDebugString(templateArgs[i]));
+    for (i = 0, paramPrefix = '?'; i < templateArgs.length; i++, paramPrefix = '&') {
+      message += paramPrefix + 'p' + i + '=' + encodeURIComponent(templateArgs[i]);
     }
 
     return new ErrorConstructor(message);
@@ -79,6 +77,9 @@ function minErr(module, ErrorConstructor) {
   splice,
   push,
   toString,
+  minErrConfig,
+  errorHandlingConfig,
+  isValidObjectMaxDepth,
   ngMinErr,
   angularModule,
   uid,
@@ -193,6 +194,50 @@ var VALIDITY_STATE_PROPERTY = 'validity';
 
 
 var hasOwnProperty = Object.prototype.hasOwnProperty;
+
+var minErrConfig = {
+  objectMaxDepth: 5
+};
+
+ /**
+ * @ngdoc function
+ * @name angular.errorHandlingConfig
+ * @module ng
+ * @kind function
+ *
+ * @description
+ * Configure several aspects of error handling in AngularJS if used as a setter or return the
+ * current configuration if used as a getter. The following options are supported:
+ *
+ * - **objectMaxDepth**: The maximum depth to which objects are traversed when stringified for error messages.
+ *
+ * Omitted or undefined options will leave the corresponding configuration values unchanged.
+ *
+ * @param {Object=} config - The configuration object. May only contain the options that need to be
+ *     updated. Supported keys:
+ *
+ * * `objectMaxDepth`  **{Number}** - The max depth for stringifying objects. Setting to a
+ *   non-positive or non-numeric value, removes the max depth limit.
+ *   Default: 5
+ */
+function errorHandlingConfig(config) {
+  if (isObject(config)) {
+    if (isDefined(config.objectMaxDepth)) {
+      minErrConfig.objectMaxDepth = isValidObjectMaxDepth(config.objectMaxDepth) ? config.objectMaxDepth : NaN;
+    }
+  } else {
+    return minErrConfig;
+  }
+}
+
+/**
+ * @private
+ * @param {Number} maxDepth
+ * @return {boolean}
+ */
+function isValidObjectMaxDepth(maxDepth) {
+  return isNumber(maxDepth) && maxDepth > 0;
+}
 
 /**
  * @ngdoc function
@@ -916,9 +961,10 @@ function arrayRemove(array, value) {
     </file>
   </example>
  */
-function copy(source, destination) {
+function copy(source, destination, maxDepth) {
   var stackSource = [];
   var stackDest = [];
+  maxDepth = isValidObjectMaxDepth(maxDepth) ? maxDepth : NaN;
 
   if (destination) {
     if (isTypedArray(destination) || isArrayBuffer(destination)) {
@@ -941,35 +987,39 @@ function copy(source, destination) {
 
     stackSource.push(source);
     stackDest.push(destination);
-    return copyRecurse(source, destination);
+    return copyRecurse(source, destination, maxDepth);
   }
 
-  return copyElement(source);
+  return copyElement(source, maxDepth);
 
-  function copyRecurse(source, destination) {
+  function copyRecurse(source, destination, maxDepth) {
+    maxDepth--;
+    if (maxDepth < 0) {
+      return '...';
+    }
     var h = destination.$$hashKey;
     var key;
     if (isArray(source)) {
       for (var i = 0, ii = source.length; i < ii; i++) {
-        destination.push(copyElement(source[i]));
+        destination.push(copyElement(source[i], maxDepth));
       }
     } else if (isBlankObject(source)) {
       // createMap() fast path --- Safe to avoid hasOwnProperty check because prototype chain is empty
       for (key in source) {
-        destination[key] = copyElement(source[key]);
+        destination[key] = copyElement(source[key], maxDepth);
       }
     } else if (source && typeof source.hasOwnProperty === 'function') {
       // Slow path, which must rely on hasOwnProperty
       for (key in source) {
         if (source.hasOwnProperty(key)) {
-          destination[key] = copyElement(source[key]);
+          destination[key] = copyElement(source[key], maxDepth);
         }
       }
     } else {
       // Slowest path --- hasOwnProperty can't be called as a method
       for (key in source) {
         if (hasOwnProperty.call(source, key)) {
-          destination[key] = copyElement(source[key]);
+          destination[key] = copyElement(source[key], maxDepth);
         }
       }
     }
@@ -977,7 +1027,7 @@ function copy(source, destination) {
     return destination;
   }
 
-  function copyElement(source) {
+  function copyElement(source, maxDepth) {
     // Simple values
     if (!isObject(source)) {
       return source;
@@ -1006,7 +1056,7 @@ function copy(source, destination) {
     stackDest.push(destination);
 
     return needsRecurse
-      ? copyRecurse(source, destination)
+      ? copyRecurse(source, destination, maxDepth)
       : destination;
   }
 
@@ -1548,30 +1598,51 @@ function getNgAttribute(element, ngAttr) {
 }
 
 function allowAutoBootstrap(document) {
-  if (!document.currentScript) {
+  var script = document.currentScript;
+
+  if (!script) {
+    // IE does not have `document.currentScript`
     return true;
   }
-  var src = document.currentScript.getAttribute('src');
-  var link = document.createElement('a');
-  link.href = src;
-  if (document.location.origin === link.origin) {
-    // Same-origin resources are always allowed, even for non-whitelisted schemes.
-    return true;
+
+  // If the `currentScript` property has been clobbered just return false, since this indicates a probable attack
+  if (!(script instanceof window.HTMLScriptElement || script instanceof window.SVGScriptElement)) {
+    return false;
   }
-  // Disabled bootstrapping unless angular.js was loaded from a known scheme used on the web.
-  // This is to prevent angular.js bundled with browser extensions from being used to bypass the
-  // content security policy in web pages and other browser extensions.
-  switch (link.protocol) {
-    case 'http:':
-    case 'https:':
-    case 'ftp:':
-    case 'blob:':
-    case 'file:':
-    case 'data:':
+
+  var attributes = script.attributes;
+  var srcs = [attributes.getNamedItem('src'), attributes.getNamedItem('href'), attributes.getNamedItem('xlink:href')];
+
+  return srcs.every(function(src) {
+    if (!src) {
       return true;
-    default:
+    }
+    if (!src.value) {
       return false;
-  }
+    }
+
+    var link = document.createElement('a');
+    link.href = src.value;
+
+    if (document.location.origin === link.origin) {
+      // Same-origin resources are always allowed, even for non-whitelisted schemes.
+      return true;
+    }
+    // Disabled bootstrapping unless angular.js was loaded from a known scheme used on the web.
+    // This is to prevent angular.js bundled with browser extensions from being used to bypass the
+    // content security policy in web pages and other browser extensions.
+    switch (link.protocol) {
+      case 'http:':
+      case 'https:':
+      case 'ftp:':
+      case 'blob:':
+      case 'file:':
+      case 'data:':
+        return true;
+      default:
+        return false;
+    }
+  });
 }
 
 // Cached as it has to run during loading so that document.currentScript is available.
@@ -1935,7 +2006,7 @@ function bindJQuery() {
     extend(jQuery.fn, {
       scope: JQLitePrototype.scope,
       isolateScope: JQLitePrototype.isolateScope,
-      controller: JQLitePrototype.controller,
+      controller: /** @type {?} */ (JQLitePrototype).controller,
       injector: JQLitePrototype.injector,
       inheritedData: JQLitePrototype.inheritedData
     });
@@ -2168,6 +2239,9 @@ function setupModuleLoader(window) {
      * @returns {angular.Module} new module with the {@link angular.Module} api.
      */
     return function module(name, requires, configFn) {
+
+      var info = {};
+
       var assertNotHasOwnProperty = function(name, context) {
         if (name === 'hasOwnProperty') {
           throw ngMinErr('badname', 'hasOwnProperty is not a valid {0} name', context);
@@ -2202,6 +2276,45 @@ function setupModuleLoader(window) {
           _invokeQueue: invokeQueue,
           _configBlocks: configBlocks,
           _runBlocks: runBlocks,
+
+          /**
+           * @ngdoc method
+           * @name angular.Module#info
+           * @module ng
+           *
+           * @param {Object=} info Information about the module
+           * @returns {Object|Module} The current info object for this module if called as a getter,
+           *                          or `this` if called as a setter.
+           *
+           * @description
+           * Read and write custom information about this module.
+           * For example you could put the version of the module in here.
+           *
+           * ```js
+           * angular.module('myModule', []).info({ version: '1.0.0' });
+           * ```
+           *
+           * The version could then be read back out by accessing the module elsewhere:
+           *
+           * ```
+           * var version = angular.module('myModule').info().version;
+           * ```
+           *
+           * You can also retrieve this information during runtime via the
+           * {@link $injector#modules `$injector.modules`} property:
+           *
+           * ```js
+           * var version = $injector.modules['myModule'].info().version;
+           * ```
+           */
+          info: function(value) {
+            if (isDefined(value)) {
+              if (!isObject(value)) throw ngMinErr('aobj', 'Argument \'{0}\' must be an object', 'value');
+              info = value;
+              return this;
+            }
+            return info;
+          },
 
           /**
            * @ngdoc property
@@ -2481,9 +2594,15 @@ function shallowCopy(src, dst) {
 
 /* global toDebugString: true */
 
-function serializeObject(obj) {
+function serializeObject(obj, maxDepth) {
   var seen = [];
 
+  // There is no direct way to stringify object until reaching a specific depth
+  // and a very deep object can cause a performance issue, so we copy the object
+  // based on this specific depth and then stringify it.
+  if (isValidObjectMaxDepth(maxDepth)) {
+    obj = copy(obj, null, maxDepth);
+  }
   return JSON.stringify(obj, function(key, val) {
     val = toJsonReplacer(key, val);
     if (isObject(val)) {
@@ -2496,13 +2615,13 @@ function serializeObject(obj) {
   });
 }
 
-function toDebugString(obj) {
+function toDebugString(obj, maxDepth) {
   if (typeof obj === 'function') {
     return obj.toString().replace(/ \{[\s\S]*$/, '');
   } else if (isUndefined(obj)) {
     return 'undefined';
   } else if (typeof obj !== 'string') {
-    return serializeObject(obj);
+    return serializeObject(obj, maxDepth);
   }
   return obj;
 }
@@ -2577,7 +2696,6 @@ function toDebugString(obj) {
   $$ForceReflowProvider,
   $InterpolateProvider,
   $IntervalProvider,
-  $$HashMapProvider,
   $HttpProvider,
   $HttpParamSerializerProvider,
   $HttpParamSerializerJQLikeProvider,
@@ -2586,6 +2704,7 @@ function toDebugString(obj) {
   $jsonpCallbacksProvider,
   $LocationProvider,
   $LogProvider,
+  $$MapProvider,
   $ParseProvider,
   $RootScopeProvider,
   $QProvider,
@@ -2623,16 +2742,17 @@ function toDebugString(obj) {
 var version = {
   // These placeholder strings will be replaced by grunt's `build` task.
   // They need to be double- or single-quoted.
-  full: '1.6.1',
+  full: '1.6.3',
   major: 1,
   minor: 6,
-  dot: 1,
-  codeName: 'promise-rectification'
+  dot: 3,
+  codeName: 'scriptalicious-bootstrapping'
 };
 
 
 function publishExternalAPI(angular) {
   extend(angular, {
+    'errorHandlingConfig': errorHandlingConfig,
     'bootstrap': bootstrap,
     'copy': copy,
     'extend': extend,
@@ -2767,11 +2887,12 @@ function publishExternalAPI(angular) {
         $window: $WindowProvider,
         $$rAF: $$RAFProvider,
         $$jqLite: $$jqLiteProvider,
-        $$HashMap: $$HashMapProvider,
+        $$Map: $$MapProvider,
         $$cookieReader: $$CookieReaderProvider
       });
     }
-  ]);
+  ])
+  .info({ angularVersion: '1.6.3' });
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
@@ -3915,50 +4036,70 @@ function hashKey(obj, nextUidFn) {
   return key;
 }
 
-/**
- * HashMap which can use objects as keys
- */
-function HashMap(array, isolatedUid) {
-  if (isolatedUid) {
-    var uid = 0;
-    this.nextUid = function() {
-      return ++uid;
-    };
-  }
-  forEach(array, this.put, this);
+// A minimal ES2015 Map implementation.
+// Should be bug/feature equivalent to the native implementations of supported browsers
+// (for the features required in Angular).
+// See https://kangax.github.io/compat-table/es6/#test-Map
+var nanKey = Object.create(null);
+function NgMapShim() {
+  this._keys = [];
+  this._values = [];
+  this._lastKey = NaN;
+  this._lastIndex = -1;
 }
-HashMap.prototype = {
-  /**
-   * Store key value pair
-   * @param key key to store can be any type
-   * @param value value to store can be any type
-   */
-  put: function(key, value) {
-    this[hashKey(key, this.nextUid)] = value;
+NgMapShim.prototype = {
+  _idx: function(key) {
+    if (key === this._lastKey) {
+      return this._lastIndex;
+    }
+    this._lastKey = key;
+    this._lastIndex = this._keys.indexOf(key);
+    return this._lastIndex;
   },
-
-  /**
-   * @param key
-   * @returns {Object} the value for the key
-   */
+  _transformKey: function(key) {
+    return isNumberNaN(key) ? nanKey : key;
+  },
   get: function(key) {
-    return this[hashKey(key, this.nextUid)];
+    key = this._transformKey(key);
+    var idx = this._idx(key);
+    if (idx !== -1) {
+      return this._values[idx];
+    }
   },
+  set: function(key, value) {
+    key = this._transformKey(key);
+    var idx = this._idx(key);
+    if (idx === -1) {
+      idx = this._lastIndex = this._keys.length;
+    }
+    this._keys[idx] = key;
+    this._values[idx] = value;
 
-  /**
-   * Remove the key/value pair
-   * @param key
-   */
-  remove: function(key) {
-    var value = this[key = hashKey(key, this.nextUid)];
-    delete this[key];
-    return value;
+    // Support: IE11
+    // Do not `return this` to simulate the partial IE11 implementation
+  },
+  delete: function(key) {
+    key = this._transformKey(key);
+    var idx = this._idx(key);
+    if (idx === -1) {
+      return false;
+    }
+    this._keys.splice(idx, 1);
+    this._values.splice(idx, 1);
+    this._lastKey = NaN;
+    this._lastIndex = -1;
+    return true;
   }
 };
 
-var $$HashMapProvider = [/** @this */function() {
+// For now, always use `NgMapShim`, even if `window.Map` is available. Some native implementations
+// are still buggy (often in subtle ways) and can cause hard-to-debug failures. When native `Map`
+// implementations get more stable, we can reconsider switching to `window.Map` (when available).
+var NgMap = NgMapShim;
+
+var $$MapProvider = [/** @this */function() {
   this.$get = [function() {
-    return HashMap;
+    return NgMap;
   }];
 }];
 
@@ -4033,11 +4174,7 @@ var STRIP_COMMENTS = /((\/\/.*$)|(\/\*[\s\S]*?\*\/))/mg;
 var $injectorMinErr = minErr('$injector');
 
 function stringifyFn(fn) {
-  // Support: Chrome 50-51 only
-  // Creating a new string by adding `' '` at the end, to hack around some bug in Chrome v50/51
-  // (See https://github.com/angular/angular.js/issues/14487.)
-  // TODO (gkalpak): Remove workaround when Chrome v52 is released
-  return Function.prototype.toString.call(fn) + ' ';
+  return Function.prototype.toString.call(fn);
 }
 
 function extractArgs(fn) {
@@ -4145,6 +4282,28 @@ function annotate(fn, strictDi, name) {
  * ## Inline
  * As an array of injection names, where the last item in the array is the function to call.
  */
+
+/**
+ * @ngdoc property
+ * @name $injector#modules
+ * @type {Object}
+ * @description
+ * A hash containing all the modules that have been loaded into the
+ * $injector.
+ *
+ * You can use this property to find out information about a module via the
+ * {@link angular.Module#info `myModule.info(...)`} method.
+ *
+ * For example:
+ *
+ * ```
+ * var info = $injector.modules['ngAnimate'].info();
+ * ```
+ *
+ * **Do not use this property to attempt to modify the modules after the application
+ * has been bootstrapped.**
+ */
+
 
 /**
  * @ngdoc method
@@ -4611,7 +4770,7 @@ function createInjector(modulesToLoad, strictDi) {
   var INSTANTIATING = {},
       providerSuffix = 'Provider',
       path = [],
-      loadedModules = new HashMap([], true),
+      loadedModules = new NgMap(),
       providerCache = {
         $provide: {
             provider: supportObject(provider),
@@ -4639,6 +4798,7 @@ function createInjector(modulesToLoad, strictDi) {
       instanceInjector = protoInstanceInjector;
 
   providerCache['$injector' + providerSuffix] = { $get: valueFn(protoInstanceInjector) };
+  instanceInjector.modules = providerInjector.modules = createMap();
   var runBlocks = loadModules(modulesToLoad);
   instanceInjector = protoInstanceInjector.get('$injector');
   instanceInjector.strictDi = strictDi;
@@ -4719,7 +4879,7 @@ function createInjector(modulesToLoad, strictDi) {
     var runBlocks = [], moduleFn;
     forEach(modulesToLoad, function(module) {
       if (loadedModules.get(module)) return;
-      loadedModules.put(module, true);
+      loadedModules.set(module, true);
 
       function runInvokeQueue(queue) {
         var i, ii;
@@ -4734,6 +4894,7 @@ function createInjector(modulesToLoad, strictDi) {
       try {
         if (isString(module)) {
           moduleFn = angularModule(module);
+          instanceInjector.modules[module] = moduleFn;
           runBlocks = runBlocks.concat(loadModules(moduleFn.requires)).concat(moduleFn._runBlocks);
           runInvokeQueue(moduleFn._invokeQueue);
           runInvokeQueue(moduleFn._configBlocks);
@@ -5205,7 +5366,7 @@ var $$CoreAnimateJsProvider = /** @this */ function() {
 // this is prefixed with Core since it conflicts with
 // the animateQueueProvider defined in ngAnimate/animateQueue.js
 var $$CoreAnimateQueueProvider = /** @this */ function() {
-  var postDigestQueue = new HashMap();
+  var postDigestQueue = new NgMap();
   var postDigestElements = [];
 
   this.$get = ['$$AnimateRunner', '$rootScope',
@@ -5284,7 +5445,7 @@ var $$CoreAnimateQueueProvider = /** @this */ function() {
               jqLiteRemoveClass(elm, toRemove);
             }
           });
-          postDigestQueue.remove(element);
+          postDigestQueue.delete(element);
         }
       });
       postDigestElements.length = 0;
@@ -5299,7 +5460,7 @@ var $$CoreAnimateQueueProvider = /** @this */ function() {
 
       if (classesAdded || classesRemoved) {
 
-        postDigestQueue.put(element, data);
+        postDigestQueue.set(element, data);
         postDigestElements.push(element);
 
         if (postDigestElements.length === 1) {
@@ -5324,6 +5485,7 @@ var $$CoreAnimateQueueProvider = /** @this */ function() {
  */
 var $AnimateProvider = ['$provide', /** @this */ function($provide) {
   var provider = this;
+  var classNameFilter = null;
 
   this.$$registeredAnimations = Object.create(null);
 
@@ -5392,15 +5554,16 @@ var $AnimateProvider = ['$provide', /** @this */ function($provide) {
    */
   this.classNameFilter = function(expression) {
     if (arguments.length === 1) {
-      this.$$classNameFilter = (expression instanceof RegExp) ? expression : null;
-      if (this.$$classNameFilter) {
-        var reservedRegex = new RegExp('(\\s+|\\/)' + NG_ANIMATE_CLASSNAME + '(\\s+|\\/)');
-        if (reservedRegex.test(this.$$classNameFilter.toString())) {
-          throw $animateMinErr('nongcls','$animateProvider.classNameFilter(regex) prohibits accepting a regex value which matches/contains the "{0}" CSS class.', NG_ANIMATE_CLASSNAME);
+      classNameFilter = (expression instanceof RegExp) ? expression : null;
+      if (classNameFilter) {
+        var reservedRegex = new RegExp('[(\\s|\\/)]' + NG_ANIMATE_CLASSNAME + '[(\\s|\\/)]');
+        if (reservedRegex.test(classNameFilter.toString())) {
+          classNameFilter = null;
+          throw $animateMinErr('nongcls', '$animateProvider.classNameFilter(regex) prohibits accepting a regex value which matches/contains the "{0}" CSS class.', NG_ANIMATE_CLASSNAME);
         }
       }
     }
-    return this.$$classNameFilter;
+    return classNameFilter;
   };
 
   this.$get = ['$$animateQueue', function($$animateQueue) {
@@ -6159,7 +6322,6 @@ function Browser(window, document, $log, $sniffer) {
       };
 
   cacheState();
-  lastHistoryState = cachedState;
 
   /**
    * @name $browser#url
@@ -6213,8 +6375,6 @@ function Browser(window, document, $log, $sniffer) {
       if ($sniffer.history && (!sameBase || !sameState)) {
         history[replace ? 'replaceState' : 'pushState'](state, '', url);
         cacheState();
-        // Do the assignment again so that those two variables are referentially identical.
-        lastHistoryState = cachedState;
       } else {
         if (!sameBase) {
           pendingLocation = url;
@@ -6263,8 +6423,7 @@ function Browser(window, document, $log, $sniffer) {
 
   function cacheStateAndFireUrlChange() {
     pendingLocation = null;
-    cacheState();
-    fireUrlChange();
+    fireStateOrUrlChange();
   }
 
   // This variable should be used *only* inside the cacheState function.
@@ -6278,11 +6437,16 @@ function Browser(window, document, $log, $sniffer) {
     if (equals(cachedState, lastCachedState)) {
       cachedState = lastCachedState;
     }
+
     lastCachedState = cachedState;
+    lastHistoryState = cachedState;
   }
 
-  function fireUrlChange() {
-    if (lastBrowserUrl === self.url() && lastHistoryState === cachedState) {
+  function fireStateOrUrlChange() {
+    var prevLastHistoryState = lastHistoryState;
+    cacheState();
+
+    if (lastBrowserUrl === self.url() && prevLastHistoryState === cachedState) {
       return;
     }
 
@@ -6317,8 +6481,8 @@ function Browser(window, document, $log, $sniffer) {
   self.onUrlChange = function(callback) {
     // TODO(vojta): refactor to use node's syntax for events
     if (!urlChangeInit) {
-      // We listen on both (hashchange/popstate) when available, as some browsers (e.g. Opera)
-      // don't fire popstate when user change the address bar and don't fire hashchange when url
+      // We listen on both (hashchange/popstate) when available, as some browsers don't
+      // fire popstate when user changes the address bar and don't fire hashchange when url
       // changed by push/replaceState
 
       // html5 history api - popstate event
@@ -6348,7 +6512,7 @@ function Browser(window, document, $log, $sniffer) {
    * Needs to be exported to be able to check for changes that have been done in sync,
    * as hashchange/popstate events fire in async.
    */
-  self.$$checkUrlChange = fireUrlChange;
+  self.$$checkUrlChange = fireStateOrUrlChange;
 
   //////////////////////////////////////////////////////////////
   // Misc API
@@ -6958,7 +7122,8 @@ function $TemplateCacheProvider() {
  * * `$onChanges(changesObj)` - Called whenever one-way (`<`) or interpolation (`@`) bindings are updated. The
  *   `changesObj` is a hash whose keys are the names of the bound properties that have changed, and the values are an
  *   object of the form `{ currentValue, previousValue, isFirstChange() }`. Use this hook to trigger updates within a
- *   component such as cloning the bound value to prevent accidental mutation of the outer value.
+ *   component such as cloning the bound value to prevent accidental mutation of the outer value. Note that this will
+ *   also be called when your bindings are initialized.
  * * `$doCheck()` - Called on each turn of the digest cycle. Provides an opportunity to detect and act on
  *   changes. Any actions that you wish to take in response to the changes that you detect must be
  *   invoked from this hook; implementing this has no effect on when `$onChanges` is called. For example, this hook
@@ -7106,10 +7271,12 @@ function $TemplateCacheProvider() {
  * the directive's element. If multiple directives on the same element request a new scope,
  * only one new scope is created.
  *
- * * **`{...}` (an object hash):** A new "isolate" scope is created for the directive's element. The
- * 'isolate' scope differs from normal scope in that it does not prototypically inherit from its parent
- * scope. This is useful when creating reusable components, which should not accidentally read or modify
- * data in the parent scope.
+ * * **`{...}` (an object hash):** A new "isolate" scope is created for the directive's template.
+ * The 'isolate' scope differs from normal scope in that it does not prototypically
+ * inherit from its parent scope. This is useful when creating reusable components, which should not
+ * accidentally read or modify data in the parent scope. Note that an isolate scope
+ * directive without a `template` or `templateUrl` will not apply the isolate scope
+ * to its children elements.
  *
  * The 'isolate' scope object hash defines a set of local scope properties derived from attributes on the
  * directive's element. These local properties are useful for aliasing values for templates. The keys in
@@ -7813,7 +7980,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
   var bindingCache = createMap();
 
   function parseIsolateBindings(scope, directiveName, isController) {
-    var LOCAL_REGEXP = /^\s*([@&<]|=(\*?))(\??)\s*(\w*)\s*$/;
+    var LOCAL_REGEXP = /^\s*([@&<]|=(\*?))(\??)\s*([\w$]*)\s*$/;
 
     var bindings = createMap();
 
@@ -9985,7 +10152,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
           if (error instanceof Error) {
             $exceptionHandler(error);
           }
-        }).catch(noop);
+        });
 
       return function delayedNodeLinkFn(ignoreChildLinkFn, scope, node, rootElement, boundTranscludeFn) {
         var childBoundTranscludeFn = boundTranscludeFn;
@@ -12117,7 +12284,8 @@ function $HttpProvider() {
       if ((config.cache || defaults.cache) && config.cache !== false &&
           (config.method === 'GET' || config.method === 'JSONP')) {
         cache = isObject(config.cache) ? config.cache
-              : isObject(defaults.cache) ? defaults.cache
+            : isObject(/** @type {?} */ (defaults).cache)
+              ? /** @type {?} */ (defaults).cache
               : defaultCache;
       }
 
@@ -13076,8 +13244,8 @@ function $IntervalProvider() {
  * how they vary compared to the requested url.
  */
 var $jsonpCallbacksProvider = /** @this */ function() {
-  this.$get = ['$window', function($window) {
-    var callbacks = $window.angular.callbacks;
+  this.$get = function() {
+    var callbacks = angular.callbacks;
     var callbackMap = {};
 
     function createCallback(callbackId) {
@@ -13144,7 +13312,7 @@ var $jsonpCallbacksProvider = /** @this */ function() {
         delete callbackMap[callbackPath];
       }
     };
-  }];
+  };
 };
 
 /**
@@ -13295,6 +13463,8 @@ function LocationHtml5Url(appBase, appBaseNoFile, basePrefix) {
 
     this.$$url = encodePath(this.$$path) + (search ? '?' + search : '') + hash;
     this.$$absUrl = appBaseNoFile + this.$$url.substr(1); // first char is always '/'
+
+    this.$$urlUpdatedByLocation = true;
   };
 
   this.$$parseLinkUrl = function(url, relHref) {
@@ -13372,7 +13542,7 @@ function LocationHashbangUrl(appBase, appBaseNoFile, hashPrefix) {
         withoutHashUrl = '';
         if (isUndefined(withoutBaseUrl)) {
           appBase = url;
-          this.replace();
+          /** @type {?} */ (this).replace();
         }
       }
     }
@@ -13428,6 +13598,8 @@ function LocationHashbangUrl(appBase, appBaseNoFile, hashPrefix) {
 
     this.$$url = encodePath(this.$$path) + (search ? '?' + search : '') + hash;
     this.$$absUrl = appBase + (this.$$url ? hashPrefix + this.$$url : '');
+
+    this.$$urlUpdatedByLocation = true;
   };
 
   this.$$parseLinkUrl = function(url, relHref) {
@@ -13485,6 +13657,8 @@ function LocationHashbangInHtml5Url(appBase, appBaseNoFile, hashPrefix) {
     this.$$url = encodePath(this.$$path) + (search ? '?' + search : '') + hash;
     // include hashPrefix in $$absUrl when $$url is empty so IE9 does not reload page because of removal of '#'
     this.$$absUrl = appBase + hashPrefix + this.$$url;
+
+    this.$$urlUpdatedByLocation = true;
   };
 
 }
@@ -13814,6 +13988,7 @@ forEach([LocationHashbangInHtml5Url, LocationHashbangUrl, LocationHtml5Url], fun
     // but we're changing the $$state reference to $browser.state() during the $digest
     // so the modification window is narrow.
     this.$$state = isUndefined(state) ? null : state;
+    this.$$urlUpdatedByLocation = true;
 
     return this;
   };
@@ -14126,36 +14301,40 @@ function $LocationProvider() {
 
     // update browser
     $rootScope.$watch(function $locationWatch() {
-      var oldUrl = trimEmptyHash($browser.url());
-      var newUrl = trimEmptyHash($location.absUrl());
-      var oldState = $browser.state();
-      var currentReplace = $location.$$replace;
-      var urlOrStateChanged = oldUrl !== newUrl ||
-        ($location.$$html5 && $sniffer.history && oldState !== $location.$$state);
+      if (initializing || $location.$$urlUpdatedByLocation) {
+        $location.$$urlUpdatedByLocation = false;
 
-      if (initializing || urlOrStateChanged) {
-        initializing = false;
+        var oldUrl = trimEmptyHash($browser.url());
+        var newUrl = trimEmptyHash($location.absUrl());
+        var oldState = $browser.state();
+        var currentReplace = $location.$$replace;
+        var urlOrStateChanged = oldUrl !== newUrl ||
+          ($location.$$html5 && $sniffer.history && oldState !== $location.$$state);
 
-        $rootScope.$evalAsync(function() {
-          var newUrl = $location.absUrl();
-          var defaultPrevented = $rootScope.$broadcast('$locationChangeStart', newUrl, oldUrl,
-              $location.$$state, oldState).defaultPrevented;
+        if (initializing || urlOrStateChanged) {
+          initializing = false;
 
-          // if the location was changed by a `$locationChangeStart` handler then stop
-          // processing this location change
-          if ($location.absUrl() !== newUrl) return;
+          $rootScope.$evalAsync(function() {
+            var newUrl = $location.absUrl();
+            var defaultPrevented = $rootScope.$broadcast('$locationChangeStart', newUrl, oldUrl,
+                $location.$$state, oldState).defaultPrevented;
 
-          if (defaultPrevented) {
-            $location.$$parse(oldUrl);
-            $location.$$state = oldState;
-          } else {
-            if (urlOrStateChanged) {
-              setBrowserUrlWithFallback(newUrl, currentReplace,
-                                        oldState === $location.$$state ? null : $location.$$state);
+            // if the location was changed by a `$locationChangeStart` handler then stop
+            // processing this location change
+            if ($location.absUrl() !== newUrl) return;
+
+            if (defaultPrevented) {
+              $location.$$parse(oldUrl);
+              $location.$$state = oldState;
+            } else {
+              if (urlOrStateChanged) {
+                setBrowserUrlWithFallback(newUrl, currentReplace,
+                                          oldState === $location.$$state ? null : $location.$$state);
+              }
+              afterLocationChange(oldUrl, oldState);
             }
-            afterLocationChange(oldUrl, oldState);
-          }
-        });
+          });
+        }
       }
 
       $location.$$replace = false;
@@ -14233,13 +14412,22 @@ function $LogProvider() {
   this.debugEnabled = function(flag) {
     if (isDefined(flag)) {
       debug = flag;
-    return this;
+      return this;
     } else {
       return debug;
     }
   };
 
   this.$get = ['$window', function($window) {
+    // Support: IE 9-11, Edge 12-14+
+    // IE/Edge display errors in such a way that it requires the user to click in 4 places
+    // to see the stack trace. There is no way to feature-detect it so there's a chance
+    // of the user agent sniffing to go wrong but since it's only about logging, this shouldn't
+    // break apps. Other browsers display errors in a sensible way and some of them map stack
+    // traces along source maps if available so it makes sense to let browsers display it
+    // as they want.
+    var formatStackTrace = msie || /\bEdge\//.test($window.navigator && $window.navigator.userAgent);
+
     return {
       /**
        * @ngdoc method
@@ -14297,7 +14485,7 @@ function $LogProvider() {
 
     function formatError(arg) {
       if (arg instanceof Error) {
-        if (arg.stack) {
+        if (arg.stack && formatStackTrace) {
           arg = (arg.message && arg.stack.indexOf(arg.message) === -1)
               ? 'Error: ' + arg.message + '\n' + arg.stack
               : arg.stack;
@@ -15055,6 +15243,13 @@ function findConstantAndWatchExpressions(ast, $filter) {
       if (!property.value.constant) {
         argsToWatch.push.apply(argsToWatch, property.value.toWatch);
       }
+      if (property.computed) {
+        findConstantAndWatchExpressions(property.key, $filter);
+        if (!property.key.constant) {
+          argsToWatch.push.apply(argsToWatch, property.key.toWatch);
+        }
+      }
+
     });
     ast.constant = allConstants;
     ast.toWatch = argsToWatch;
@@ -16120,13 +16315,13 @@ function $ParseProvider() {
       }
     }
 
-    function expressionInputDirtyCheck(newValue, oldValueOfValue) {
+    function expressionInputDirtyCheck(newValue, oldValueOfValue, compareObjectIdentity) {
 
       if (newValue == null || oldValueOfValue == null) { // null/undefined
         return newValue === oldValueOfValue;
       }
 
-      if (typeof newValue === 'object') {
+      if (typeof newValue === 'object' && !compareObjectIdentity) {
 
         // attempt to convert the value to a primitive type
         // TODO(docs): add a note to docs that by implementing valueOf even objects and arrays can
@@ -16155,7 +16350,7 @@ function $ParseProvider() {
         inputExpressions = inputExpressions[0];
         return scope.$watch(function expressionInputWatch(scope) {
           var newInputValue = inputExpressions(scope);
-          if (!expressionInputDirtyCheck(newInputValue, oldInputValueOf)) {
+          if (!expressionInputDirtyCheck(newInputValue, oldInputValueOf, parsedExpression.literal)) {
             lastResult = parsedExpression(scope, undefined, undefined, [newInputValue]);
             oldInputValueOf = newInputValue && getValueOf(newInputValue);
           }
@@ -16175,7 +16370,7 @@ function $ParseProvider() {
 
         for (var i = 0, ii = inputExpressions.length; i < ii; i++) {
           var newInputValue = inputExpressions[i](scope);
-          if (changed || (changed = !expressionInputDirtyCheck(newInputValue, oldInputValueOfValues[i]))) {
+          if (changed || (changed = !expressionInputDirtyCheck(newInputValue, oldInputValueOfValues[i], parsedExpression.literal))) {
             oldInputValues[i] = newInputValue;
             oldInputValueOfValues[i] = newInputValue && getValueOf(newInputValue);
           }
@@ -17778,12 +17973,13 @@ function $RootScopeProvider() {
           current = target;
 
           // It's safe for asyncQueuePosition to be a local variable here because this loop can't
-          // be reentered recursively. Calling $digest from a function passed to $applyAsync would
+          // be reentered recursively. Calling $digest from a function passed to $evalAsync would
           // lead to a '$digest already in progress' error.
           for (var asyncQueuePosition = 0; asyncQueuePosition < asyncQueue.length; asyncQueuePosition++) {
             try {
               asyncTask = asyncQueue[asyncQueuePosition];
-              asyncTask.scope.$eval(asyncTask.expression, asyncTask.locals);
+              fn = asyncTask.fn;
+              fn(asyncTask.scope, asyncTask.locals);
             } catch (e) {
               $exceptionHandler(e);
             }
@@ -17868,6 +18064,10 @@ function $RootScopeProvider() {
           }
         }
         postDigestQueue.length = postDigestQueuePosition = 0;
+
+        // Check for changes to browser url that happened during the $digest
+        // (for which no event is fired; e.g. via `history.pushState()`)
+        $browser.$$checkUrlChange();
       },
 
 
@@ -18013,7 +18213,7 @@ function $RootScopeProvider() {
           });
         }
 
-        asyncQueue.push({scope: this, expression: $parse(expr), locals: locals});
+        asyncQueue.push({scope: this, fn: $parse(expr), locals: locals});
       },
 
       $$postDigest: function(fn) {
@@ -19573,7 +19773,10 @@ function $SnifferProvider() {
         // (see https://developer.chrome.com/apps/api_index). If sandboxed, they can be detected by
         // the presence of an extension runtime ID and the absence of other Chrome runtime APIs
         // (see https://developer.chrome.com/apps/manifest/sandbox).
+        // (NW.js apps have access to Chrome APIs, but do support `history`.)
+        isNw = $window.nw && $window.nw.process,
         isChromePackagedApp =
+            !isNw &&
             $window.chrome &&
             ($window.chrome.app && $window.chrome.app.runtime ||
                 !$window.chrome.app && $window.chrome.runtime && $window.chrome.runtime.id),
@@ -19978,7 +20181,7 @@ var originUrl = urlResolve(window.location.href);
  * URL will be resolved into an absolute URL in the context of the application document.
  * Parsing means that the anchor node's host, hostname, protocol, port, pathname and related
  * properties are all populated to reflect the normalized URL.  This approach has wide
- * compatibility - Safari 1+, Mozilla 1+, Opera 7+,e etc.  See
+ * compatibility - Safari 1+, Mozilla 1+ etc.  See
  * http://www.aptana.com/reference/html/api/HTMLAnchorElement.html
  *
  * Implementation Notes for IE
@@ -20344,6 +20547,9 @@ function $FilterProvider($provide) {
  * Selects a subset of items from `array` and returns it as a new array.
  *
  * @param {Array} array The source array.
+ * <div class="alert alert-info">
+ *   **Note**: If the array contains objects that reference themselves, filtering is not possible.
+ * </div>
  * @param {string|Object|function()} expression The predicate to be used for selecting items from
  *   `array`.
  *
@@ -20561,7 +20767,10 @@ function deepCompare(actual, expected, comparator, anyPropertyKey, matchAgainstA
       var key;
       if (matchAgainstAnyProp) {
         for (key in actual) {
-          if ((key.charAt(0) !== '$') && deepCompare(actual[key], expected, comparator, anyPropertyKey, true)) {
+          // Under certain, rare, circumstances, key may not be a string and `charAt` will be undefined
+          // See: https://github.com/angular/angular.js/issues/15644
+          if (key.charAt && (key.charAt(0) !== '$') &&
+              deepCompare(actual[key], expected, comparator, anyPropertyKey, true)) {
             return true;
           }
         }
@@ -22334,7 +22543,8 @@ var htmlAnchorDirective = valueFn({
  *
  * @description
  *
- * This directive sets the `disabled` attribute on the element if the
+ * This directive sets the `disabled` attribute on the element (typically a form control,
+ * e.g. `input`, `button`, `select` etc.) if the
  * {@link guide/expression expression} inside `ngDisabled` evaluates to truthy.
  *
  * A special directive is necessary because we cannot use interpolation inside the `disabled`
@@ -24840,15 +25050,27 @@ function isValidForStep(viewValue, stepBase, step) {
   // and `viewValue` is expected to be a valid stringified number.
   var value = Number(viewValue);
 
+  var isNonIntegerValue = !isNumberInteger(value);
+  var isNonIntegerStepBase = !isNumberInteger(stepBase);
+  var isNonIntegerStep = !isNumberInteger(step);
+
   // Due to limitations in Floating Point Arithmetic (e.g. `0.3 - 0.2 !== 0.1` or
   // `0.5 % 0.1 !== 0`), we need to convert all numbers to integers.
-  if (!isNumberInteger(value) || !isNumberInteger(stepBase) || !isNumberInteger(step)) {
-    var decimalCount = Math.max(countDecimals(value), countDecimals(stepBase), countDecimals(step));
+  if (isNonIntegerValue || isNonIntegerStepBase || isNonIntegerStep) {
+    var valueDecimals = isNonIntegerValue ? countDecimals(value) : 0;
+    var stepBaseDecimals = isNonIntegerStepBase ? countDecimals(stepBase) : 0;
+    var stepDecimals = isNonIntegerStep ? countDecimals(step) : 0;
+
+    var decimalCount = Math.max(valueDecimals, stepBaseDecimals, stepDecimals);
     var multiplier = Math.pow(10, decimalCount);
 
     value = value * multiplier;
     stepBase = stepBase * multiplier;
     step = step * multiplier;
+
+    if (isNonIntegerValue) value = Math.round(value);
+    if (isNonIntegerStepBase) stepBase = Math.round(stepBase);
+    if (isNonIntegerStep) step = Math.round(step);
   }
 
   return (value - stepBase) % step === 0;
@@ -25405,7 +25627,10 @@ var ngValueDirective = function() {
    *  makes it possible to use ngValue as a sort of one-way bind.
    */
   function updateElementValue(element, attr, value) {
-    element.prop('value', value);
+    // Support: IE9 only
+    // In IE9 values are converted to string (e.g. `input.value = null` results in `input.value === 'null'`).
+    var propValue = isDefined(value) ? value : (msie === 9) ? '' : null;
+    element.prop('value', propValue);
     attr.$set('value', value);
   }
 
@@ -26733,15 +26958,15 @@ forEach(
       return {
         restrict: 'A',
         compile: function($element, attr) {
-          // We expose the powerful $event object on the scope that provides access to the Window,
-          // etc. that isn't protected by the fast paths in $parse.  We explicitly request better
-          // checks at the cost of speed since event handler expressions are not executed as
-          // frequently as regular change detection.
-          var fn = $parse(attr[directiveName], /* interceptorFn */ null, /* expensiveChecks */ true);
+          // NOTE:
+          // We expose the powerful `$event` object on the scope that provides access to the Window,
+          // etc. This is OK, because expressions are not sandboxed any more (and the expression
+          // sandbox was never meant to be a security feature anyway).
+          var fn = $parse(attr[directiveName]);
           return function ngEventHandler(scope, element) {
             element.on(eventName, function(event) {
               var callback = function() {
-                fn(scope, {$event:event});
+                fn(scope, {$event: event});
               };
               if (forceAsyncEvents[eventName] && $rootScope.$$phase) {
                 scope.$evalAsync(callback);
@@ -27822,32 +28047,57 @@ var ngModelMinErr = minErr('ngModel');
  * @property {*} $viewValue The actual value from the control's view. For `input` elements, this is a
  * String. See {@link ngModel.NgModelController#$setViewValue} for information about when the $viewValue
  * is set.
+ *
  * @property {*} $modelValue The value in the model that the control is bound to.
+ *
  * @property {Array.<Function>} $parsers Array of functions to execute, as a pipeline, whenever
-       the control reads value from the DOM. The functions are called in array order, each passing
-       its return value through to the next. The last return value is forwarded to the
-       {@link ngModel.NgModelController#$validators `$validators`} collection.
+ *  the control updates the ngModelController with a new {@link ngModel.NgModelController#$viewValue
+    `$viewValue`} from the DOM, usually via user input.
+    See {@link ngModel.NgModelController#$setViewValue `$setViewValue()`} for a detailed lifecycle explanation.
+    Note that the `$parsers` are not called when the bound ngModel expression changes programmatically.
 
-Parsers are used to sanitize / convert the {@link ngModel.NgModelController#$viewValue
-`$viewValue`}.
+  The functions are called in array order, each passing
+    its return value through to the next. The last return value is forwarded to the
+    {@link ngModel.NgModelController#$validators `$validators`} collection.
 
-Returning `undefined` from a parser means a parse error occurred. In that case,
-no {@link ngModel.NgModelController#$validators `$validators`} will run and the `ngModel`
-will be set to `undefined` unless {@link ngModelOptions `ngModelOptions.allowInvalid`}
-is set to `true`. The parse error is stored in `ngModel.$error.parse`.
+  Parsers are used to sanitize / convert the {@link ngModel.NgModelController#$viewValue
+    `$viewValue`}.
+
+  Returning `undefined` from a parser means a parse error occurred. In that case,
+    no {@link ngModel.NgModelController#$validators `$validators`} will run and the `ngModel`
+    will be set to `undefined` unless {@link ngModelOptions `ngModelOptions.allowInvalid`}
+    is set to `true`. The parse error is stored in `ngModel.$error.parse`.
+
+  This simple example shows a parser that would convert text input value to lowercase:
+ * ```js
+ * function parse(value) {
+ *   if (value) {
+ *     return value.toLowerCase();
+ *   }
+ * }
+ * ngModelController.$parsers.push(parse);
+ * ```
 
  *
  * @property {Array.<Function>} $formatters Array of functions to execute, as a pipeline, whenever
-       the model value changes. The functions are called in reverse array order, each passing the value through to the
-       next. The last return value is used as the actual DOM value.
-       Used to format / convert values for display in the control.
+    the bound ngModel expression changes programmatically. The `$formatters` are not called when the
+    value of the control is changed by user interaction.
+
+  Formatters are used to format / convert the {@link ngModel.NgModelController#$modelValue
+    `$modelValue`} for display in the control.
+
+  The functions are called in reverse array order, each passing the value through to the
+    next. The last return value is used as the actual DOM value.
+
+  This simple example shows a formatter that would convert the model value to uppercase:
+
  * ```js
- * function formatter(value) {
+ * function format(value) {
  *   if (value) {
  *     return value.toUpperCase();
  *   }
  * }
- * ngModel.$formatters.push(formatter);
+ * ngModel.$formatters.push(format);
  * ```
  *
  * @property {Object.<string, function>} $validators A collection of validators that are applied
@@ -28555,9 +28805,10 @@ NgModelController.prototype = {
    *
    * When `$setViewValue` is called, the new `value` will be staged for committing through the `$parsers`
    * and `$validators` pipelines. If there are no special {@link ngModelOptions} specified then the staged
-   * value sent directly for processing, finally to be applied to `$modelValue` and then the
-   * **expression** specified in the `ng-model` attribute. Lastly, all the registered change listeners,
-   * in the `$viewChangeListeners` list, are called.
+   * value is sent directly for processing through the `$parsers` pipeline. After this, the `$validators` and
+   * `$asyncValidators` are called and the value is applied to `$modelValue`.
+   * Finally, the value is set to the **expression** specified in the `ng-model` attribute and
+   * all the registered change listeners, in the `$viewChangeListeners` list are called.
    *
    * In case the {@link ng.directive:ngModelOptions ngModelOptions} directive is used with `updateOn`
    * and the `default` trigger is not listed, all those actions will remain pending until one of the
@@ -28620,6 +28871,29 @@ NgModelController.prototype = {
         that.$commitViewValue();
       });
     }
+  },
+
+  /**
+   * @ngdoc method
+   *
+   * @name ngModel.NgModelController#$overrideModelOptions
+   *
+   * @description
+   *
+   * Override the current model options settings programmatically.
+   *
+   * The previous `ModelOptions` value will not be modified. Instead, a
+   * new `ModelOptions` object will inherit from the previous one overriding
+   * or inheriting settings that are defined in the given parameter.
+   *
+   * See {@link ngModelOptions} for information about what options can be specified
+   * and how model option inheritance works.
+   *
+   * @param {Object} options a hash of settings to override the previous options
+   *
+   */
+  $overrideModelOptions: function(options) {
+    this.$options = this.$options.createChild(options);
   }
 };
 
@@ -29461,13 +29735,8 @@ var ngOptionsMinErr = minErr('ngOptions');
  * is not matched against any `<option>` and the `<select>` appears as having no selected value.
  *
  *
- * @param {string} ngModel Assignable angular expression to data-bind to.
- * @param {string=} name Property name of the form under which the control is published.
- * @param {string=} required The control is considered valid only if value is entered.
- * @param {string=} ngRequired Adds `required` attribute and `required` validation constraint to
- *    the element when the ngRequired expression evaluates to true. Use `ngRequired` instead of
- *    `required` when you want to data-bind to the `required` attribute.
- * @param {comprehension_expression=} ngOptions in one of the following forms:
+ * @param {string} ngModel Assignable AngularJS expression to data-bind to.
+ * @param {comprehension_expression} ngOptions in one of the following forms:
  *
  *   * for array data sources:
  *     * `label` **`for`** `value` **`in`** `array`
@@ -29506,6 +29775,13 @@ var ngOptionsMinErr = minErr('ngOptions');
  *      used to identify the objects in the array. The `trackexpr` will most likely refer to the
  *     `value` variable (e.g. `value.propertyName`). With this the selection is preserved
  *      even when the options are recreated (e.g. reloaded from the server).
+ * @param {string=} name Property name of the form under which the control is published.
+ * @param {string=} required The control is considered valid only if value is entered.
+ * @param {string=} ngRequired Adds `required` attribute and `required` validation constraint to
+ *    the element when the ngRequired expression evaluates to true. Use `ngRequired` instead of
+ *    `required` when you want to data-bind to the `required` attribute.
+ * @param {string=} ngAttrSize sets the size of the select element dynamically. Uses the
+ * {@link guide/interpolation#-ngattr-for-binding-to-arbitrary-attributes ngAttr} directive.
  *
  * @example
     <example module="selectExample" name="select">
@@ -30317,6 +30593,7 @@ var ngPluralizeDirective = ['$locale', '$interpolate', '$log', function($locale,
  * @ngdoc directive
  * @name ngRepeat
  * @multiElement
+ * @restrict A
  *
  * @description
  * The `ngRepeat` directive instantiates a template once per item from a collection. Each template
@@ -30883,11 +31160,13 @@ var NG_HIDE_IN_PROGRESS_CLASS = 'ng-hide-animate';
  * @multiElement
  *
  * @description
- * The `ngShow` directive shows or hides the given HTML element based on the expression
- * provided to the `ngShow` attribute. The element is shown or hidden by removing or adding
- * the `.ng-hide` CSS class onto the element. The `.ng-hide` CSS class is predefined
- * in AngularJS and sets the display style to none (using an !important flag).
- * For CSP mode please add `angular-csp.css` to your html file (see {@link ng.directive:ngCsp ngCsp}).
+ * The `ngShow` directive shows or hides the given HTML element based on the expression provided to
+ * the `ngShow` attribute.
+ *
+ * The element is shown or hidden by removing or adding the `.ng-hide` CSS class onto the element.
+ * The `.ng-hide` CSS class is predefined in AngularJS and sets the display style to none (using an
+ * `!important` flag). For CSP mode please add `angular-csp.css` to your HTML file (see
+ * {@link ng.directive:ngCsp ngCsp}).
  *
  * ```html
  * <!-- when $scope.myValue is truthy (element is visible) -->
@@ -30897,31 +31176,32 @@ var NG_HIDE_IN_PROGRESS_CLASS = 'ng-hide-animate';
  * <div ng-show="myValue" class="ng-hide"></div>
  * ```
  *
- * When the `ngShow` expression evaluates to a falsy value then the `.ng-hide` CSS class is added to the class
- * attribute on the element causing it to become hidden. When truthy, the `.ng-hide` CSS class is removed
- * from the element causing the element not to appear hidden.
+ * When the `ngShow` expression evaluates to a falsy value then the `.ng-hide` CSS class is added
+ * to the class attribute on the element causing it to become hidden. When truthy, the `.ng-hide`
+ * CSS class is removed from the element causing the element not to appear hidden.
  *
- * ## Why is !important used?
+ * ## Why is `!important` used?
  *
- * You may be wondering why !important is used for the `.ng-hide` CSS class. This is because the `.ng-hide` selector
- * can be easily overridden by heavier selectors. For example, something as simple
- * as changing the display style on a HTML list item would make hidden elements appear visible.
- * This also becomes a bigger issue when dealing with CSS frameworks.
+ * You may be wondering why `!important` is used for the `.ng-hide` CSS class. This is because the
+ * `.ng-hide` selector can be easily overridden by heavier selectors. For example, something as
+ * simple as changing the display style on a HTML list item would make hidden elements appear
+ * visible. This also becomes a bigger issue when dealing with CSS frameworks.
  *
- * By using !important, the show and hide behavior will work as expected despite any clash between CSS selector
- * specificity (when !important isn't used with any conflicting styles). If a developer chooses to override the
- * styling to change how to hide an element then it is just a matter of using !important in their own CSS code.
+ * By using `!important`, the show and hide behavior will work as expected despite any clash between
+ * CSS selector specificity (when `!important` isn't used with any conflicting styles). If a
+ * developer chooses to override the styling to change how to hide an element then it is just a
+ * matter of using `!important` in their own CSS code.
  *
  * ### Overriding `.ng-hide`
  *
- * By default, the `.ng-hide` class will style the element with `display: none!important`. If you wish to change
- * the hide behavior with ngShow/ngHide then this can be achieved by restating the styles for the `.ng-hide`
- * class CSS. Note that the selector that needs to be used is actually `.ng-hide:not(.ng-hide-animate)` to cope
- * with extra animation classes that can be added.
+ * By default, the `.ng-hide` class will style the element with `display: none !important`. If you
+ * wish to change the hide behavior with `ngShow`/`ngHide`, you can simply overwrite the styles for
+ * the `.ng-hide` CSS class. Note that the selector that needs to be used is actually
+ * `.ng-hide:not(.ng-hide-animate)` to cope with extra animation classes that can be added.
  *
  * ```css
  * .ng-hide:not(.ng-hide-animate) {
- *   /&#42; this is just another form of hiding an element &#42;/
+ *   /&#42; These are just alternative ways of hiding an element &#42;/
  *   display: block!important;
  *   position: absolute;
  *   top: -9999px;
@@ -30929,29 +31209,20 @@ var NG_HIDE_IN_PROGRESS_CLASS = 'ng-hide-animate';
  * }
  * ```
  *
- * By default you don't need to override in CSS anything and the animations will work around the display style.
+ * By default you don't need to override anything in CSS and the animations will work around the
+ * display style.
  *
  * ## A note about animations with `ngShow`
  *
- * Animations in ngShow/ngHide work with the show and hide events that are triggered when the directive expression
- * is true and false. This system works like the animation system present with ngClass except that
- * you must also include the !important flag to override the display property
- * so that you can perform an animation when the element is hidden during the time of the animation.
+ * Animations in `ngShow`/`ngHide` work with the show and hide events that are triggered when the
+ * directive expression is true and false. This system works like the animation system present with
+ * `ngClass` except that you must also include the `!important` flag to override the display
+ * property so that the elements are not actually hidden during the animation.
  *
  * ```css
- * //
- * //a working example can be found at the bottom of this page
- * //
+ * /&#42; A working example can be found at the bottom of this page. &#42;/
  * .my-element.ng-hide-add, .my-element.ng-hide-remove {
- *   /&#42; this is required as of 1.3x to properly
- *      apply all styling in a show/hide animation &#42;/
- *   transition: 0s linear all;
- * }
- *
- * .my-element.ng-hide-add-active,
- * .my-element.ng-hide-remove-active {
- *   /&#42; the transition is defined in the active class &#42;/
- *   transition: 1s linear all;
+ *   transition: all 0.5s linear;
  * }
  *
  * .my-element.ng-hide-add { ... }
@@ -30960,76 +31231,108 @@ var NG_HIDE_IN_PROGRESS_CLASS = 'ng-hide-animate';
  * .my-element.ng-hide-remove.ng-hide-remove-active { ... }
  * ```
  *
- * Keep in mind that, as of AngularJS version 1.3, there is no need to change the display
- * property to block during animation states--ngAnimate will handle the style toggling automatically for you.
+ * Keep in mind that, as of AngularJS version 1.3, there is no need to change the display property
+ * to block during animation states - ngAnimate will automatically handle the style toggling for you.
  *
  * @animations
- * | Animation                        | Occurs                              |
- * |----------------------------------|-------------------------------------|
- * | {@link $animate#addClass addClass} `.ng-hide`  | after the `ngShow` expression evaluates to a non truthy value and just before the contents are set to hidden |
- * | {@link $animate#removeClass removeClass}  `.ng-hide`  | after the `ngShow` expression evaluates to a truthy value and just before contents are set to visible |
+ * | Animation                                           | Occurs                                                                                                        |
+ * |-----------------------------------------------------|---------------------------------------------------------------------------------------------------------------|
+ * | {@link $animate#addClass addClass} `.ng-hide`       | After the `ngShow` expression evaluates to a non truthy value and just before the contents are set to hidden. |
+ * | {@link $animate#removeClass removeClass} `.ng-hide` | After the `ngShow` expression evaluates to a truthy value and just before contents are set to visible.        |
  *
  * @element ANY
- * @param {expression} ngShow If the {@link guide/expression expression} is truthy
- *     then the element is shown or hidden respectively.
+ * @param {expression} ngShow If the {@link guide/expression expression} is truthy/falsy then the
+ *                            element is shown/hidden respectively.
  *
  * @example
-  <example module="ngAnimate" deps="angular-animate.js" animations="true" name="ng-show">
+ * A simple example, animating the element's opacity:
+ *
+  <example module="ngAnimate" deps="angular-animate.js" animations="true" name="ng-show-simple">
     <file name="index.html">
-      Click me: <input type="checkbox" ng-model="checked" aria-label="Toggle ngHide"><br/>
-      <div>
-        Show:
-        <div class="check-element animate-show" ng-show="checked">
-          <span class="glyphicon glyphicon-thumbs-up"></span> I show up when your checkbox is checked.
-        </div>
+      Show: <input type="checkbox" ng-model="checked" aria-label="Toggle ngShow"><br />
+      <div class="check-element animate-show-hide" ng-show="checked">
+        I show up when your checkbox is checked.
       </div>
-      <div>
-        Hide:
-        <div class="check-element animate-show" ng-hide="checked">
-          <span class="glyphicon glyphicon-thumbs-down"></span> I hide when your checkbox is checked.
-        </div>
-      </div>
-    </file>
-    <file name="glyphicons.css">
-      @import url(../../components/bootstrap-3.1.1/css/bootstrap.css);
     </file>
     <file name="animations.css">
-      .animate-show {
-        line-height: 20px;
-        opacity: 1;
-        padding: 10px;
-        border: 1px solid black;
-        background: white;
+      .animate-show-hide.ng-hide {
+        opacity: 0;
       }
 
-      .animate-show.ng-hide-add, .animate-show.ng-hide-remove {
+      .animate-show-hide.ng-hide-add,
+      .animate-show-hide.ng-hide-remove {
         transition: all linear 0.5s;
       }
 
-      .animate-show.ng-hide {
-        line-height: 0;
-        opacity: 0;
-        padding: 0 10px;
-      }
-
       .check-element {
-        padding: 10px;
         border: 1px solid black;
-        background: white;
+        opacity: 1;
+        padding: 10px;
       }
     </file>
     <file name="protractor.js" type="protractor">
-      var thumbsUp = element(by.css('span.glyphicon-thumbs-up'));
-      var thumbsDown = element(by.css('span.glyphicon-thumbs-down'));
+      it('should check ngShow', function() {
+        var checkbox = element(by.model('checked'));
+        var checkElem = element(by.css('.check-element'));
 
-      it('should check ng-show / ng-hide', function() {
-        expect(thumbsUp.isDisplayed()).toBeFalsy();
-        expect(thumbsDown.isDisplayed()).toBeTruthy();
+        expect(checkElem.isDisplayed()).toBe(false);
+        checkbox.click();
+        expect(checkElem.isDisplayed()).toBe(true);
+      });
+    </file>
+  </example>
+ *
+ * <hr />
+ * @example
+ * A more complex example, featuring different show/hide animations:
+ *
+  <example module="ngAnimate" deps="angular-animate.js" animations="true" name="ng-show-complex">
+    <file name="index.html">
+      Show: <input type="checkbox" ng-model="checked" aria-label="Toggle ngShow"><br />
+      <div class="check-element funky-show-hide" ng-show="checked">
+        I show up when your checkbox is checked.
+      </div>
+    </file>
+    <file name="animations.css">
+      body {
+        overflow: hidden;
+        perspective: 1000px;
+      }
 
-        element(by.model('checked')).click();
+      .funky-show-hide.ng-hide-add {
+        transform: rotateZ(0);
+        transform-origin: right;
+        transition: all 0.5s ease-in-out;
+      }
 
-        expect(thumbsUp.isDisplayed()).toBeTruthy();
-        expect(thumbsDown.isDisplayed()).toBeFalsy();
+      .funky-show-hide.ng-hide-add.ng-hide-add-active {
+        transform: rotateZ(-135deg);
+      }
+
+      .funky-show-hide.ng-hide-remove {
+        transform: rotateY(90deg);
+        transform-origin: left;
+        transition: all 0.5s ease;
+      }
+
+      .funky-show-hide.ng-hide-remove.ng-hide-remove-active {
+        transform: rotateY(0);
+      }
+
+      .check-element {
+        border: 1px solid black;
+        opacity: 1;
+        padding: 10px;
+      }
+    </file>
+    <file name="protractor.js" type="protractor">
+      it('should check ngShow', function() {
+        var checkbox = element(by.model('checked'));
+        var checkElem = element(by.css('.check-element'));
+
+        expect(checkElem.isDisplayed()).toBe(false);
+        checkbox.click();
+        expect(checkElem.isDisplayed()).toBe(true);
       });
     </file>
   </example>
@@ -31059,11 +31362,13 @@ var ngShowDirective = ['$animate', function($animate) {
  * @multiElement
  *
  * @description
- * The `ngHide` directive shows or hides the given HTML element based on the expression
- * provided to the `ngHide` attribute. The element is shown or hidden by removing or adding
- * the `ng-hide` CSS class onto the element. The `.ng-hide` CSS class is predefined
- * in AngularJS and sets the display style to none (using an !important flag).
- * For CSP mode please add `angular-csp.css` to your html file (see {@link ng.directive:ngCsp ngCsp}).
+ * The `ngHide` directive shows or hides the given HTML element based on the expression provided to
+ * the `ngHide` attribute.
+ *
+ * The element is shown or hidden by removing or adding the `.ng-hide` CSS class onto the element.
+ * The `.ng-hide` CSS class is predefined in AngularJS and sets the display style to none (using an
+ * `!important` flag). For CSP mode please add `angular-csp.css` to your HTML file (see
+ * {@link ng.directive:ngCsp ngCsp}).
  *
  * ```html
  * <!-- when $scope.myValue is truthy (element is hidden) -->
@@ -31073,30 +31378,32 @@ var ngShowDirective = ['$animate', function($animate) {
  * <div ng-hide="myValue"></div>
  * ```
  *
- * When the `ngHide` expression evaluates to a truthy value then the `.ng-hide` CSS class is added to the class
- * attribute on the element causing it to become hidden. When falsy, the `.ng-hide` CSS class is removed
- * from the element causing the element not to appear hidden.
+ * When the `ngHide` expression evaluates to a truthy value then the `.ng-hide` CSS class is added
+ * to the class attribute on the element causing it to become hidden. When falsy, the `.ng-hide`
+ * CSS class is removed from the element causing the element not to appear hidden.
  *
- * ## Why is !important used?
+ * ## Why is `!important` used?
  *
- * You may be wondering why !important is used for the `.ng-hide` CSS class. This is because the `.ng-hide` selector
- * can be easily overridden by heavier selectors. For example, something as simple
- * as changing the display style on a HTML list item would make hidden elements appear visible.
- * This also becomes a bigger issue when dealing with CSS frameworks.
+ * You may be wondering why `!important` is used for the `.ng-hide` CSS class. This is because the
+ * `.ng-hide` selector can be easily overridden by heavier selectors. For example, something as
+ * simple as changing the display style on a HTML list item would make hidden elements appear
+ * visible. This also becomes a bigger issue when dealing with CSS frameworks.
  *
- * By using !important, the show and hide behavior will work as expected despite any clash between CSS selector
- * specificity (when !important isn't used with any conflicting styles). If a developer chooses to override the
- * styling to change how to hide an element then it is just a matter of using !important in their own CSS code.
+ * By using `!important`, the show and hide behavior will work as expected despite any clash between
+ * CSS selector specificity (when `!important` isn't used with any conflicting styles). If a
+ * developer chooses to override the styling to change how to hide an element then it is just a
+ * matter of using `!important` in their own CSS code.
  *
  * ### Overriding `.ng-hide`
  *
- * By default, the `.ng-hide` class will style the element with `display: none!important`. If you wish to change
- * the hide behavior with ngShow/ngHide then this can be achieved by restating the styles for the `.ng-hide`
- * class in CSS:
+ * By default, the `.ng-hide` class will style the element with `display: none !important`. If you
+ * wish to change the hide behavior with `ngShow`/`ngHide`, you can simply overwrite the styles for
+ * the `.ng-hide` CSS class. Note that the selector that needs to be used is actually
+ * `.ng-hide:not(.ng-hide-animate)` to cope with extra animation classes that can be added.
  *
  * ```css
- * .ng-hide {
- *   /&#42; this is just another form of hiding an element &#42;/
+ * .ng-hide:not(.ng-hide-animate) {
+ *   /&#42; These are just alternative ways of hiding an element &#42;/
  *   display: block!important;
  *   position: absolute;
  *   top: -9999px;
@@ -31104,20 +31411,20 @@ var ngShowDirective = ['$animate', function($animate) {
  * }
  * ```
  *
- * By default you don't need to override in CSS anything and the animations will work around the display style.
+ * By default you don't need to override in CSS anything and the animations will work around the
+ * display style.
  *
  * ## A note about animations with `ngHide`
  *
- * Animations in ngShow/ngHide work with the show and hide events that are triggered when the directive expression
- * is true and false. This system works like the animation system present with ngClass, except that the `.ng-hide`
- * CSS class is added and removed for you instead of your own CSS class.
+ * Animations in `ngShow`/`ngHide` work with the show and hide events that are triggered when the
+ * directive expression is true and false. This system works like the animation system present with
+ * `ngClass` except that you must also include the `!important` flag to override the display
+ * property so that the elements are not actually hidden during the animation.
  *
  * ```css
- * //
- * //a working example can be found at the bottom of this page
- * //
+ * /&#42; A working example can be found at the bottom of this page. &#42;/
  * .my-element.ng-hide-add, .my-element.ng-hide-remove {
- *   transition: 0.5s linear all;
+ *   transition: all 0.5s linear;
  * }
  *
  * .my-element.ng-hide-add { ... }
@@ -31126,74 +31433,109 @@ var ngShowDirective = ['$animate', function($animate) {
  * .my-element.ng-hide-remove.ng-hide-remove-active { ... }
  * ```
  *
- * Keep in mind that, as of AngularJS version 1.3, there is no need to change the display
- * property to block during animation states--ngAnimate will handle the style toggling automatically for you.
+ * Keep in mind that, as of AngularJS version 1.3, there is no need to change the display property
+ * to block during animation states - ngAnimate will automatically handle the style toggling for you.
  *
  * @animations
- * | Animation                        | Occurs                              |
- * |----------------------------------|-------------------------------------|
- * | {@link $animate#addClass addClass} `.ng-hide`  | after the `ngHide` expression evaluates to a truthy value and just before the contents are set to hidden |
- * | {@link $animate#removeClass removeClass}  `.ng-hide`  | after the `ngHide` expression evaluates to a non truthy value and just before contents are set to visible |
+ * | Animation                                           | Occurs                                                                                                     |
+ * |-----------------------------------------------------|------------------------------------------------------------------------------------------------------------|
+ * | {@link $animate#addClass addClass} `.ng-hide`       | After the `ngHide` expression evaluates to a truthy value and just before the contents are set to hidden.  |
+ * | {@link $animate#removeClass removeClass} `.ng-hide` | After the `ngHide` expression evaluates to a non truthy value and just before contents are set to visible. |
  *
  *
  * @element ANY
- * @param {expression} ngHide If the {@link guide/expression expression} is truthy then
- *     the element is shown or hidden respectively.
+ * @param {expression} ngHide If the {@link guide/expression expression} is truthy/falsy then the
+ *                            element is hidden/shown respectively.
  *
  * @example
-  <example module="ngAnimate" deps="angular-animate.js" animations="true" name="ng-hide">
+ * A simple example, animating the element's opacity:
+ *
+  <example module="ngAnimate" deps="angular-animate.js" animations="true" name="ng-hide-simple">
     <file name="index.html">
-      Click me: <input type="checkbox" ng-model="checked" aria-label="Toggle ngShow"><br/>
-      <div>
-        Show:
-        <div class="check-element animate-hide" ng-show="checked">
-          <span class="glyphicon glyphicon-thumbs-up"></span> I show up when your checkbox is checked.
-        </div>
+      Hide: <input type="checkbox" ng-model="checked" aria-label="Toggle ngHide"><br />
+      <div class="check-element animate-show-hide" ng-hide="checked">
+        I hide when your checkbox is checked.
       </div>
-      <div>
-        Hide:
-        <div class="check-element animate-hide" ng-hide="checked">
-          <span class="glyphicon glyphicon-thumbs-down"></span> I hide when your checkbox is checked.
-        </div>
-      </div>
-    </file>
-    <file name="glyphicons.css">
-      @import url(../../components/bootstrap-3.1.1/css/bootstrap.css);
     </file>
     <file name="animations.css">
-      .animate-hide {
-        transition: all linear 0.5s;
-        line-height: 20px;
-        opacity: 1;
-        padding: 10px;
-        border: 1px solid black;
-        background: white;
+      .animate-show-hide.ng-hide {
+        opacity: 0;
       }
 
-      .animate-hide.ng-hide {
-        line-height: 0;
-        opacity: 0;
-        padding: 0 10px;
+      .animate-show-hide.ng-hide-add,
+      .animate-show-hide.ng-hide-remove {
+        transition: all linear 0.5s;
       }
 
       .check-element {
-        padding: 10px;
         border: 1px solid black;
-        background: white;
+        opacity: 1;
+        padding: 10px;
       }
     </file>
     <file name="protractor.js" type="protractor">
-      var thumbsUp = element(by.css('span.glyphicon-thumbs-up'));
-      var thumbsDown = element(by.css('span.glyphicon-thumbs-down'));
+      it('should check ngHide', function() {
+        var checkbox = element(by.model('checked'));
+        var checkElem = element(by.css('.check-element'));
 
-      it('should check ng-show / ng-hide', function() {
-        expect(thumbsUp.isDisplayed()).toBeFalsy();
-        expect(thumbsDown.isDisplayed()).toBeTruthy();
+        expect(checkElem.isDisplayed()).toBe(true);
+        checkbox.click();
+        expect(checkElem.isDisplayed()).toBe(false);
+      });
+    </file>
+  </example>
+ *
+ * <hr />
+ * @example
+ * A more complex example, featuring different show/hide animations:
+ *
+  <example module="ngAnimate" deps="angular-animate.js" animations="true" name="ng-hide-complex">
+    <file name="index.html">
+      Hide: <input type="checkbox" ng-model="checked" aria-label="Toggle ngHide"><br />
+      <div class="check-element funky-show-hide" ng-hide="checked">
+        I hide when your checkbox is checked.
+      </div>
+    </file>
+    <file name="animations.css">
+      body {
+        overflow: hidden;
+        perspective: 1000px;
+      }
 
-        element(by.model('checked')).click();
+      .funky-show-hide.ng-hide-add {
+        transform: rotateZ(0);
+        transform-origin: right;
+        transition: all 0.5s ease-in-out;
+      }
 
-        expect(thumbsUp.isDisplayed()).toBeTruthy();
-        expect(thumbsDown.isDisplayed()).toBeFalsy();
+      .funky-show-hide.ng-hide-add.ng-hide-add-active {
+        transform: rotateZ(-135deg);
+      }
+
+      .funky-show-hide.ng-hide-remove {
+        transform: rotateY(90deg);
+        transform-origin: left;
+        transition: all 0.5s ease;
+      }
+
+      .funky-show-hide.ng-hide-remove.ng-hide-remove-active {
+        transform: rotateY(0);
+      }
+
+      .check-element {
+        border: 1px solid black;
+        opacity: 1;
+        padding: 10px;
+      }
+    </file>
+    <file name="protractor.js" type="protractor">
+      it('should check ngHide', function() {
+        var checkbox = element(by.model('checked'));
+        var checkElem = element(by.css('.check-element'));
+
+        expect(checkElem.isDisplayed()).toBe(true);
+        checkbox.click();
+        expect(checkElem.isDisplayed()).toBe(false);
       });
     </file>
   </example>
@@ -31776,6 +32118,18 @@ var scriptDirective = ['$templateCache', function($templateCache) {
 
 var noopNgModelController = { $setViewValue: noop, $render: noop };
 
+function setOptionSelectedStatus(optionEl, value) {
+  optionEl.prop('selected', value); // needed for IE
+  /**
+   * When unselecting an option, setting the property to null / false should be enough
+   * However, screenreaders might react to the selected attribute instead, see
+   * https://github.com/angular/angular.js/issues/14419
+   * Note: "selected" is a boolean attr and will be removed when the "value" arg in attr() is false
+   * or null
+   */
+  optionEl.attr('selected', value);
+}
+
 /**
  * @ngdoc type
  * @name  select.SelectController
@@ -31788,7 +32142,7 @@ var SelectController =
         ['$element', '$scope', /** @this */ function($element, $scope) {
 
   var self = this,
-      optionsMap = new HashMap();
+      optionsMap = new NgMap();
 
   self.selectValueMap = {}; // Keys are the hashed values, values the original values
 
@@ -31816,14 +32170,14 @@ var SelectController =
     var unknownVal = self.generateUnknownOptionValue(val);
     self.unknownOption.val(unknownVal);
     $element.prepend(self.unknownOption);
-    setOptionAsSelected(self.unknownOption);
+    setOptionSelectedStatus(self.unknownOption, true);
     $element.val(unknownVal);
   };
 
   self.updateUnknownOption = function(val) {
     var unknownVal = self.generateUnknownOptionValue(val);
     self.unknownOption.val(unknownVal);
-    setOptionAsSelected(self.unknownOption);
+    setOptionSelectedStatus(self.unknownOption, true);
     $element.val(unknownVal);
   };
 
@@ -31838,7 +32192,7 @@ var SelectController =
   self.selectEmptyOption = function() {
     if (self.emptyOption) {
       $element.val('');
-      setOptionAsSelected(self.emptyOption);
+      setOptionSelectedStatus(self.emptyOption, true);
     }
   };
 
@@ -31874,7 +32228,7 @@ var SelectController =
     // Make sure to remove the selected attribute from the previously selected option
     // Otherwise, screen readers might get confused
     var currentlySelectedOption = $element[0].options[$element[0].selectedIndex];
-    if (currentlySelectedOption) currentlySelectedOption.removeAttribute('selected');
+    if (currentlySelectedOption) setOptionSelectedStatus(jqLite(currentlySelectedOption), false);
 
     if (self.hasOption(value)) {
       self.removeUnknownOption();
@@ -31884,7 +32238,7 @@ var SelectController =
 
       // Set selected attribute and property on selected option for screen readers
       var selectedOption = $element[0].options[$element[0].selectedIndex];
-      setOptionAsSelected(jqLite(selectedOption));
+      setOptionSelectedStatus(jqLite(selectedOption), true);
     } else {
       if (value == null && self.emptyOption) {
         self.removeUnknownOption();
@@ -31909,7 +32263,7 @@ var SelectController =
       self.emptyOption = element;
     }
     var count = optionsMap.get(value) || 0;
-    optionsMap.put(value, count + 1);
+    optionsMap.set(value, count + 1);
     // Only render at the end of a digest. This improves render performance when many options
     // are added during a digest and ensures all relevant options are correctly marked as selected
     scheduleRender();
@@ -31920,13 +32274,13 @@ var SelectController =
     var count = optionsMap.get(value);
     if (count) {
       if (count === 1) {
-        optionsMap.remove(value);
+        optionsMap.delete(value);
         if (value === '') {
           self.hasEmptyOption = false;
           self.emptyOption = undefined;
         }
       } else {
-        optionsMap.put(value, count - 1);
+        optionsMap.set(value, count - 1);
       }
     }
   };
@@ -32053,7 +32407,7 @@ var SelectController =
       var removeValue = optionAttrs.value;
 
       self.removeOption(removeValue);
-      self.ngModelCtrl.$render();
+      scheduleRender();
 
       if (self.multiple && currentValue && currentValue.indexOf(removeValue) !== -1 ||
           currentValue === removeValue
@@ -32064,11 +32418,6 @@ var SelectController =
       }
     });
   };
-
-  function setOptionAsSelected(optionEl) {
-    optionEl.prop('selected', true); // needed for IE
-    optionEl.attr('selected', true);
-  }
 }];
 
 /**
@@ -32138,6 +32487,8 @@ var SelectController =
  *    interaction with the select element.
  * @param {string=} ngOptions sets the options that the select is populated with and defines what is
  * set on the model on selection. See {@link ngOptions `ngOptions`}.
+ * @param {string=} ngAttrSize sets the size of the select element dynamically. Uses the
+ * {@link guide/interpolation#-ngattr-for-binding-to-arbitrary-attributes ngAttr} directive.
  *
  * @example
  * ### Simple `select` elements with static options
@@ -32378,9 +32729,21 @@ var selectDirective = function() {
 
         // Write value now needs to set the selected property of each matching option
         selectCtrl.writeValue = function writeMultipleValue(value) {
-          var items = new HashMap(value);
           forEach(element.find('option'), function(option) {
-            option.selected = isDefined(items.get(option.value)) || isDefined(items.get(selectCtrl.selectValueMap[option.value]));
+            var shouldBeSelected = !!value && (includes(value, option.value) ||
+                                               includes(value, selectCtrl.selectValueMap[option.value]));
+            var currentlySelected = option.selected;
+
+            // IE and Edge, adding options to the selection via shift+click/UP/DOWN,
+            // will de-select already selected options if "selected" on those options was set
+            // more than once (i.e. when the options were already selected)
+            // So we only modify the selected property if neccessary.
+            // Note: this behavior cannot be replicated via unit tests because it only shows in the
+            // actual user interface.
+            if (shouldBeSelected !== currentlySelected) {
+              setOptionSelectedStatus(jqLite(option), shouldBeSelected);
+            }
+
           });
         };
 
@@ -32981,8 +33344,8 @@ $provide.value("$locale", {
 
 !window.angular.$$csp().noInlineStyle && window.angular.element(document.head).prepend('<style type="text/css">@charset "UTF-8";[ng\\:cloak],[ng-cloak],[data-ng-cloak],[x-ng-cloak],.ng-cloak,.x-ng-cloak,.ng-hide:not(.ng-hide-animate){display:none !important;}ng\\:form{display:block;}.ng-animate-shim{visibility:hidden;}.ng-anchor{position:absolute;}</style>');
 /**
- * @license AngularJS v1.6.1
- * (c) 2010-2016 Google, Inc. http://angularjs.org
+ * @license AngularJS v1.6.3
+ * (c) 2010-2017 Google, Inc. http://angularjs.org
  * License: MIT
  */
 (function(window, angular) {'use strict';
@@ -35152,9 +35515,9 @@ var $$AnimateQueueProvider = ['$animateProvider', /** @this */ function($animate
     }
   }
 
-  function isAllowed(ruleType, element, currentAnimation, previousAnimation) {
+  function isAllowed(ruleType, currentAnimation, previousAnimation) {
     return rules[ruleType].some(function(fn) {
-      return fn(element, currentAnimation, previousAnimation);
+      return fn(currentAnimation, previousAnimation);
     });
   }
 
@@ -35164,40 +35527,40 @@ var $$AnimateQueueProvider = ['$animateProvider', /** @this */ function($animate
     return and ? a && b : a || b;
   }
 
-  rules.join.push(function(element, newAnimation, currentAnimation) {
+  rules.join.push(function(newAnimation, currentAnimation) {
     // if the new animation is class-based then we can just tack that on
     return !newAnimation.structural && hasAnimationClasses(newAnimation);
   });
 
-  rules.skip.push(function(element, newAnimation, currentAnimation) {
+  rules.skip.push(function(newAnimation, currentAnimation) {
     // there is no need to animate anything if no classes are being added and
     // there is no structural animation that will be triggered
     return !newAnimation.structural && !hasAnimationClasses(newAnimation);
   });
 
-  rules.skip.push(function(element, newAnimation, currentAnimation) {
+  rules.skip.push(function(newAnimation, currentAnimation) {
     // why should we trigger a new structural animation if the element will
     // be removed from the DOM anyway?
     return currentAnimation.event === 'leave' && newAnimation.structural;
   });
 
-  rules.skip.push(function(element, newAnimation, currentAnimation) {
+  rules.skip.push(function(newAnimation, currentAnimation) {
     // if there is an ongoing current animation then don't even bother running the class-based animation
     return currentAnimation.structural && currentAnimation.state === RUNNING_STATE && !newAnimation.structural;
   });
 
-  rules.cancel.push(function(element, newAnimation, currentAnimation) {
+  rules.cancel.push(function(newAnimation, currentAnimation) {
     // there can never be two structural animations running at the same time
     return currentAnimation.structural && newAnimation.structural;
   });
 
-  rules.cancel.push(function(element, newAnimation, currentAnimation) {
+  rules.cancel.push(function(newAnimation, currentAnimation) {
     // if the previous animation is already running, but the new animation will
     // be triggered, but the new animation is structural
     return currentAnimation.state === RUNNING_STATE && newAnimation.structural;
   });
 
-  rules.cancel.push(function(element, newAnimation, currentAnimation) {
+  rules.cancel.push(function(newAnimation, currentAnimation) {
     // cancel the animation if classes added / removed in both animation cancel each other out,
     // but only if the current animation isn't structural
 
@@ -35216,15 +35579,15 @@ var $$AnimateQueueProvider = ['$animateProvider', /** @this */ function($animate
     return hasMatchingClasses(nA, cR) || hasMatchingClasses(nR, cA);
   });
 
-  this.$get = ['$$rAF', '$rootScope', '$rootElement', '$document', '$$HashMap',
+  this.$get = ['$$rAF', '$rootScope', '$rootElement', '$document', '$$Map',
                '$$animation', '$$AnimateRunner', '$templateRequest', '$$jqLite', '$$forceReflow',
                '$$isDocumentHidden',
-       function($$rAF,   $rootScope,   $rootElement,   $document,   $$HashMap,
+       function($$rAF,   $rootScope,   $rootElement,   $document,   $$Map,
                 $$animation,   $$AnimateRunner,   $templateRequest,   $$jqLite,   $$forceReflow,
                 $$isDocumentHidden) {
 
-    var activeAnimationsLookup = new $$HashMap();
-    var disabledElementsLookup = new $$HashMap();
+    var activeAnimationsLookup = new $$Map();
+    var disabledElementsLookup = new $$Map();
     var animationsEnabled = null;
 
     function postDigestTaskFactory() {
@@ -35297,10 +35660,7 @@ var $$AnimateQueueProvider = ['$animateProvider', /** @this */ function($animate
       return this === arg || !!(this.compareDocumentPosition(arg) & 16);
     };
 
-    function findCallbacks(parent, element, event) {
-      var targetNode = getDomNode(element);
-      var targetParentNode = getDomNode(parent);
-
+    function findCallbacks(targetParentNode, targetNode, event) {
       var matches = [];
       var entries = callbackRegistry[event];
       if (entries) {
@@ -35325,11 +35685,11 @@ var $$AnimateQueueProvider = ['$animateProvider', /** @this */ function($animate
       });
     }
 
-    function cleanupEventListeners(phase, element) {
-      if (phase === 'close' && !element[0].parentNode) {
+    function cleanupEventListeners(phase, node) {
+      if (phase === 'close' && !node.parentNode) {
         // If the element is not attached to a parentNode, it has been removed by
         // the domOperation, and we can safely remove the event callbacks
-        $animate.off(element);
+        $animate.off(node);
       }
     }
 
@@ -35410,7 +35770,7 @@ var $$AnimateQueueProvider = ['$animateProvider', /** @this */ function($animate
               bool = !disabledElementsLookup.get(node);
             } else {
               // (element, bool) - Element setter
-              disabledElementsLookup.put(node, !bool);
+              disabledElementsLookup.set(node, !bool);
             }
           }
         }
@@ -35421,18 +35781,15 @@ var $$AnimateQueueProvider = ['$animateProvider', /** @this */ function($animate
 
     return $animate;
 
-    function queueAnimation(element, event, initialOptions) {
+    function queueAnimation(originalElement, event, initialOptions) {
       // we always make a copy of the options since
       // there should never be any side effects on
       // the input data when running `$animateCss`.
       var options = copy(initialOptions);
 
-      var node, parent;
-      element = stripCommentsFromElement(element);
-      if (element) {
-        node = getDomNode(element);
-        parent = element.parent();
-      }
+      var element = stripCommentsFromElement(originalElement);
+      var node = getDomNode(element);
+      var parentNode = node && node.parentNode;
 
       options = prepareAnimationOptions(options);
 
@@ -35497,7 +35854,7 @@ var $$AnimateQueueProvider = ['$animateProvider', /** @this */ function($animate
       // there is no point in traversing the same collection of parent ancestors if a followup
       // animation will be run on the same element that already did all that checking work
       if (!skipAnimations && (!hasExistingAnimation || existingAnimation.state !== PRE_DIGEST_STATE)) {
-        skipAnimations = !areAnimationsAllowed(element, parent, event);
+        skipAnimations = !areAnimationsAllowed(node, parentNode, event);
       }
 
       if (skipAnimations) {
@@ -35509,7 +35866,7 @@ var $$AnimateQueueProvider = ['$animateProvider', /** @this */ function($animate
       }
 
       if (isStructural) {
-        closeChildAnimations(element);
+        closeChildAnimations(node);
       }
 
       var newAnimation = {
@@ -35524,7 +35881,7 @@ var $$AnimateQueueProvider = ['$animateProvider', /** @this */ function($animate
       };
 
       if (hasExistingAnimation) {
-        var skipAnimationFlag = isAllowed('skip', element, newAnimation, existingAnimation);
+        var skipAnimationFlag = isAllowed('skip', newAnimation, existingAnimation);
         if (skipAnimationFlag) {
           if (existingAnimation.state === RUNNING_STATE) {
             close();
@@ -35534,7 +35891,7 @@ var $$AnimateQueueProvider = ['$animateProvider', /** @this */ function($animate
             return existingAnimation.runner;
           }
         }
-        var cancelAnimationFlag = isAllowed('cancel', element, newAnimation, existingAnimation);
+        var cancelAnimationFlag = isAllowed('cancel', newAnimation, existingAnimation);
         if (cancelAnimationFlag) {
           if (existingAnimation.state === RUNNING_STATE) {
             // this will end the animation right away and it is safe
@@ -35556,7 +35913,7 @@ var $$AnimateQueueProvider = ['$animateProvider', /** @this */ function($animate
           // a joined animation means that this animation will take over the existing one
           // so an example would involve a leave animation taking over an enter. Then when
           // the postDigest kicks in the enter will be ignored.
-          var joinAnimationFlag = isAllowed('join', element, newAnimation, existingAnimation);
+          var joinAnimationFlag = isAllowed('join', newAnimation, existingAnimation);
           if (joinAnimationFlag) {
             if (existingAnimation.state === RUNNING_STATE) {
               normalizeAnimationDetails(element, newAnimation);
@@ -35590,7 +35947,7 @@ var $$AnimateQueueProvider = ['$animateProvider', /** @this */ function($animate
 
       if (!isValidAnimation) {
         close();
-        clearElementAnimationState(element);
+        clearElementAnimationState(node);
         return runner;
       }
 
@@ -35598,9 +35955,18 @@ var $$AnimateQueueProvider = ['$animateProvider', /** @this */ function($animate
       var counter = (existingAnimation.counter || 0) + 1;
       newAnimation.counter = counter;
 
-      markElementAnimationState(element, PRE_DIGEST_STATE, newAnimation);
+      markElementAnimationState(node, PRE_DIGEST_STATE, newAnimation);
 
       $rootScope.$$postDigest(function() {
+        // It is possible that the DOM nodes inside `originalElement` have been replaced. This can
+        // happen if the animated element is a transcluded clone and also has a `templateUrl`
+        // directive on it. Therefore, we must recreate `element` in order to interact with the
+        // actual DOM nodes.
+        // Note: We still need to use the old `node` for certain things, such as looking up in
+        //       HashMaps where it was used as the key.
+
+        element = stripCommentsFromElement(originalElement);
+
         var animationDetails = activeAnimationsLookup.get(node);
         var animationCancelled = !animationDetails;
         animationDetails = animationDetails || {};
@@ -35639,7 +36005,7 @@ var $$AnimateQueueProvider = ['$animateProvider', /** @this */ function($animate
           // isn't allowed to animate from here then we need to clear the state of the element
           // so that any future animations won't read the expired animation data.
           if (!isValidAnimation) {
-            clearElementAnimationState(element);
+            clearElementAnimationState(node);
           }
 
           return;
@@ -35651,7 +36017,7 @@ var $$AnimateQueueProvider = ['$animateProvider', /** @this */ function($animate
             ? 'setClass'
             : animationDetails.event;
 
-        markElementAnimationState(element, RUNNING_STATE);
+        markElementAnimationState(node, RUNNING_STATE);
         var realRunner = $$animation(element, event, animationDetails.options);
 
         // this will update the runner's flow-control events based on
@@ -35663,7 +36029,7 @@ var $$AnimateQueueProvider = ['$animateProvider', /** @this */ function($animate
           close(!status);
           var animationDetails = activeAnimationsLookup.get(node);
           if (animationDetails && animationDetails.counter === counter) {
-            clearElementAnimationState(getDomNode(element));
+            clearElementAnimationState(node);
           }
           notifyProgress(runner, event, 'close', {});
         });
@@ -35673,7 +36039,7 @@ var $$AnimateQueueProvider = ['$animateProvider', /** @this */ function($animate
 
       function notifyProgress(runner, event, phase, data) {
         runInNextPostDigestOrNow(function() {
-          var callbacks = findCallbacks(parent, element, event);
+          var callbacks = findCallbacks(parentNode, node, event);
           if (callbacks.length) {
             // do not optimize this call here to RAF because
             // we don't know how heavy the callback code here will
@@ -35683,10 +36049,10 @@ var $$AnimateQueueProvider = ['$animateProvider', /** @this */ function($animate
               forEach(callbacks, function(callback) {
                 callback(element, phase, data);
               });
-              cleanupEventListeners(phase, element);
+              cleanupEventListeners(phase, node);
             });
           } else {
-            cleanupEventListeners(phase, element);
+            cleanupEventListeners(phase, node);
           }
         });
         runner.progress(event, phase, data);
@@ -35701,8 +36067,7 @@ var $$AnimateQueueProvider = ['$animateProvider', /** @this */ function($animate
       }
     }
 
-    function closeChildAnimations(element) {
-      var node = getDomNode(element);
+    function closeChildAnimations(node) {
       var children = node.querySelectorAll('[' + NG_ANIMATE_ATTR_NAME + ']');
       forEach(children, function(child) {
         var state = parseInt(child.getAttribute(NG_ANIMATE_ATTR_NAME), 10);
@@ -35713,21 +36078,16 @@ var $$AnimateQueueProvider = ['$animateProvider', /** @this */ function($animate
               animationDetails.runner.end();
               /* falls through */
             case PRE_DIGEST_STATE:
-              activeAnimationsLookup.remove(child);
+              activeAnimationsLookup.delete(child);
               break;
           }
         }
       });
     }
 
-    function clearElementAnimationState(element) {
-      var node = getDomNode(element);
+    function clearElementAnimationState(node) {
       node.removeAttribute(NG_ANIMATE_ATTR_NAME);
-      activeAnimationsLookup.remove(node);
-    }
-
-    function isMatchingElement(nodeOrElmA, nodeOrElmB) {
-      return getDomNode(nodeOrElmA) === getDomNode(nodeOrElmB);
+      activeAnimationsLookup.delete(node);
     }
 
     /**
@@ -35737,54 +36097,54 @@ var $$AnimateQueueProvider = ['$animateProvider', /** @this */ function($animate
      * c) the element is not a child of the body
      * d) the element is not a child of the $rootElement
      */
-    function areAnimationsAllowed(element, parentElement, event) {
-      var bodyElement = jqLite($document[0].body);
-      var bodyElementDetected = isMatchingElement(element, bodyElement) || element[0].nodeName === 'HTML';
-      var rootElementDetected = isMatchingElement(element, $rootElement);
-      var parentAnimationDetected = false;
-      var animateChildren;
-      var elementDisabled = disabledElementsLookup.get(getDomNode(element));
+    function areAnimationsAllowed(node, parentNode, event) {
+      var bodyNode = $document[0].body;
+      var rootNode = getDomNode($rootElement);
 
-      var parentHost = jqLite.data(element[0], NG_ANIMATE_PIN_DATA);
+      var bodyNodeDetected = (node === bodyNode) || node.nodeName === 'HTML';
+      var rootNodeDetected = (node === rootNode);
+      var parentAnimationDetected = false;
+      var elementDisabled = disabledElementsLookup.get(node);
+      var animateChildren;
+
+      var parentHost = jqLite.data(node, NG_ANIMATE_PIN_DATA);
       if (parentHost) {
-        parentElement = parentHost;
+        parentNode = getDomNode(parentHost);
       }
 
-      parentElement = getDomNode(parentElement);
-
-      while (parentElement) {
-        if (!rootElementDetected) {
+      while (parentNode) {
+        if (!rootNodeDetected) {
           // angular doesn't want to attempt to animate elements outside of the application
           // therefore we need to ensure that the rootElement is an ancestor of the current element
-          rootElementDetected = isMatchingElement(parentElement, $rootElement);
+          rootNodeDetected = (parentNode === rootNode);
         }
 
-        if (parentElement.nodeType !== ELEMENT_NODE) {
+        if (parentNode.nodeType !== ELEMENT_NODE) {
           // no point in inspecting the #document element
           break;
         }
 
-        var details = activeAnimationsLookup.get(parentElement) || {};
+        var details = activeAnimationsLookup.get(parentNode) || {};
         // either an enter, leave or move animation will commence
         // therefore we can't allow any animations to take place
         // but if a parent animation is class-based then that's ok
         if (!parentAnimationDetected) {
-          var parentElementDisabled = disabledElementsLookup.get(parentElement);
+          var parentNodeDisabled = disabledElementsLookup.get(parentNode);
 
-          if (parentElementDisabled === true && elementDisabled !== false) {
+          if (parentNodeDisabled === true && elementDisabled !== false) {
             // disable animations if the user hasn't explicitly enabled animations on the
             // current element
             elementDisabled = true;
             // element is disabled via parent element, no need to check anything else
             break;
-          } else if (parentElementDisabled === false) {
+          } else if (parentNodeDisabled === false) {
             elementDisabled = false;
           }
           parentAnimationDetected = details.structural;
         }
 
         if (isUndefined(animateChildren) || animateChildren === true) {
-          var value = jqLite.data(parentElement, NG_ANIMATE_CHILDREN_DATA);
+          var value = jqLite.data(parentNode, NG_ANIMATE_CHILDREN_DATA);
           if (isDefined(value)) {
             animateChildren = value;
           }
@@ -35793,47 +36153,46 @@ var $$AnimateQueueProvider = ['$animateProvider', /** @this */ function($animate
         // there is no need to continue traversing at this point
         if (parentAnimationDetected && animateChildren === false) break;
 
-        if (!bodyElementDetected) {
+        if (!bodyNodeDetected) {
           // we also need to ensure that the element is or will be a part of the body element
           // otherwise it is pointless to even issue an animation to be rendered
-          bodyElementDetected = isMatchingElement(parentElement, bodyElement);
+          bodyNodeDetected = (parentNode === bodyNode);
         }
 
-        if (bodyElementDetected && rootElementDetected) {
+        if (bodyNodeDetected && rootNodeDetected) {
           // If both body and root have been found, any other checks are pointless,
           // as no animation data should live outside the application
           break;
         }
 
-        if (!rootElementDetected) {
-          // If no rootElement is detected, check if the parentElement is pinned to another element
-          parentHost = jqLite.data(parentElement, NG_ANIMATE_PIN_DATA);
+        if (!rootNodeDetected) {
+          // If `rootNode` is not detected, check if `parentNode` is pinned to another element
+          parentHost = jqLite.data(parentNode, NG_ANIMATE_PIN_DATA);
           if (parentHost) {
             // The pin target element becomes the next parent element
-            parentElement = getDomNode(parentHost);
+            parentNode = getDomNode(parentHost);
             continue;
           }
         }
 
-        parentElement = parentElement.parentNode;
+        parentNode = parentNode.parentNode;
       }
 
       var allowAnimation = (!parentAnimationDetected || animateChildren) && elementDisabled !== true;
-      return allowAnimation && rootElementDetected && bodyElementDetected;
+      return allowAnimation && rootNodeDetected && bodyNodeDetected;
     }
 
-    function markElementAnimationState(element, state, details) {
+    function markElementAnimationState(node, state, details) {
       details = details || {};
       details.state = state;
 
-      var node = getDomNode(element);
       node.setAttribute(NG_ANIMATE_ATTR_NAME, state);
 
       var oldValue = activeAnimationsLookup.get(node);
       var newValue = oldValue
           ? extend(oldValue, details)
           : details;
-      activeAnimationsLookup.put(node, newValue);
+      activeAnimationsLookup.set(node, newValue);
     }
   }];
 }];
@@ -35859,21 +36218,21 @@ var $$AnimationProvider = ['$animateProvider', /** @this */ function($animatePro
     return element.data(RUNNER_STORAGE_KEY);
   }
 
-  this.$get = ['$$jqLite', '$rootScope', '$injector', '$$AnimateRunner', '$$HashMap', '$$rAFScheduler',
-       function($$jqLite,   $rootScope,   $injector,   $$AnimateRunner,   $$HashMap,   $$rAFScheduler) {
+  this.$get = ['$$jqLite', '$rootScope', '$injector', '$$AnimateRunner', '$$Map', '$$rAFScheduler',
+       function($$jqLite,   $rootScope,   $injector,   $$AnimateRunner,   $$Map,   $$rAFScheduler) {
 
     var animationQueue = [];
     var applyAnimationClasses = applyAnimationClassesFactory($$jqLite);
 
     function sortAnimations(animations) {
       var tree = { children: [] };
-      var i, lookup = new $$HashMap();
+      var i, lookup = new $$Map();
 
-      // this is done first beforehand so that the hashmap
+      // this is done first beforehand so that the map
       // is filled with a list of the elements that will be animated
       for (i = 0; i < animations.length; i++) {
         var animation = animations[i];
-        lookup.put(animation.domNode, animations[i] = {
+        lookup.set(animation.domNode, animations[i] = {
           domNode: animation.domNode,
           fn: animation.fn,
           children: []
@@ -35892,7 +36251,7 @@ var $$AnimationProvider = ['$animateProvider', /** @this */ function($animatePro
 
         var elementNode = entry.domNode;
         var parentNode = elementNode.parentNode;
-        lookup.put(elementNode, entry);
+        lookup.set(elementNode, entry);
 
         var parentEntry;
         while (parentNode) {
@@ -36539,6 +36898,10 @@ var ngAnimateSwapDirective = ['$animate', '$rootScope', function($animate, $root
  *   /&#42; As of 1.4.4, this must always be set: it signals ngAnimate
  *     to not accidentally inherit a delay property from another CSS class &#42;/
  *   transition-duration: 0s;
+ *
+ *   /&#42; if you are using animations instead of transitions you should configure as follows:
+ *     animation-delay: 0.1s;
+ *     animation-duration: 0s; &#42;/
  * }
  * .my-animation.ng-enter.ng-enter-active {
  *   /&#42; standard transition styles &#42;/
@@ -37118,6 +37481,7 @@ angular.module('ngAnimate', [], function initAngularHelpers() {
   isFunction  = angular.isFunction;
   isElement   = angular.isElement;
 })
+  .info({ angularVersion: '1.6.3' })
   .directive('ngAnimateSwap', ngAnimateSwapDirective)
 
   .directive('ngAnimateChildren', $$AnimateChildrenDirective)
@@ -37136,8 +37500,8 @@ angular.module('ngAnimate', [], function initAngularHelpers() {
 })(window, window.angular);
 
 /**
- * @license AngularJS v1.6.1
- * (c) 2010-2016 Google, Inc. http://angularjs.org
+ * @license AngularJS v1.6.3
+ * (c) 2010-2017 Google, Inc. http://angularjs.org
  * License: MIT
  */
 (function(window, angular) {'use strict';
@@ -37196,6 +37560,7 @@ angular.module('ngAnimate', [], function initAngularHelpers() {
  * {@link guide/accessibility Developer Guide}.
  */
 var ngAriaModule = angular.module('ngAria', ['ng']).
+                        info({ angularVersion: '1.6.3' }).
                         provider('$aria', $AriaProvider);
 
 /**
@@ -37497,7 +37862,7 @@ ngAriaModule.directive('ngShow', ['$aria', function($aria) {
   return {
     restrict: 'A',
     compile: function(elem, attr) {
-      var fn = $parse(attr.ngClick, /* interceptorFn */ null, /* expensiveChecks */ true);
+      var fn = $parse(attr.ngClick);
       return function(scope, elem, attr) {
 
         if (!isNodeOneOf(elem, nodeBlackList)) {
@@ -37539,8 +37904,8 @@ ngAriaModule.directive('ngShow', ['$aria', function($aria) {
 })(window, window.angular);
 
 /**
- * @license AngularJS v1.6.1
- * (c) 2010-2016 Google, Inc. http://angularjs.org
+ * @license AngularJS v1.6.3
+ * (c) 2010-2017 Google, Inc. http://angularjs.org
  * License: MIT
  */
 (function(window, angular) {'use strict';
@@ -37812,6 +38177,7 @@ angular.module('ngMessages', [], function initAngularHelpers() {
   isString = angular.isString;
   jqLite = angular.element;
 })
+  .info({ angularVersion: '1.6.3' })
 
   /**
    * @ngdoc directive
@@ -41477,7 +41843,7 @@ function ngMessageDirectiveFactory() {
  * Angular Material Design
  * https://github.com/angular/material
  * @license MIT
- * v1.1.1
+ * v1.1.3
  */
 (function( window, angular, undefined ){
 "use strict";
@@ -41485,7 +41851,7 @@ function ngMessageDirectiveFactory() {
 (function(){
 "use strict";
 
-angular.module('ngMaterial', ["ng","ngAnimate","ngAria","material.core","material.core.gestures","material.core.layout","material.core.meta","material.core.theming.palette","material.core.theming","material.core.animate","material.components.autocomplete","material.components.backdrop","material.components.bottomSheet","material.components.button","material.components.card","material.components.chips","material.components.checkbox","material.components.colors","material.components.content","material.components.datepicker","material.components.dialog","material.components.divider","material.components.fabActions","material.components.fabShared","material.components.fabSpeedDial","material.components.fabToolbar","material.components.gridList","material.components.icon","material.components.input","material.components.list","material.components.menu","material.components.menuBar","material.components.navBar","material.components.panel","material.components.progressCircular","material.components.progressLinear","material.components.radioButton","material.components.select","material.components.showHide","material.components.sidenav","material.components.slider","material.components.sticky","material.components.subheader","material.components.swipe","material.components.switch","material.components.tabs","material.components.toast","material.components.toolbar","material.components.tooltip","material.components.virtualRepeat","material.components.whiteframe"]);
+angular.module('ngMaterial', ["ng","ngAnimate","ngAria","material.core","material.core.gestures","material.core.interaction","material.core.layout","material.core.meta","material.core.theming.palette","material.core.theming","material.core.animate","material.components.autocomplete","material.components.backdrop","material.components.bottomSheet","material.components.button","material.components.card","material.components.checkbox","material.components.chips","material.components.colors","material.components.content","material.components.datepicker","material.components.dialog","material.components.divider","material.components.fabActions","material.components.fabShared","material.components.fabSpeedDial","material.components.fabToolbar","material.components.gridList","material.components.icon","material.components.input","material.components.list","material.components.menu","material.components.menuBar","material.components.panel","material.components.navBar","material.components.progressCircular","material.components.progressLinear","material.components.radioButton","material.components.select","material.components.showHide","material.components.sidenav","material.components.slider","material.components.sticky","material.components.subheader","material.components.swipe","material.components.switch","material.components.toast","material.components.tabs","material.components.toolbar","material.components.tooltip","material.components.truncate","material.components.virtualRepeat","material.components.whiteframe"]);
 })();
 (function(){
 "use strict";
@@ -41497,11 +41863,13 @@ angular.module('ngMaterial', ["ng","ngAnimate","ngAria","material.core","materia
 DetectNgTouch.$inject = ["$log", "$injector"];
 MdCoreConfigure.$inject = ["$provide", "$mdThemingProvider"];
 rAFDecorator.$inject = ["$delegate"];
+qDecorator.$inject = ["$delegate"];
 angular
   .module('material.core', [
     'ngAnimate',
     'material.core.animate',
     'material.core.layout',
+    'material.core.interaction',
     'material.core.gestures',
     'material.core.theming'
   ])
@@ -41529,7 +41897,8 @@ function DetectNgTouch($log, $injector) {
  */
 function MdCoreConfigure($provide, $mdThemingProvider) {
 
-  $provide.decorator('$$rAF', ["$delegate", rAFDecorator]);
+  $provide.decorator('$$rAF', ['$delegate', rAFDecorator]);
+  $provide.decorator('$q', ['$delegate', qDecorator]);
 
   $mdThemingProvider.theme('default')
     .primaryPalette('indigo')
@@ -41572,11 +41941,30 @@ function rAFDecorator($delegate) {
   return $delegate;
 }
 
+/**
+ * @ngInject
+ */
+function qDecorator($delegate) {
+  /**
+   * Adds a shim for $q.resolve for Angular version that don't have it,
+   * so we don't have to think about it.
+   *
+   * via https://github.com/angular/angular.js/pull/11987
+   */
+
+  // TODO(crisbeto): this won't be necessary once we drop Angular 1.3
+  if (!$delegate.resolve) {
+    $delegate.resolve = $delegate.when;
+  }
+  return $delegate;
+}
+
 })();
 (function(){
 "use strict";
 
-angular.module('material.core')
+
+MdAutofocusDirective.$inject = ["$parse"];angular.module('material.core')
   .directive('mdAutofocus', MdAutofocusDirective)
 
   // Support the deprecated md-auto-focus and md-sidenav-focus as well
@@ -41668,21 +42056,42 @@ angular.module('material.core')
  * </div>
  * </hljs>
  **/
-function MdAutofocusDirective() {
+function MdAutofocusDirective($parse) {
   return {
     restrict: 'A',
+    link: {
+      pre: preLink
+    }
+  };
 
-    link: postLink
+  function preLink(scope, element, attr) {
+    var attrExp = attr.mdAutoFocus || attr.mdAutofocus || attr.mdSidenavFocus;
+
+    // Initially update the expression by manually parsing the expression as per $watch source.
+    updateExpression($parse(attrExp)(scope));
+
+    // Only watch the expression if it is not empty.
+    if (attrExp) {
+      scope.$watch(attrExp, updateExpression);
+    }
+
+    /**
+     * Updates the autofocus class which is used to determine whether the attribute
+     * expression evaluates to true or false.
+     * @param {string|boolean} value Attribute Value
+     */
+    function updateExpression(value) {
+
+      // Rather than passing undefined to the jqLite toggle class function we explicitly set the
+      // value to true. Otherwise the class will be just toggled instead of being forced.
+      if (angular.isUndefined(value)) {
+        value = true;
+      }
+
+      element.toggleClass('md-autofocus', !!value);
+    }
   }
-}
 
-function postLink(scope, element, attrs) {
-  var attr = attrs.mdAutoFocus || attrs.mdAutofocus || attrs.mdSidenavFocus;
-
-  // Setup a watcher on the proper attribute to update a class we can check for in $mdUtil
-  scope.$watch(attr, function(canAutofocus) {
-    element.toggleClass('md-autofocus', canAutofocus);
-  });
 }
 
 })();
@@ -41760,26 +42169,26 @@ function ColorUtilFactory() {
     hexToRgba: hexToRgba,
     rgbToRgba: rgbToRgba,
     rgbaToRgb: rgbaToRgb
-  }
+  };
 }
+
 })();
 (function(){
 "use strict";
 
-
-MdConstantFactory.$inject = ["$sniffer", "$window", "$document"];angular.module('material.core')
+angular.module('material.core')
 .factory('$mdConstant', MdConstantFactory);
 
 /**
  * Factory function that creates the grab-bag $mdConstant service.
  * @ngInject
  */
-function MdConstantFactory($sniffer, $window, $document) {
+function MdConstantFactory() {
 
-  var vendorPrefix = $sniffer.vendorPrefix;
+  var prefixTestEl = document.createElement('div');
+  var vendorPrefix = getVendorPrefix(prefixTestEl);
   var isWebkit = /webkit/i.test(vendorPrefix);
   var SPECIAL_CHARS_REGEXP = /([:\-_]+(.))/g;
-  var prefixTestEl = document.createElement('div');
 
   function vendorProperty(name) {
     // Add a dash between the prefix and name, to be able to transform the string into camelcase.
@@ -41787,13 +42196,13 @@ function MdConstantFactory($sniffer, $window, $document) {
     var ucPrefix = camelCase(prefixedName);
     var lcPrefix = ucPrefix.charAt(0).toLowerCase() + ucPrefix.substring(1);
 
-    return hasStyleProperty(name)     ? name     :       // The current browser supports the un-prefixed property
-           hasStyleProperty(ucPrefix) ? ucPrefix :       // The current browser only supports the prefixed property.
-           hasStyleProperty(lcPrefix) ? lcPrefix : name; // Some browsers are only supporting the prefix in lowercase.
+    return hasStyleProperty(prefixTestEl, name)     ? name     :       // The current browser supports the un-prefixed property
+           hasStyleProperty(prefixTestEl, ucPrefix) ? ucPrefix :       // The current browser only supports the prefixed property.
+           hasStyleProperty(prefixTestEl, lcPrefix) ? lcPrefix : name; // Some browsers are only supporting the prefix in lowercase.
   }
 
-  function hasStyleProperty(property) {
-    return angular.isDefined(prefixTestEl.style[property]);
+  function hasStyleProperty(testElement, property) {
+    return angular.isDefined(testElement.style[property]);
   }
 
   function camelCase(input) {
@@ -41802,14 +42211,41 @@ function MdConstantFactory($sniffer, $window, $document) {
     });
   }
 
+  function getVendorPrefix(testElement) {
+    var prop, match;
+    var vendorRegex = /^(Moz|webkit|ms)(?=[A-Z])/;
+
+    for (prop in testElement.style) {
+      if (match = vendorRegex.exec(prop)) {
+        return match[0];
+      }
+    }
+  }
+
   var self = {
     isInputKey : function(e) { return (e.keyCode >= 31 && e.keyCode <= 90); },
     isNumPadKey : function (e){ return (3 === e.location && e.keyCode >= 97 && e.keyCode <= 105); },
     isNavigationKey : function(e) {
       var kc = self.KEY_CODE, NAVIGATION_KEYS =  [kc.SPACE, kc.ENTER, kc.UP_ARROW, kc.DOWN_ARROW];
-      return (NAVIGATION_KEYS.indexOf(e.keyCode) != -1);    
+      return (NAVIGATION_KEYS.indexOf(e.keyCode) != -1);
     },
 
+    /**
+     * Maximum size, in pixels, that can be explicitly set to an element. The actual value varies
+     * between browsers, but IE11 has the very lowest size at a mere 1,533,917px. Ideally we could
+     * compute this value, but Firefox always reports an element to have a size of zero if it
+     * goes over the max, meaning that we'd have to binary search for the value.
+     */
+    ELEMENT_MAX_PIXELS: 1533917,
+
+    /**
+     * Priority for a directive that should run before the directives from ngAria.
+     */
+    BEFORE_NG_ARIA: 210,
+
+    /**
+     * Common Keyboard actions and their associated keycode.
+     */
     KEY_CODE: {
       COMMA: 188,
       SEMICOLON : 186,
@@ -41828,6 +42264,11 @@ function MdConstantFactory($sniffer, $window, $document) {
       BACKSPACE: 8,
       DELETE: 46
     },
+
+    /**
+     * Vendor prefixed CSS properties to be used to support the given functionality in older browsers
+     * as well.
+     */
     CSS: {
       /* Constants */
       TRANSITIONEND: 'transitionend' + (isWebkit ? ' webkitTransitionEnd' : ''),
@@ -41843,6 +42284,7 @@ function MdConstantFactory($sniffer, $window, $document) {
       ANIMATION_TIMING: vendorProperty('animationTimingFunction'),
       ANIMATION_DIRECTION: vendorProperty('animationDirection')
     },
+
     /**
      * As defined in core/style/variables.scss
      *
@@ -41866,6 +42308,7 @@ function MdConstantFactory($sniffer, $window, $document) {
       'portrait'  : '(orientation: portrait)'                    ,
       'print' : 'print'
     },
+
     MEDIA_PRIORITY: [
       'xl',
       'gt-lg',
@@ -42306,7 +42749,7 @@ function mdMediaFactory($mdConstant, $rootScope, $window) {
     });
 
     return function unwatch() {
-      unwatchFns.forEach(function(fn) { fn(); })
+      unwatchFns.forEach(function(fn) { fn(); });
     };
   }
 
@@ -42366,7 +42809,7 @@ function MdPrefixer(initialAttributes, buildSelector) {
 
     return _buildList(attributes)
       .map(function(item) {
-        return '[' + item + ']'
+        return '[' + item + ']';
       })
       .join(',');
   }
@@ -42417,6 +42860,7 @@ function MdPrefixer(initialAttributes, buildSelector) {
   }
 
 }
+
 })();
 (function(){
 "use strict";
@@ -42483,9 +42927,28 @@ function UtilFactory($document, $timeout, $compile, $rootScope, $$mdAnimate, $in
 
   var $mdUtil = {
     dom: {},
-    now: window.performance ?
+    now: window.performance && window.performance.now ?
       angular.bind(window.performance, window.performance.now) : Date.now || function() {
       return new Date().getTime();
+    },
+
+    /**
+     * Cross-version compatibility method to retrieve an option of a ngModel controller,
+     * which supports the breaking changes in the AngularJS snapshot (SHA 87a2ff76af5d0a9268d8eb84db5755077d27c84c).
+     * @param {!angular.ngModelCtrl} ngModelCtrl
+     * @param {!string} optionName
+     * @returns {Object|undefined}
+     */
+    getModelOption: function (ngModelCtrl, optionName) {
+      if (!ngModelCtrl.$options) {
+        return;
+      }
+
+      var $options = ngModelCtrl.$options;
+
+      // The newer versions of Angular introduced a `getOption function and made the option values no longer
+      // visible on the $options object.
+      return $options.getOption ? $options.getOption(optionName) : $options[optionName]
     },
 
     /**
@@ -42557,18 +43020,12 @@ function UtilFactory($document, $timeout, $compile, $rootScope, $$mdAnimate, $in
     },
 
     /**
-     * Calculate the positive scroll offset
-     * TODO: Check with pinch-zoom in IE/Chrome;
-     *       https://code.google.com/p/chromium/issues/detail?id=496285
+     * Determines the absolute position of the viewport.
+     * Useful when making client rectangles absolute.
+     * @returns {number}
      */
-    scrollTop: function(element) {
-      element = angular.element(element || $document[0].body);
-
-      var body = (element[0] == $document[0].body) ? $document[0].body : undefined;
-      var scrollTop = body ? body.scrollTop + body.parentElement.scrollTop : 0;
-
-      // Calculate the positive scroll offset
-      return scrollTop || Math.abs(element[0].getBoundingClientRect().top);
+    getViewportTop: function() {
+      return window.scrollY || window.pageYOffset || 0;
     },
 
     /**
@@ -42628,44 +43085,56 @@ function UtilFactory($document, $timeout, $compile, $rootScope, $$mdAnimate, $in
      *     use the passed parent element.
      */
     disableScrollAround: function(element, parent, options) {
-      $mdUtil.disableScrollAround._count = $mdUtil.disableScrollAround._count || 0;
-      ++$mdUtil.disableScrollAround._count;
-      if ($mdUtil.disableScrollAround._enableScrolling) return $mdUtil.disableScrollAround._enableScrolling;
-      var body = $document[0].body,
-        restoreBody = disableBodyScroll(),
-        restoreElement = disableElementScroll(parent);
+      options = options || {};
 
-      return $mdUtil.disableScrollAround._enableScrolling = function() {
-        if (!--$mdUtil.disableScrollAround._count) {
+      $mdUtil.disableScrollAround._count = Math.max(0, $mdUtil.disableScrollAround._count || 0);
+      $mdUtil.disableScrollAround._count++;
+
+      if ($mdUtil.disableScrollAround._restoreScroll) {
+        return $mdUtil.disableScrollAround._restoreScroll;
+      }
+
+      var body = $document[0].body;
+      var restoreBody = disableBodyScroll();
+      var restoreElement = disableElementScroll(parent);
+
+      return $mdUtil.disableScrollAround._restoreScroll = function() {
+        if (--$mdUtil.disableScrollAround._count <= 0) {
           restoreBody();
           restoreElement();
-          delete $mdUtil.disableScrollAround._enableScrolling;
+          delete $mdUtil.disableScrollAround._restoreScroll;
         }
       };
 
-      // Creates a virtual scrolling mask to absorb touchmove, keyboard, scrollbar clicking, and wheel events
+      /**
+       * Creates a virtual scrolling mask to prevent touchmove, keyboard, scrollbar clicking,
+       * and wheel events
+       */
       function disableElementScroll(element) {
         element = angular.element(element || body);
+
         var scrollMask;
-        if (options && options.disableScrollMask) {
+
+        if (options.disableScrollMask) {
           scrollMask = element;
         } else {
-          element = element[0];
           scrollMask = angular.element(
             '<div class="md-scroll-mask">' +
             '  <div class="md-scroll-mask-bar"></div>' +
             '</div>');
-          element.appendChild(scrollMask[0]);
+          element.append(scrollMask);
         }
 
         scrollMask.on('wheel', preventDefault);
         scrollMask.on('touchmove', preventDefault);
 
-        return function restoreScroll() {
+        return function restoreElementScroll() {
           scrollMask.off('wheel');
           scrollMask.off('touchmove');
-          scrollMask[0].parentNode.removeChild(scrollMask[0]);
-          delete $mdUtil.disableScrollAround._enableScrolling;
+
+          if (!options.disableScrollMask) {
+            scrollMask[0].parentNode.removeChild(scrollMask[0]);
+          }
         };
 
         function preventDefault(e) {
@@ -42675,42 +43144,51 @@ function UtilFactory($document, $timeout, $compile, $rootScope, $$mdAnimate, $in
 
       // Converts the body to a position fixed block and translate it to the proper scroll position
       function disableBodyScroll() {
-        var htmlNode = body.parentNode;
-        var restoreHtmlStyle = htmlNode.style.cssText || '';
-        var restoreBodyStyle = body.style.cssText || '';
-        var scrollOffset = $mdUtil.scrollTop(body);
-        var clientWidth = body.clientWidth;
+        var documentElement = $document[0].documentElement;
 
-        if (body.scrollHeight > body.clientHeight + 1) {
-          applyStyles(body, {
+        var prevDocumentStyle = documentElement.style.cssText || '';
+        var prevBodyStyle = body.style.cssText || '';
+
+        var viewportTop = $mdUtil.getViewportTop();
+        var clientWidth = body.clientWidth;
+        var hasVerticalScrollbar = body.scrollHeight > body.clientHeight + 1;
+
+        if (hasVerticalScrollbar) {
+          angular.element(body).css({
             position: 'fixed',
             width: '100%',
-            top: -scrollOffset + 'px'
+            top: -viewportTop + 'px'
           });
-
-          htmlNode.style.overflowY = 'scroll';
         }
 
-        if (body.clientWidth < clientWidth) applyStyles(body, {overflow: 'hidden'});
+        if (body.clientWidth < clientWidth) {
+          body.style.overflow = 'hidden';
+        }
+
+        // This should be applied after the manipulation to the body, because
+        // adding a scrollbar can potentially resize it, causing the measurement
+        // to change.
+        if (hasVerticalScrollbar) {
+          documentElement.style.overflowY = 'scroll';
+        }
 
         return function restoreScroll() {
-          body.style.cssText = restoreBodyStyle;
-          htmlNode.style.cssText = restoreHtmlStyle;
-          body.scrollTop = scrollOffset;
-          htmlNode.scrollTop = scrollOffset;
+          // Reset the inline style CSS to the previous.
+          body.style.cssText = prevBodyStyle;
+          documentElement.style.cssText = prevDocumentStyle;
+
+          // The body loses its scroll position while being fixed.
+          body.scrollTop = viewportTop;
         };
       }
 
-      function applyStyles(el, styles) {
-        for (var key in styles) {
-          el.style[key] = styles[key];
-        }
-      }
     },
+
     enableScrolling: function() {
-      var method = this.disableScrollAround._enableScrolling;
-      method && method();
+      var restoreFn = this.disableScrollAround._restoreScroll;
+      restoreFn && restoreFn();
     },
+
     floatingScrollbars: function() {
       if (this.floatingScrollbars.cached === undefined) {
         var tempNode = angular.element('<div><div></div></div>').css({
@@ -42934,7 +43412,7 @@ function UtilFactory($document, $timeout, $compile, $rootScope, $$mdAnimate, $in
       if ( angular.isString(validateWith) ) {
         var tagName = validateWith.toUpperCase();
         validateWith = function(el) {
-          return el.nodeName === tagName;
+          return el.nodeName.toUpperCase() === tagName;
         };
       }
 
@@ -43187,10 +43665,11 @@ function UtilFactory($document, $timeout, $compile, $rootScope, $$mdAnimate, $in
     /**
      * Animate the requested element's scrollTop to the requested scrollPosition with basic easing.
      *
-     * @param element The element to scroll.
-     * @param scrollEnd The new/final scroll position.
+     * @param {!HTMLElement} element The element to scroll.
+     * @param {number} scrollEnd The new/final scroll position.
+     * @param {number=} duration Duration of the scroll. Default is 1000ms.
      */
-    animateScrollTo: function(element, scrollEnd) {
+    animateScrollTo: function(element, scrollEnd, duration) {
       var scrollStart = element.scrollTop;
       var scrollChange = scrollEnd - scrollStart;
       var scrollingDown = scrollStart < scrollEnd;
@@ -43200,19 +43679,19 @@ function UtilFactory($document, $timeout, $compile, $rootScope, $$mdAnimate, $in
 
       function scrollChunk() {
         var newPosition = calculateNewPosition();
-        
+
         element.scrollTop = newPosition;
-        
+
         if (scrollingDown ? newPosition < scrollEnd : newPosition > scrollEnd) {
           $$rAF(scrollChunk);
         }
       }
-      
+
       function calculateNewPosition() {
-        var duration = 1000;
+        var easeDuration = duration || 1000;
         var currentTime = $mdUtil.now() - startTime;
-        
-        return ease(currentTime, scrollStart, scrollChange, duration);
+
+        return ease(currentTime, scrollStart, scrollChange, easeDuration);
       }
 
       function ease(currentTime, start, change, duration) {
@@ -43221,12 +43700,31 @@ function UtilFactory($document, $timeout, $compile, $rootScope, $$mdAnimate, $in
         if (currentTime > duration) {
           return start + change;
         }
-        
+
         var ts = (currentTime /= duration) * currentTime;
         var tc = ts * currentTime;
 
         return start + change * (-2 * tc + 3 * ts);
       }
+    },
+
+    /**
+     * Provides an easy mechanism for removing duplicates from an array.
+     *
+     *    var myArray = [1, 2, 2, 3, 3, 3, 4, 4, 4, 4];
+     *
+     *    $mdUtil.uniq(myArray) => [1, 2, 3, 4]
+     *
+     * @param {array} array The array whose unique values should be returned.
+     *
+     * @returns {array} A copy of the array containing only unique values.
+     */
+    uniq: function(array) {
+      if (!array) { return; }
+
+      return array.filter(function(value, index, self) {
+        return self.indexOf(value) === index;
+      });
     }
   };
 
@@ -43267,6 +43765,341 @@ angular.element.prototype.blur = angular.element.prototype.blur || function() {
 
 /**
  * @ngdoc module
+ * @name material.core.compiler
+ * @description
+ * Angular Material template and element compiler.
+ */
+MdCompilerService.$inject = ["$q", "$templateRequest", "$injector", "$compile", "$controller"];
+angular
+  .module('material.core')
+  .service('$mdCompiler', MdCompilerService);
+
+/**
+ * @ngdoc service
+ * @name $mdCompiler
+ * @module material.core.compiler
+ * @description
+ * The $mdCompiler service is an abstraction of Angular's compiler, that allows developers
+ * to easily compile an element with options like in a Directive Definition Object.
+ *
+ * > The compiler powers a lot of components inside of Angular Material.
+ * > Like the `$mdPanel` or `$mdDialog`.
+ *
+ * @usage
+ *
+ * Basic Usage with a template
+ *
+ * <hljs lang="js">
+ *   $mdCompiler.compile({
+ *     templateUrl: 'modal.html',
+ *     controller: 'ModalCtrl',
+ *     locals: {
+ *       modal: myModalInstance;
+ *     }
+ *   }).then(function (compileData) {
+ *     compileData.element; // Compiled DOM element
+ *     compileData.link(myScope); // Instantiate controller and link element to scope.
+ *   });
+ * </hljs>
+ *
+ * Example with a content element
+ *
+ * <hljs lang="js">
+ *
+ *   // Create a virtual element and link it manually.
+ *   // The compiler doesn't need to recompile the element each time.
+ *   var myElement = $compile('<span>Test</span>')(myScope);
+ *
+ *   $mdCompiler.compile({
+ *     contentElement: myElement
+ *   }).then(function (compileData) {
+ *     compileData.element // Content Element (same as above)
+ *     compileData.link // This does nothing when using a contentElement.
+ *   });
+ * </hljs>
+ *
+ * > Content Element is a significant performance improvement when the developer already knows that the
+ * > compiled element will be always the same and the scope will not change either.
+ *
+ * The `contentElement` option also supports DOM elements which will be temporary removed and restored
+ * at its old position.
+ *
+ * <hljs lang="js">
+ *   var domElement = document.querySelector('#myElement');
+ *
+ *   $mdCompiler.compile({
+ *     contentElement: myElement
+ *   }).then(function (compileData) {
+ *     compileData.element // Content Element (same as above)
+ *     compileData.link // This does nothing when using a contentElement.
+ *   });
+ * </hljs>
+ *
+ * The `$mdCompiler` can also query for the element in the DOM itself.
+ *
+ * <hljs lang="js">
+ *   $mdCompiler.compile({
+ *     contentElement: '#myElement'
+ *   }).then(function (compileData) {
+ *     compileData.element // Content Element (same as above)
+ *     compileData.link // This does nothing when using a contentElement.
+ *   });
+ * </hljs>
+ *
+ */
+function MdCompilerService($q, $templateRequest, $injector, $compile, $controller) {
+  /** @private @const {!angular.$q} */
+  this.$q = $q;
+
+  /** @private @const {!angular.$templateRequest} */
+  this.$templateRequest = $templateRequest;
+
+  /** @private @const {!angular.$injector} */
+  this.$injector = $injector;
+
+  /** @private @const {!angular.$compile} */
+  this.$compile = $compile;
+
+  /** @private @const {!angular.$controller} */
+  this.$controller = $controller;
+}
+
+/**
+ * @ngdoc method
+ * @name $mdCompiler#compile
+ * @description
+ *
+ * A method to compile a HTML template with the Angular compiler.
+ * The `$mdCompiler` is wrapper around the Angular compiler and provides extra functionality
+ * like controller instantiation or async resolves.
+ *
+ * @param {!Object} options An options object, with the following properties:
+ *
+ *    - `controller` - `{string|Function}` Controller fn that should be associated with
+ *         newly created scope or the name of a registered controller if passed as a string.
+ *    - `controllerAs` - `{string=}` A controller alias name. If present the controller will be
+ *         published to scope under the `controllerAs` name.
+ *    - `contentElement` - `{string|Element}`: Instead of using a template, which will be
+ *         compiled each time, you can also use a DOM element.<br/>
+ *    - `template` - `{string=}` An html template as a string.
+ *    - `templateUrl` - `{string=}` A path to an html template.
+ *    - `transformTemplate` - `{function(template)=}` A function which transforms the template after
+ *        it is loaded. It will be given the template string as a parameter, and should
+ *        return a a new string representing the transformed template.
+ *    - `resolve` - `{Object.<string, function>=}` - An optional map of dependencies which should
+ *        be injected into the controller. If any of these dependencies are promises, the compiler
+ *        will wait for them all to be resolved, or if one is rejected before the controller is
+ *        instantiated `compile()` will fail..
+ *      * `key` - `{string}`: a name of a dependency to be injected into the controller.
+ *      * `factory` - `{string|function}`: If `string` then it is an alias for a service.
+ *        Otherwise if function, then it is injected and the return value is treated as the
+ *        dependency. If the result is a promise, it is resolved before its value is
+ *        injected into the controller.
+ *
+ * @returns {Object} promise A promise, which will be resolved with a `compileData` object.
+ * `compileData` has the following properties:
+ *
+ *   - `element` - `{element}`: an uncompiled element matching the provided template.
+ *   - `link` - `{function(scope)}`: A link function, which, when called, will compile
+ *     the element and instantiate the provided controller (if given).
+ *   - `locals` - `{object}`: The locals which will be passed into the controller once `link` is
+ *     called. If `bindToController` is true, they will be coppied to the ctrl instead
+ *
+ */
+MdCompilerService.prototype.compile = function(options) {
+
+  if (options.contentElement) {
+    return this._prepareContentElement(options);
+  } else {
+    return this._compileTemplate(options);
+  }
+
+};
+
+/**
+ * Instead of compiling any template, the compiler just fetches an existing HTML element from the DOM and
+ * provides a restore function to put the element back it old DOM position.
+ * @param {!Object} options Options to be used for the compiler.
+ * @private
+ */
+MdCompilerService.prototype._prepareContentElement = function(options) {
+
+  var contentElement = this._fetchContentElement(options);
+
+  return this.$q.resolve({
+    element: contentElement.element,
+    cleanup: contentElement.restore,
+    locals: {},
+    link: function() {
+      return contentElement.element;
+    }
+  });
+
+};
+
+/**
+ * Compiles a template by considering all options and waiting for all resolves to be ready.
+ * @param {!Object} options Compile options
+ * @returns {!Object} Compile data with link function.
+ * @private
+ */
+MdCompilerService.prototype._compileTemplate = function(options) {
+
+  var self = this;
+  var templateUrl = options.templateUrl;
+  var template = options.template || '';
+  var resolve = angular.extend({}, options.resolve);
+  var locals = angular.extend({}, options.locals);
+  var transformTemplate = options.transformTemplate || angular.identity;
+
+  // Take resolve values and invoke them.
+  // Resolves can either be a string (value: 'MyRegisteredAngularConst'),
+  // or an invokable 'factory' of sorts: (value: function ValueGetter($dependency) {})
+  angular.forEach(resolve, function(value, key) {
+    if (angular.isString(value)) {
+      resolve[key] = self.$injector.get(value);
+    } else {
+      resolve[key] = self.$injector.invoke(value);
+    }
+  });
+
+  // Add the locals, which are just straight values to inject
+  // eg locals: { three: 3 }, will inject three into the controller
+  angular.extend(resolve, locals);
+
+  if (templateUrl) {
+    resolve.$$ngTemplate = this.$templateRequest(templateUrl);
+  } else {
+    resolve.$$ngTemplate = this.$q.when(template);
+  }
+
+
+  // Wait for all the resolves to finish if they are promises
+  return this.$q.all(resolve).then(function(locals) {
+
+    var template = transformTemplate(locals.$$ngTemplate, options);
+    var element = options.element || angular.element('<div>').html(template.trim()).contents();
+
+    return self._compileElement(locals, element, options);
+  });
+
+};
+
+/**
+ * Method to compile an element with the given options.
+ * @param {!Object} locals Locals to be injected to the controller if present
+ * @param {!JQLite} element Element to be compiled and linked
+ * @param {!Object} options Options to be used for linking.
+ * @returns {!Object} Compile data with link function.
+ * @private
+ */
+MdCompilerService.prototype._compileElement = function(locals, element, options) {
+  var self = this;
+  var ngLinkFn = this.$compile(element);
+
+  var compileData = {
+    element: element,
+    cleanup: element.remove.bind(element),
+    locals: locals,
+    link: linkFn
+  };
+
+  function linkFn(scope) {
+    locals.$scope = scope;
+
+    // Instantiate controller if the developer provided one.
+    if (options.controller) {
+
+      var injectLocals = angular.extend(locals, {
+        $element: element
+      });
+
+      var invokeCtrl = self.$controller(options.controller, injectLocals, true, options.controllerAs);
+
+      if (options.bindToController) {
+        angular.extend(invokeCtrl.instance, locals);
+      }
+
+      var ctrl = invokeCtrl();
+
+      // Unique identifier for Angular Route ngView controllers.
+      element.data('$ngControllerController', ctrl);
+      element.children().data('$ngControllerController', ctrl);
+
+      // Expose the instantiated controller to the compile data
+      compileData.controller = ctrl;
+    }
+
+    // Invoke the Angular $compile link function.
+    return ngLinkFn(scope);
+  }
+
+  return compileData;
+
+};
+
+/**
+ * Fetches an element removing it from the DOM and using it temporary for the compiler.
+ * Elements which were fetched will be restored after use.
+ * @param {!Object} options Options to be used for the compilation.
+ * @returns {{element: !JQLite, restore: !Function}}
+ * @private
+ */
+MdCompilerService.prototype._fetchContentElement = function(options) {
+
+  var contentEl = options.contentElement;
+  var restoreFn = null;
+
+  if (angular.isString(contentEl)) {
+    contentEl = document.querySelector(contentEl);
+    restoreFn = createRestoreFn(contentEl);
+  } else {
+    contentEl = contentEl[0] || contentEl;
+
+    // When the element is visible in the DOM, then we restore it at close of the dialog.
+    // Otherwise it will be removed from the DOM after close.
+    if (document.contains(contentEl)) {
+      restoreFn = createRestoreFn(contentEl);
+    } else {
+      restoreFn = function() {
+        if (contentEl.parentNode) {
+          contentEl.parentNode.removeChild(contentEl);
+        }
+      }
+    }
+  }
+
+  return {
+    element: angular.element(contentEl),
+    restore: restoreFn
+  };
+
+  function createRestoreFn(element) {
+    var parent = element.parentNode;
+    var nextSibling = element.nextElementSibling;
+
+    return function() {
+      if (!nextSibling) {
+        // When the element didn't had any sibling, then it can be simply appended to the
+        // parent, because it plays no role, which index it had before.
+        parent.appendChild(element);
+      } else {
+        // When the element had a sibling, which marks the previous position of the element
+        // in the DOM, we insert it correctly before the sibling, to have the same index as
+        // before.
+        parent.insertBefore(element, nextSibling);
+      }
+    }
+  }
+};
+
+
+})();
+(function(){
+"use strict";
+
+/**
+ * @ngdoc module
  * @name material.core.aria
  * @description
  * Aria Expectations for ngMaterial components.
@@ -43298,18 +44131,15 @@ angular
  */
 function MdAriaProvider() {
 
-  var self = this;
-
-  /**
-   * Whether we should show ARIA warnings in the console, if labels are missing on the element
-   * By default the warnings are enabled
-   */
-  self.showWarnings = true;
+  var config = {
+    /** Whether we should show ARIA warnings in the console if labels are missing on the element */
+    showWarnings: true
+  };
 
   return {
     disableWarnings: disableWarnings,
     $get: ["$$rAF", "$log", "$window", "$interpolate", function($$rAF, $log, $window, $interpolate) {
-      return MdAriaService.apply(self, arguments);
+      return MdAriaService.apply(config, arguments);
     }]
   };
 
@@ -43319,7 +44149,7 @@ function MdAriaProvider() {
    * @description Disables all ARIA warnings generated by Angular Material.
    */
   function disableWarnings() {
-    self.showWarnings = false;
+    config.showWarnings = false;
   }
 }
 
@@ -43336,7 +44166,8 @@ function MdAriaService($$rAF, $log, $window, $interpolate) {
     expect: expect,
     expectAsync: expectAsync,
     expectWithText: expectWithText,
-    expectWithoutText: expectWithoutText
+    expectWithoutText: expectWithoutText,
+    getText: getText
   };
 
   /**
@@ -43378,7 +44209,7 @@ function MdAriaService($$rAF, $log, $window, $interpolate) {
     var content = getText(element) || "";
     var hasBinding = content.indexOf($interpolate.startSymbol()) > -1;
 
-    if ( hasBinding ) {
+    if (hasBinding) {
       expectAsync(element, attrName, function() {
         return getText(element);
       });
@@ -43442,147 +44273,6 @@ function MdAriaService($$rAF, $log, $window, $interpolate) {
 
     return hasAttr;
   }
-}
-
-})();
-(function(){
-"use strict";
-
-
-mdCompilerService.$inject = ["$q", "$templateRequest", "$injector", "$compile", "$controller"];angular
-  .module('material.core')
-  .service('$mdCompiler', mdCompilerService);
-
-function mdCompilerService($q, $templateRequest, $injector, $compile, $controller) {
-  /* jshint validthis: true */
-
-  /*
-   * @ngdoc service
-   * @name $mdCompiler
-   * @module material.core
-   * @description
-   * The $mdCompiler service is an abstraction of angular's compiler, that allows the developer
-   * to easily compile an element with a templateUrl, controller, and locals.
-   *
-   * @usage
-   * <hljs lang="js">
-   * $mdCompiler.compile({
-   *   templateUrl: 'modal.html',
-   *   controller: 'ModalCtrl',
-   *   locals: {
-   *     modal: myModalInstance;
-   *   }
-   * }).then(function(compileData) {
-   *   compileData.element; // modal.html's template in an element
-   *   compileData.link(myScope); //attach controller & scope to element
-   * });
-   * </hljs>
-   */
-
-   /*
-    * @ngdoc method
-    * @name $mdCompiler#compile
-    * @description A helper to compile an HTML template/templateUrl with a given controller,
-    * locals, and scope.
-    * @param {object} options An options object, with the following properties:
-    *
-    *    - `controller` - `{(string=|function()=}` Controller fn that should be associated with
-    *      newly created scope or the name of a registered controller if passed as a string.
-    *    - `controllerAs` - `{string=}` A controller alias name. If present the controller will be
-    *      published to scope under the `controllerAs` name.
-    *    - `template` - `{string=}` An html template as a string.
-    *    - `templateUrl` - `{string=}` A path to an html template.
-    *    - `transformTemplate` - `{function(template)=}` A function which transforms the template after
-    *      it is loaded. It will be given the template string as a parameter, and should
-    *      return a a new string representing the transformed template.
-    *    - `resolve` - `{Object.<string, function>=}` - An optional map of dependencies which should
-    *      be injected into the controller. If any of these dependencies are promises, the compiler
-    *      will wait for them all to be resolved, or if one is rejected before the controller is
-    *      instantiated `compile()` will fail..
-    *      * `key` - `{string}`: a name of a dependency to be injected into the controller.
-    *      * `factory` - `{string|function}`: If `string` then it is an alias for a service.
-    *        Otherwise if function, then it is injected and the return value is treated as the
-    *        dependency. If the result is a promise, it is resolved before its value is
-    *        injected into the controller.
-    *
-    * @returns {object=} promise A promise, which will be resolved with a `compileData` object.
-    * `compileData` has the following properties:
-    *
-    *   - `element` - `{element}`: an uncompiled element matching the provided template.
-    *   - `link` - `{function(scope)}`: A link function, which, when called, will compile
-    *     the element and instantiate the provided controller (if given).
-    *   - `locals` - `{object}`: The locals which will be passed into the controller once `link` is
-    *     called. If `bindToController` is true, they will be coppied to the ctrl instead
-    *   - `bindToController` - `bool`: bind the locals to the controller, instead of passing them in.
-    */
-  this.compile = function(options) {
-    var templateUrl = options.templateUrl;
-    var template = options.template || '';
-    var controller = options.controller;
-    var controllerAs = options.controllerAs;
-    var resolve = angular.extend({}, options.resolve || {});
-    var locals = angular.extend({}, options.locals || {});
-    var transformTemplate = options.transformTemplate || angular.identity;
-    var bindToController = options.bindToController;
-
-    // Take resolve values and invoke them.
-    // Resolves can either be a string (value: 'MyRegisteredAngularConst'),
-    // or an invokable 'factory' of sorts: (value: function ValueGetter($dependency) {})
-    angular.forEach(resolve, function(value, key) {
-      if (angular.isString(value)) {
-        resolve[key] = $injector.get(value);
-      } else {
-        resolve[key] = $injector.invoke(value);
-      }
-    });
-    //Add the locals, which are just straight values to inject
-    //eg locals: { three: 3 }, will inject three into the controller
-    angular.extend(resolve, locals);
-
-    if (templateUrl) {
-      resolve.$template = $templateRequest(templateUrl)
-        .then(function(response) {
-          return response;
-        });
-    } else {
-      resolve.$template = $q.when(template);
-    }
-
-    // Wait for all the resolves to finish if they are promises
-    return $q.all(resolve).then(function(locals) {
-
-      var compiledData;
-      var template = transformTemplate(locals.$template, options);
-      var element = options.element || angular.element('<div>').html(template.trim()).contents();
-      var linkFn = $compile(element);
-
-      // Return a linking function that can be used later when the element is ready
-      return compiledData = {
-        locals: locals,
-        element: element,
-        link: function link(scope) {
-          locals.$scope = scope;
-
-          //Instantiate controller if it exists, because we have scope
-          if (controller) {
-            var invokeCtrl = $controller(controller, locals, true, controllerAs);
-            if (bindToController) {
-              angular.extend(invokeCtrl.instance, locals);
-            }
-            var ctrl = invokeCtrl();
-            //See angular-route source for this logic
-            element.data('$ngControllerController', ctrl);
-            element.children().data('$ngControllerController', ctrl);
-
-            // Publish reference to this controller
-            compiledData.controller = ctrl;
-          }
-          return linkFn(scope);
-        }
-      };
-    });
-
-  };
 }
 
 })();
@@ -43672,8 +44362,6 @@ function MdGesture($$MdGestureHandler, $$rAF, $timeout) {
   var self = {
     handler: addHandler,
     register: register,
-    isIos: isIos,
-    isAndroid: isAndroid,
     // On mobile w/out jQuery, we normally intercept clicks. Should we skip that?
     isHijackingClicks: (isIos || isAndroid) && !hasJQuery && !forceSkipClickHijack
   };
@@ -43843,7 +44531,7 @@ function MdGesture($$MdGestureHandler, $$rAF, $timeout) {
         if (touchActionProperty) {
           // We check for horizontal to be false, because otherwise we would overwrite the default opts.
           this.oldTouchAction = element[0].style[touchActionProperty];
-          element[0].style[touchActionProperty] = options.horizontal === false ? 'pan-y' : 'pan-x';
+          element[0].style[touchActionProperty] = options.horizontal ? 'pan-y' : 'pan-x';
         }
       },
       onCleanup: function(element) {
@@ -44362,7 +45050,7 @@ angular.module('material.core')
  */
 
 function InterimElementProvider() {
-  InterimElementFactory.$inject = ["$document", "$q", "$$q", "$rootScope", "$timeout", "$rootElement", "$animate", "$mdUtil", "$mdCompiler", "$mdTheming", "$injector"];
+  InterimElementFactory.$inject = ["$document", "$q", "$rootScope", "$timeout", "$rootElement", "$animate", "$mdUtil", "$mdCompiler", "$mdTheming", "$injector", "$exceptionHandler"];
   createInterimElementProvider.$get = InterimElementFactory;
   return createInterimElementProvider;
 
@@ -44391,8 +45079,8 @@ function InterimElementProvider() {
      * all interim elements will come with the 'build' preset
      */
     provider.addPreset('build', {
-      methods: ['controller', 'controllerAs', 'resolve',
-        'template', 'templateUrl', 'themable', 'transformTemplate', 'parent']
+      methods: ['controller', 'controllerAs', 'resolve', 'multiple',
+        'template', 'templateUrl', 'themable', 'transformTemplate', 'parent', 'contentElement']
     });
 
     return provider;
@@ -44582,8 +45270,8 @@ function InterimElementProvider() {
   }
 
   /* @ngInject */
-  function InterimElementFactory($document, $q, $$q, $rootScope, $timeout, $rootElement, $animate,
-                                 $mdUtil, $mdCompiler, $mdTheming, $injector ) {
+  function InterimElementFactory($document, $q, $rootScope, $timeout, $rootElement, $animate,
+                                 $mdUtil, $mdCompiler, $mdTheming, $injector, $exceptionHandler) {
     return function createInterimElementService() {
       var SHOW_CANCELLED = false;
 
@@ -44595,15 +45283,20 @@ function InterimElementProvider() {
        * A service used to control inserting and removing an element into the DOM.
        *
        */
-      var service, stack = [];
+
+      var service;
+
+      var showPromises = []; // Promises for the interim's which are currently opening.
+      var hidePromises = []; // Promises for the interim's which are currently hiding.
+      var showingInterims = []; // Interim elements which are currently showing up.
 
       // Publish instance $$interimElement service;
       // ... used as $mdDialog, $mdToast, $mdMenu, and $mdSelect
 
       return service = {
         show: show,
-        hide: hide,
-        cancel: cancel,
+        hide: waitForInterim(hide),
+        cancel: waitForInterim(cancel),
         destroy : destroy,
         $injector_: $injector
       };
@@ -44624,29 +45317,47 @@ function InterimElementProvider() {
       function show(options) {
         options = options || {};
         var interimElement = new InterimElement(options || {});
+
         // When an interim element is currently showing, we have to cancel it.
         // Just hiding it, will resolve the InterimElement's promise, the promise should be
         // rejected instead.
-        var hideExisting = !options.skipHide && stack.length ? service.cancel() : $q.when(true);
+        var hideAction = options.multiple ? $q.resolve() : $q.all(showPromises);
 
-        // This hide()s only the current interim element before showing the next, new one
-        // NOTE: this is not reversible (e.g. interim elements are not stackable)
+        if (!options.multiple) {
+          // Wait for all opening interim's to finish their transition.
+          hideAction = hideAction.then(function() {
+            // Wait for all closing and showing interim's to be completely closed.
+            var promiseArray = hidePromises.concat(showingInterims.map(service.cancel));
+            return $q.all(promiseArray);
+          });
+        }
 
-        hideExisting.finally(function() {
+        var showAction = hideAction.then(function() {
 
-          stack.push(interimElement);
-          interimElement
+          return interimElement
             .show()
-            .catch(function( reason ) {
-              //$log.error("InterimElement.show() error: " + reason );
-              return reason;
+            .catch(function(reason) { return reason; })
+            .finally(function() {
+              showPromises.splice(showPromises.indexOf(showAction), 1);
+              showingInterims.push(interimElement);
             });
 
         });
 
+        showPromises.push(showAction);
+
+        // In Angular 1.6+, exceptions inside promises will cause a rejection. We need to handle
+        // the rejection and only log it if it's an error.
+        interimElement.deferred.promise.catch(function(fault) {
+          if (fault instanceof Error) {
+            $exceptionHandler(fault);
+          }
+
+          return fault;
+        });
+
         // Return a promise that will be resolved when the interim
         // element is hidden or cancelled...
-
         return interimElement.deferred.promise;
       }
 
@@ -44663,27 +45374,30 @@ function InterimElementProvider() {
        *
        */
       function hide(reason, options) {
-        if ( !stack.length ) return $q.when(reason);
         options = options || {};
 
         if (options.closeAll) {
-          var promise = $q.all(stack.reverse().map(closeElement));
-          stack = [];
-          return promise;
+          // We have to make a shallow copy of the array, because otherwise the map will break.
+          return $q.all(showingInterims.slice().reverse().map(closeElement));
         } else if (options.closeTo !== undefined) {
-          return $q.all(stack.splice(options.closeTo).map(closeElement));
-        } else {
-          var interim = stack.pop();
-          return closeElement(interim);
+          return $q.all(showingInterims.slice(options.closeTo).map(closeElement));
         }
 
+        // Hide the latest showing interim element.
+        return closeElement(showingInterims[showingInterims.length - 1]);
+
         function closeElement(interim) {
-          interim
+
+          var hideAction = interim
             .remove(reason, false, options || { })
-            .catch(function( reason ) {
-              //$log.error("InterimElement.hide() error: " + reason );
-              return reason;
+            .catch(function(reason) { return reason; })
+            .finally(function() {
+              hidePromises.splice(hidePromises.indexOf(hideAction), 1);
             });
+
+          showingInterims.splice(showingInterims.indexOf(interim), 1);
+          hidePromises.push(hideAction);
+
           return interim.deferred.promise;
         }
       }
@@ -44701,15 +45415,19 @@ function InterimElementProvider() {
        *
        */
       function cancel(reason, options) {
-        var interim = stack.pop();
-        if ( !interim ) return $q.when(reason);
+        var interim = showingInterims.pop();
+        if (!interim) {
+          return $q.when(reason);
+        }
 
-        interim
-          .remove(reason, true, options || { })
-          .catch(function( reason ) {
-            //$log.error("InterimElement.cancel() error: " + reason );
-            return reason;
+        var cancelAction = interim
+          .remove(reason, true, options || {})
+          .catch(function(reason) { return reason; })
+          .finally(function() {
+            hidePromises.splice(hidePromises.indexOf(cancelAction), 1);
           });
+
+        hidePromises.push(cancelAction);
 
         // Since Angular 1.6.7, promises will be logged to $exceptionHandler when the promise
         // is not handling the rejection. We create a pseudo catch handler, which will prevent the
@@ -44717,30 +45435,56 @@ function InterimElementProvider() {
         return interim.deferred.promise.catch(angular.noop);
       }
 
+      /**
+       * Creates a function to wait for at least one interim element to be available.
+       * @param callbackFn Function to be used as callback
+       * @returns {Function}
+       */
+      function waitForInterim(callbackFn) {
+        return function() {
+          var fnArguments = arguments;
+
+          if (!showingInterims.length) {
+            // When there are still interim's opening, then wait for the first interim element to
+            // finish its open animation.
+            if (showPromises.length) {
+              return showPromises[0].finally(function () {
+                return callbackFn.apply(service, fnArguments);
+              });
+            }
+
+            return $q.when("No interim elements currently showing up.");
+          }
+
+          return callbackFn.apply(service, fnArguments);
+        };
+      }
+
       /*
        * Special method to quick-remove the interim element without animations
        * Note: interim elements are in "interim containers"
        */
-      function destroy(target) {
-        var interim = !target ? stack.shift() : null;
-        var cntr = angular.element(target).length ? angular.element(target)[0].parentNode : null;
+      function destroy(targetEl) {
+        var interim = !targetEl ? showingInterims.shift() : null;
 
-        if (cntr) {
-            // Try to find the interim element in the stack which corresponds to the supplied DOM element.
-            var filtered = stack.filter(function(entry) {
-                  var currNode = entry.options.element[0];
-                  return  (currNode === cntr);
-                });
+        var parentEl = angular.element(targetEl).length && angular.element(targetEl)[0].parentNode;
 
-            // Note: this function might be called when the element already has been removed, in which
-            //       case we won't find any matches. That's ok.
-            if (filtered.length > 0) {
-              interim = filtered[0];
-              stack.splice(stack.indexOf(interim), 1);
-            }
+        if (parentEl) {
+          // Try to find the interim in the stack which corresponds to the supplied DOM element.
+          var filtered = showingInterims.filter(function(entry) {
+            return entry.options.element[0] === parentEl;
+          });
+
+          // Note: This function might be called when the element already has been removed,
+          // in which case we won't find any matches.
+          if (filtered.length) {
+            interim = filtered[0];
+            showingInterims.splice(showingInterims.indexOf(interim), 1);
+          }
         }
 
-        return interim ? interim.remove(SHOW_CANCELLED, false, {'$destroy':true}) : $q.when(SHOW_CANCELLED);
+        return interim ? interim.remove(SHOW_CANCELLED, false, { '$destroy': true }) :
+                         $q.when(SHOW_CANCELLED);
       }
 
       /*
@@ -44774,10 +45518,12 @@ function InterimElementProvider() {
               .then(function( compiledData ) {
                 element = linkElement( compiledData, options );
 
+                // Expose the cleanup function from the compiler.
+                options.cleanupElement = compiledData.cleanup;
+
                 showAction = showElement(element, options, compiledData.controller)
                   .then(resolve, rejectAll);
-
-              }, rejectAll);
+              }).catch(rejectAll);
 
             function rejectAll(fault) {
               // Force the '$md<xxx>.show()' promise to reject
@@ -44811,15 +45557,11 @@ function InterimElementProvider() {
             });
 
           } else {
-
-            $q.when(showAction)
-                .finally(function() {
-                  hideElement(options.element, options).then(function() {
-
-                    (isCancelled && rejectAll(response)) || resolveAll(response);
-
-                  }, rejectAll);
-                });
+            $q.when(showAction).finally(function() {
+              hideElement(options.element, options).then(function() {
+                isCancelled ? rejectAll(response) : resolveAll(response);
+              }, rejectAll);
+            });
 
             return self.deferred.promise;
           }
@@ -44950,14 +45692,14 @@ function InterimElementProvider() {
             autoHideTimer = $timeout(service.hide, options.hideDelay) ;
             cancelAutoHide = function() {
               $timeout.cancel(autoHideTimer);
-            }
+            };
           }
 
           // Cache for subsequent use
           options.cancelAutoHide = function() {
             cancelAutoHide();
             options.cancelAutoHide = undefined;
-          }
+          };
         }
 
         /**
@@ -44970,7 +45712,12 @@ function InterimElementProvider() {
           // Trigger onComplete callback when the `show()` finishes
           var notifyComplete = options.onComplete || angular.noop;
 
-          notifyShowing(options.scope, element, options, controller);
+          // Necessary for consistency between Angular 1.5 and 1.6.
+          try {
+            notifyShowing(options.scope, element, options, controller);
+          } catch (e) {
+            return $q.reject(e);
+          }
 
           return $q(function (resolve, reject) {
             try {
@@ -44981,10 +45728,9 @@ function InterimElementProvider() {
                   startAutoHide();
 
                   resolve(element);
+                }, reject);
 
-                }, reject );
-
-            } catch(e) {
+            } catch (e) {
               reject(e.message);
             }
           });
@@ -44993,35 +45739,34 @@ function InterimElementProvider() {
         function hideElement(element, options) {
           var announceRemoving = options.onRemoving || angular.noop;
 
-          return $$q(function (resolve, reject) {
+          return $q(function (resolve, reject) {
             try {
               // Start transitionIn
-              var action = $$q.when( options.onRemove(options.scope, element, options) || true );
+              var action = $q.when( options.onRemove(options.scope, element, options) || true );
 
               // Trigger callback *before* the remove operation starts
               announceRemoving(element, action);
 
-              if ( options.$destroy == true ) {
-
+              if (options.$destroy) {
                 // For $destroy, onRemove should be synchronous
                 resolve(element);
 
+                if (!options.preserveScope && options.scope ) {
+                  // scope destroy should still be be done after the current digest is done
+                  action.then( function() { options.scope.$destroy(); });
+                }
               } else {
-
                 // Wait until transition-out is done
                 action.then(function () {
-
                   if (!options.preserveScope && options.scope ) {
                     options.scope.$destroy();
                   }
 
                   resolve(element);
-
-                }, reject );
+                }, reject);
               }
-
-            } catch(e) {
-              reject(e);
+            } catch (e) {
+              reject(e.message);
             }
           });
         }
@@ -45032,6 +45777,161 @@ function InterimElementProvider() {
   }
 
 }
+
+})();
+(function(){
+"use strict";
+
+/**
+ * @ngdoc module
+ * @name material.core.interaction
+ * @description
+ * User interaction detection to provide proper accessibility.
+ */
+MdInteractionService.$inject = ["$timeout", "$mdUtil"];
+angular
+  .module('material.core.interaction', [])
+  .service('$mdInteraction', MdInteractionService);
+
+
+/**
+ * @ngdoc service
+ * @name $mdInteraction
+ * @module material.core.interaction
+ *
+ * @description
+ *
+ * Service which keeps track of the last interaction type and validates them for several browsers.
+ * The service hooks into the document's body and listens for touch, mouse and keyboard events.
+ *
+ * The most recent interaction type can be retrieved by calling the `getLastInteractionType` method.
+ *
+ * Here is an example markup for using the interaction service.
+ *
+ * <hljs lang="js">
+ *   var lastType = $mdInteraction.getLastInteractionType();
+ *
+ *   if (lastType === 'keyboard') {
+ *     // We only restore the focus for keyboard users.
+ *     restoreFocus();
+ *   }
+ * </hljs>
+ *
+ */
+function MdInteractionService($timeout, $mdUtil) {
+  this.$timeout = $timeout;
+  this.$mdUtil = $mdUtil;
+
+  this.bodyElement = angular.element(document.body);
+  this.isBuffering = false;
+  this.bufferTimeout = null;
+  this.lastInteractionType = null;
+  this.lastInteractionTime = null;
+
+  // Type Mappings for the different events
+  // There will be three three interaction types
+  // `keyboard`, `mouse` and `touch`
+  // type `pointer` will be evaluated in `pointerMap` for IE Browser events
+  this.inputEventMap = {
+    'keydown': 'keyboard',
+    'mousedown': 'mouse',
+    'mouseenter': 'mouse',
+    'touchstart': 'touch',
+    'pointerdown': 'pointer',
+    'MSPointerDown': 'pointer'
+  };
+
+  // IE PointerDown events will be validated in `touch` or `mouse`
+  // Index numbers referenced here: https://msdn.microsoft.com/library/windows/apps/hh466130.aspx
+  this.iePointerMap = {
+    2: 'touch',
+    3: 'touch',
+    4: 'mouse'
+  };
+
+  this.initializeEvents();
+}
+
+/**
+ * Initializes the interaction service, by registering all interaction events to the
+ * body element.
+ */
+MdInteractionService.prototype.initializeEvents = function() {
+  // IE browsers can also trigger pointer events, which also leads to an interaction.
+  var pointerEvent = 'MSPointerEvent' in window ? 'MSPointerDown' : 'PointerEvent' in window ? 'pointerdown' : null;
+
+  this.bodyElement.on('keydown mousedown', this.onInputEvent.bind(this));
+
+  if ('ontouchstart' in document.documentElement) {
+    this.bodyElement.on('touchstart', this.onBufferInputEvent.bind(this));
+  }
+
+  if (pointerEvent) {
+    this.bodyElement.on(pointerEvent, this.onInputEvent.bind(this));
+  }
+
+};
+
+/**
+ * Event listener for normal interaction events, which should be tracked.
+ * @param event {MouseEvent|KeyboardEvent|PointerEvent|TouchEvent}
+ */
+MdInteractionService.prototype.onInputEvent = function(event) {
+  if (this.isBuffering) {
+    return;
+  }
+
+  var type = this.inputEventMap[event.type];
+
+  if (type === 'pointer') {
+    type = this.iePointerMap[event.pointerType] || event.pointerType;
+  }
+
+  this.lastInteractionType = type;
+  this.lastInteractionTime = this.$mdUtil.now();
+};
+
+/**
+ * Event listener for interaction events which should be buffered (touch events).
+ * @param event {TouchEvent}
+ */
+MdInteractionService.prototype.onBufferInputEvent = function(event) {
+  this.$timeout.cancel(this.bufferTimeout);
+
+  this.onInputEvent(event);
+  this.isBuffering = true;
+
+  // The timeout of 650ms is needed to delay the touchstart, because otherwise the touch will call
+  // the `onInput` function multiple times.
+  this.bufferTimeout = this.$timeout(function() {
+    this.isBuffering = false;
+  }.bind(this), 650, false);
+
+};
+
+/**
+ * @ngdoc method
+ * @name $mdInteraction#getLastInteractionType
+ * @description Retrieves the last interaction type triggered in body.
+ * @returns {string|null} Last interaction type.
+ */
+MdInteractionService.prototype.getLastInteractionType = function() {
+  return this.lastInteractionType;
+};
+
+/**
+ * @ngdoc method
+ * @name $mdInteraction#isUserInvoked
+ * @description Method to detect whether any interaction happened recently or not.
+ * @param {number=} checkDelay Time to check for any interaction to have been triggered.
+ * @returns {boolean} Whether there was any interaction or not.
+ */
+MdInteractionService.prototype.isUserInvoked = function(checkDelay) {
+  var delay = angular.isNumber(checkDelay) ? checkDelay : 15;
+
+  // Check for any interaction to be within the specified check time.
+  return this.lastInteractionTime >= this.$mdUtil.now() - delay;
+};
 
 })();
 (function(){
@@ -45570,6 +46470,100 @@ function InterimElementProvider() {
 "use strict";
 
 /**
+ * @ngdoc module
+ * @name material.core.liveannouncer
+ * @description
+ * Angular Material Live Announcer to provide accessibility for Voice Readers.
+ */
+MdLiveAnnouncer.$inject = ["$timeout"];
+angular
+  .module('material.core')
+  .service('$mdLiveAnnouncer', MdLiveAnnouncer);
+
+/**
+ * @ngdoc service
+ * @name $mdLiveAnnouncer
+ * @module material.core.liveannouncer
+ *
+ * @description
+ *
+ * Service to announce messages to supported screenreaders.
+ *
+ * > The `$mdLiveAnnouncer` service is internally used for components to provide proper accessibility.
+ *
+ * <hljs lang="js">
+ *   module.controller('AppCtrl', function($mdLiveAnnouncer) {
+ *     // Basic announcement (Polite Mode)
+ *     $mdLiveAnnouncer.announce('Hey Google');
+ *
+ *     // Custom announcement (Assertive Mode)
+ *     $mdLiveAnnouncer.announce('Hey Google', 'assertive');
+ *   });
+ * </hljs>
+ *
+ */
+function MdLiveAnnouncer($timeout) {
+  /** @private @const @type {!angular.$timeout} */
+  this._$timeout = $timeout;
+
+  /** @private @const @type {!HTMLElement} */
+  this._liveElement = this._createLiveElement();
+
+  /** @private @const @type {!number} */
+  this._announceTimeout = 100;
+}
+
+/**
+ * @ngdoc method
+ * @name $mdLiveAnnouncer#announce
+ * @description Announces messages to supported screenreaders.
+ * @param {string} message Message to be announced to the screenreader
+ * @param {'off'|'polite'|'assertive'} politeness The politeness of the announcer element.
+ */
+MdLiveAnnouncer.prototype.announce = function(message, politeness) {
+  if (!politeness) {
+    politeness = 'polite';
+  }
+
+  var self = this;
+
+  self._liveElement.textContent = '';
+  self._liveElement.setAttribute('aria-live', politeness);
+
+  // This 100ms timeout is necessary for some browser + screen-reader combinations:
+  // - Both JAWS and NVDA over IE11 will not announce anything without a non-zero timeout.
+  // - With Chrome and IE11 with NVDA or JAWS, a repeated (identical) message won't be read a
+  //   second time without clearing and then using a non-zero delay.
+  // (using JAWS 17 at time of this writing).
+  self._$timeout(function() {
+    self._liveElement.textContent = message;
+  }, self._announceTimeout, false);
+};
+
+/**
+ * Creates a live announcer element, which listens for DOM changes and announces them
+ * to the screenreaders.
+ * @returns {!HTMLElement}
+ * @private
+ */
+MdLiveAnnouncer.prototype._createLiveElement = function() {
+  var liveEl = document.createElement('div');
+
+  liveEl.classList.add('md-visually-hidden');
+  liveEl.setAttribute('role', 'status');
+  liveEl.setAttribute('aria-atomic', 'true');
+  liveEl.setAttribute('aria-live', 'polite');
+
+  document.body.appendChild(liveEl);
+
+  return liveEl;
+};
+
+})();
+(function(){
+"use strict";
+
+/**
  * @ngdoc service
  * @name $$mdMeta
  * @module material.core.meta
@@ -45863,10 +46857,10 @@ angular.module('material.core.meta', [])
         return {
           isMenuItem: element.hasClass('md-menu-item'),
           dimBackground: true
-        }
+        };
       }
-    };
-  };
+    }
+  }
 })();
 
 })();
@@ -45904,8 +46898,8 @@ angular.module('material.core.meta', [])
         dimBackground: false,
         fitRipple: true
       }, options));
-    };
-  };
+    }
+  }
 })();
 
 })();
@@ -45944,8 +46938,8 @@ angular.module('material.core.meta', [])
         outline: false,
         rippleSize: 'full'
       }, options));
-    };
-  };
+    }
+  }
 })();
 
 })();
@@ -46452,8 +47446,8 @@ function attrNoDirective () {
         outline: false,
         rippleSize: 'full'
       }, options));
-    };
-  };
+    }
+  }
 })();
 
 })();
@@ -46833,7 +47827,7 @@ angular.module('material.core.theming.palette', [])
  * Theming
  */
 detectDisabledThemes.$inject = ["$mdThemingProvider"];
-ThemingDirective.$inject = ["$mdTheming", "$interpolate", "$log"];
+ThemingDirective.$inject = ["$mdTheming", "$interpolate", "$parse", "$mdUtil", "$q", "$log"];
 ThemableDirective.$inject = ["$mdTheming"];
 ThemingProvider.$inject = ["$mdColorPalette", "$$mdMetaProvider"];
 generateAllThemes.$inject = ["$injector", "$mdTheming"];
@@ -46867,7 +47861,7 @@ function detectDisabledThemes($mdThemingProvider) {
  * ### Default Theme
  * The `$mdThemingProvider` uses by default the following theme configuration:
  *
- * - Primary Palette: `Primary`
+ * - Primary Palette: `Blue`
  * - Accent Palette: `Pink`
  * - Warn Palette: `Deep-Orange`
  * - Background Palette: `Grey`
@@ -47094,7 +48088,7 @@ var themeConfig = {
  *
  */
 function ThemingProvider($mdColorPalette, $$mdMetaProvider) {
-  ThemingService.$inject = ["$rootScope", "$log"];
+  ThemingService.$inject = ["$rootScope", "$mdUtil", "$q", "$log"];
   PALETTES = { };
   var THEMES = { };
 
@@ -47122,7 +48116,7 @@ function ThemingProvider($mdColorPalette, $$mdMetaProvider) {
     return function () {
       removeChrome();
       removeWindows();
-    }
+    };
   };
 
   /**
@@ -47352,12 +48346,13 @@ function ThemingProvider($mdColorPalette, $$mdMetaProvider) {
   /**
    * @ngdoc service
    * @name $mdTheming
+   * @module material.core.theming
    *
    * @description
    *
-   * Service that makes an element apply theming related classes to itself.
+   * Service that makes an element apply theming related <b>classes</b> to itself.
    *
-   * ```js
+   * <hljs lang="js">
    * app.directive('myFancyDirective', function($mdTheming) {
    *   return {
    *     restrict: 'e',
@@ -47366,11 +48361,78 @@ function ThemingProvider($mdColorPalette, $$mdMetaProvider) {
    *     }
    *   };
    * });
-   * ```
-   * @param {el=} element to apply theming to
+   * </hljs>
+   * @param {element=} element to apply theming to
    */
+
+  /**
+   * @ngdoc property
+   * @name $mdTheming#THEMES
+   * @description
+   * Property to get all the themes defined
+   * @returns {Object} All the themes defined with their properties
+   */
+
+  /**
+   * @ngdoc property
+   * @name $mdTheming#PALETTES
+   * @description
+   * Property to get all the palettes defined
+   * @returns {Object} All the palettes defined with their colors
+   */
+
+  /**
+   * @ngdoc method
+   * @name $mdTheming#registered
+   * @description
+   * Determine is specified theme name is a valid, registered theme
+   * @param {string} themeName the theme to check if registered
+   * @returns {boolean} whether the theme is registered or not
+   */
+
+  /**
+   * @ngdoc method
+   * @name $mdTheming#defaultTheme
+   * @description
+   * Returns the default theme
+   * @returns {string} The default theme
+   */
+
+  /**
+   * @ngdoc method
+   * @name $mdTheming#generateTheme
+   * @description
+   * Lazy generate themes - by default, every theme is generated when defined.
+   * You can disable this in the configuration section using the
+   * `$mdThemingProvider.generateThemesOnDemand(true);`
+   *
+   * The theme name that is passed in must match the name of the theme that was defined as part of the configuration block.
+   *
+   * @param name {string} theme name to generate
+   */
+
+  /**
+   * @ngdoc method
+   * @name $mdTheming#setBrowserColor
+   * @description
+   * Sets browser header coloring
+   * for more info please visit:
+   * https://developers.google.com/web/fundamentals/design-and-ui/browser-customization/theme-color
+   *
+   * The default color is `800` from `primary` palette of the `default` theme
+   *
+   * options are:<br/>
+   * `theme`   - A defined theme via `$mdThemeProvider` to use the palettes from. Default is `default` theme.<br/>
+   * `palette` - Can be any one of the basic material design palettes, extended defined palettes and 'primary',
+   *             'accent', 'background' and 'warn'. Default is `primary`<br/>
+   * `hue`     - The hue from the selected palette. Default is `800`
+   *
+   * @param {Object} options Options object for the browser color
+   * @returns {Function} remove function of the browser color
+   */
+
   /* @ngInject */
-  function ThemingService($rootScope, $log) {
+  function ThemingService($rootScope, $mdUtil, $q, $log) {
         // Allow us to be invoked via a linking function signature.
     var applyTheme = function (scope, el) {
           if (el === undefined) { el = scope; scope = undefined; }
@@ -47378,12 +48440,50 @@ function ThemingProvider($mdColorPalette, $$mdMetaProvider) {
           applyTheme.inherit(el, el);
         };
 
-    applyTheme.THEMES = angular.extend({}, THEMES);
-    applyTheme.PALETTES = angular.extend({}, PALETTES);
+    Object.defineProperty(applyTheme, 'THEMES', {
+      get: function () {
+        return angular.extend({}, THEMES);
+      }
+    });
+    Object.defineProperty(applyTheme, 'PALETTES', {
+      get: function () {
+        return angular.extend({}, PALETTES);
+      }
+    });
+    Object.defineProperty(applyTheme, 'ALWAYS_WATCH', {
+      get: function () {
+        return alwaysWatchTheme;
+      }
+    });
     applyTheme.inherit = inheritTheme;
     applyTheme.registered = registered;
     applyTheme.defaultTheme = function() { return defaultTheme; };
     applyTheme.generateTheme = function(name) { generateTheme(THEMES[name], name, themeConfig.nonce); };
+    applyTheme.defineTheme = function(name, options) {
+      options = options || {};
+
+      var theme = registerTheme(name);
+
+      if (options.primary) {
+        theme.primaryPalette(options.primary);
+      }
+      if (options.accent) {
+        theme.accentPalette(options.accent);
+      }
+      if (options.warn) {
+        theme.warnPalette(options.warn);
+      }
+      if (options.background) {
+        theme.backgroundPalette(options.background);
+      }
+      if (options.dark){
+        theme.dark();
+      }
+
+      this.generateTheme(name);
+
+      return $q.resolve(name);
+    };
     applyTheme.setBrowserColor = enableBrowserColor;
 
     return applyTheme;
@@ -47400,14 +48500,25 @@ function ThemingProvider($mdColorPalette, $$mdMetaProvider) {
      * Get theme name for the element, then update with Theme CSS class
      */
     function inheritTheme (el, parent) {
-      var ctrl = parent.controller('mdTheme');
-      var attrThemeValue = el.attr('md-theme-watch');
-      var watchTheme = (alwaysWatchTheme || angular.isDefined(attrThemeValue)) && attrThemeValue != 'false';
+      var ctrl = parent.controller('mdTheme') || el.data('$mdThemeController');
 
       updateThemeClass(lookupThemeName());
 
-      if ((alwaysWatchTheme && !registerChangeCallback()) || (!alwaysWatchTheme && watchTheme)) {
-        el.on('$destroy', $rootScope.$watch(lookupThemeName, updateThemeClass) );
+      if (ctrl) {
+        var watchTheme = alwaysWatchTheme ||
+                         ctrl.$shouldWatch ||
+                         $mdUtil.parseAttributeBoolean(el.attr('md-theme-watch'));
+
+        var unwatch = ctrl.registerChanges(function (name) {
+          updateThemeClass(name);
+
+          if (!watchTheme) {
+            unwatch();
+          }
+          else {
+            el.on('$destroy', unwatch);
+          }
+        });
       }
 
       /**
@@ -47415,7 +48526,6 @@ function ThemingProvider($mdColorPalette, $$mdMetaProvider) {
        */
       function lookupThemeName() {
         // As a few components (dialog) add their controllers later, we should also watch for a controller init.
-        ctrl = parent.controller('mdTheme') || el.data('$mdThemeController');
         return ctrl && ctrl.$mdTheme || (defaultTheme == 'default' ? '' : defaultTheme);
       }
 
@@ -47438,29 +48548,34 @@ function ThemingProvider($mdColorPalette, $$mdMetaProvider) {
           el.data('$mdThemeController', ctrl);
         }
       }
-
-      /**
-       * Register change callback with parent mdTheme controller
-       */
-      function registerChangeCallback() {
-        var parentController = parent.controller('mdTheme');
-        if (!parentController) return false;
-        el.on('$destroy', parentController.registerChanges( function() {
-          updateThemeClass(lookupThemeName());
-        }));
-        return true;
-      }
     }
 
   }
 }
 
-function ThemingDirective($mdTheming, $interpolate, $log) {
+function ThemingDirective($mdTheming, $interpolate, $parse, $mdUtil, $q, $log) {
   return {
-    priority: 100,
+    priority: 101, // has to be more than 100 to be before interpolation (issue on IE)
     link: {
       pre: function(scope, el, attrs) {
         var registeredCallbacks = [];
+
+        var startSymbol = $interpolate.startSymbol();
+        var endSymbol = $interpolate.endSymbol();
+
+        var theme = attrs.mdTheme.trim();
+
+        var hasInterpolation =
+          theme.substr(0, startSymbol.length) === startSymbol &&
+          theme.lastIndexOf(endSymbol) === theme.length - endSymbol.length;
+
+        var oneTimeOperator = '::';
+        var oneTimeBind = attrs.mdTheme
+            .split(startSymbol).join('')
+            .split(endSymbol).join('')
+            .trim()
+            .substr(0, oneTimeOperator.length) === oneTimeOperator;
+
         var ctrl = {
           registerChanges: function (cb, context) {
             if (context) {
@@ -47481,16 +48596,50 @@ function ThemingDirective($mdTheming, $interpolate, $log) {
             if (!$mdTheming.registered(theme)) {
               $log.warn('attempted to use unregistered theme \'' + theme + '\'');
             }
+
             ctrl.$mdTheme = theme;
 
-            registeredCallbacks.forEach(function (cb) {
-              cb();
-            });
-          }
+            // Iterating backwards to support unregistering during iteration
+            // http://stackoverflow.com/a/9882349/890293
+            // we don't use `reverse()` of array because it mutates the array and we don't want it to get re-indexed
+            for (var i = registeredCallbacks.length; i--;) {
+              registeredCallbacks[i](theme);
+            }
+          },
+          $shouldWatch: $mdUtil.parseAttributeBoolean(el.attr('md-theme-watch')) ||
+                        $mdTheming.ALWAYS_WATCH ||
+                        (hasInterpolation && !oneTimeBind)
         };
+
         el.data('$mdThemeController', ctrl);
-        ctrl.$setTheme($interpolate(attrs.mdTheme)(scope));
-        attrs.$observe('mdTheme', ctrl.$setTheme);
+
+        var getTheme = function () {
+          var interpolation = $interpolate(attrs.mdTheme)(scope);
+          return $parse(interpolation)(scope) || interpolation;
+        };
+
+        var setParsedTheme = function (theme) {
+          if (typeof theme === 'string') {
+            return ctrl.$setTheme(theme);
+          }
+
+          $q.when( angular.isFunction(theme) ?  theme() : theme )
+            .then(function(name){
+              ctrl.$setTheme(name);
+            });
+        };
+
+        setParsedTheme(getTheme());
+
+        var unwatch = scope.$watch(getTheme, function(theme) {
+          if (theme) {
+            setParsedTheme(theme);
+
+            if (!ctrl.$shouldWatch) {
+              unwatch();
+            }
+          }
+        });
       }
     }
   };
@@ -47576,9 +48725,10 @@ function parseRules(theme, colorType, rules) {
     // Don't apply a selector rule to the default theme, making it easier to override
     // styles of the base-component
     if (theme.name == 'default') {
-      var themeRuleRegex = /((?:(?:(?: |>|\.|\w|-|:|\(|\)|\[|\]|"|'|=)+) )?)((?:(?:\w|\.|-)+)?)\.md-default-theme((?: |>|\.|\w|-|:|\(|\)|\[|\]|"|'|=)*)/g;
-      newRule = newRule.replace(themeRuleRegex, function(match, prefix, target, suffix) {
-        return match + ', ' + prefix + target + suffix;
+      var themeRuleRegex = /((?:\s|>|\.|\w|-|:|\(|\)|\[|\]|"|'|=)*)\.md-default-theme((?:\s|>|\.|\w|-|:|\(|\)|\[|\]|"|'|=)*)/g;
+
+      newRule = newRule.replace(themeRuleRegex, function(match, start, end) {
+        return match + ', ' + start + end;
       });
     }
     generatedRules.push(newRule);
@@ -47820,11 +48970,12 @@ function AnimateDomUtils($mdUtil, $q, $timeout, $mdConstant, $animateCss) {
      *
      */
     translate3d : function( target, from, to, options ) {
-      return $animateCss(target,{
-        from:from,
-        to:to,
-        addClass:options.transitionInClass,
-        removeClass:options.transitionOutClass
+      return $animateCss(target, {
+        from: from,
+        to: to,
+        addClass: options.transitionInClass,
+        removeClass: options.transitionOutClass,
+        duration: options.duration
       })
       .start()
       .then(function(){
@@ -47839,7 +48990,8 @@ function AnimateDomUtils($mdUtil, $q, $timeout, $mdConstant, $animateCss) {
         return $animateCss(target, {
            to: newFrom || from,
            addClass: options.transitionOutClass,
-           removeClass: options.transitionInClass
+           removeClass: options.transitionInClass,
+           duration: options.duration
         }).start();
 
       }
@@ -48060,12 +49212,11 @@ function AnimateDomUtils($mdUtil, $q, $timeout, $mdConstant, $animateCss) {
 (function(){
 "use strict";
 
-"use strict";
-
 if (angular.version.minor >= 4) {
   angular.module('material.core.animate', []);
 } else {
 (function() {
+  "use strict";
 
   var forEach = angular.forEach;
 
@@ -48080,7 +49231,7 @@ if (angular.version.minor >= 4) {
   var $$ForceReflowFactory = ['$document', function($document) {
     return function() {
       return $document[0].body.clientWidth + 1;
-    }
+    };
   }];
 
   var $$rAFMutexFactory = ['$$rAF', function($$rAF) {
@@ -48358,7 +49509,7 @@ if (angular.version.minor >= 4) {
               return runner;
             }
           }
-        }
+        };
       }
 
       function applyClasses(element, options) {
@@ -48374,7 +49525,7 @@ if (angular.version.minor >= 4) {
 
       function computeTimings(element) {
         var node = getDomNode(element);
-        var cs = $window.getComputedStyle(node)
+        var cs = $window.getComputedStyle(node);
         var tdr = parseMaxTime(cs[prop('transitionDuration')]);
         var adr = parseMaxTime(cs[prop('animationDuration')]);
         var tdy = parseMaxTime(cs[prop('transitionDelay')]);
@@ -48687,6 +49838,7 @@ function MdBottomSheetDirective($mdBottomSheet) {
  *   of 3.
  *   - `clickOutsideToClose` - `{boolean=}`: Whether the user can click outside the bottom sheet to
  *     close it. Default true.
+ *   - `bindToController` - `{boolean=}`: When set to true, the locals will be bound to the controller instance.
  *   - `disableBackdrop` - `{boolean=}`: When set to true, the bottomsheet will not show a backdrop.
  *   - `escapeToClose` - `{boolean=}`: Whether the user can press escape to close the bottom sheet.
  *     Default true.
@@ -48898,7 +50050,7 @@ function MdBottomSheetProvider($$interimElementProvider) {
  *
  * Button
  */
-MdButtonDirective.$inject = ["$mdButtonInkRipple", "$mdTheming", "$mdAria", "$timeout"];
+MdButtonDirective.$inject = ["$mdButtonInkRipple", "$mdTheming", "$mdAria", "$mdInteraction"];
 MdAnchorDirective.$inject = ["$mdTheming"];
 angular
     .module('material.components.button', [ 'material.core' ])
@@ -49009,7 +50161,7 @@ function MdAnchorDirective($mdTheming) {
  *  </md-button>
  * </hljs>
  */
-function MdButtonDirective($mdButtonInkRipple, $mdTheming, $mdAria, $timeout) {
+function MdButtonDirective($mdButtonInkRipple, $mdTheming, $mdAria, $mdInteraction) {
 
   return {
     restrict: 'EA',
@@ -49057,20 +50209,17 @@ function MdButtonDirective($mdButtonInkRipple, $mdTheming, $mdAria, $timeout) {
     });
 
     if (!element.hasClass('md-no-focus')) {
-      // restrict focus styles to the keyboard
-      scope.mouseActive = false;
-      element.on('mousedown', function() {
-        scope.mouseActive = true;
-        $timeout(function(){
-          scope.mouseActive = false;
-        }, 100);
-      })
-      .on('focus', function() {
-        if (scope.mouseActive === false) {
+
+      element.on('focus', function() {
+
+        // Only show the focus effect when being focused through keyboard interaction or programmatically
+        if (!$mdInteraction.isUserInvoked() || $mdInteraction.getLastInteractionType() === 'keyboard') {
           element.addClass('md-focused');
         }
-      })
-      .on('blur', function(ev) {
+
+      });
+
+      element.on('blur', function() {
         element.removeClass('md-focused');
       });
     }
@@ -49132,8 +50281,8 @@ angular.module('material.components.card', [
  *    - `md-media-sm` - Class for small image
  *    - `md-media-md` - Class for medium image
  *    - `md-media-lg` - Class for large image
+ *    - `md-media-xl` - Class for extra large image
  * * `<md-card-content>` - Card content
- *  - `md-media-xl` - Class for extra large image
  * * `<md-card-actions>` - Card actions
  *  - `<md-card-icon-actions>` - Icon actions
  *
@@ -49222,26 +50371,10 @@ function mdCardDirective($mdTheming) {
 
 /**
  * @ngdoc module
- * @name material.components.chips
- */
-/*
- * @see js folder for chips implementation
- */
-angular.module('material.components.chips', [
-  'material.core',
-  'material.components.autocomplete'
-]);
-
-})();
-(function(){
-"use strict";
-
-/**
- * @ngdoc module
  * @name material.components.checkbox
  * @description Checkbox module!
  */
-MdCheckboxDirective.$inject = ["inputDirective", "$mdAria", "$mdConstant", "$mdTheming", "$mdUtil", "$timeout"];
+MdCheckboxDirective.$inject = ["inputDirective", "$mdAria", "$mdConstant", "$mdTheming", "$mdUtil", "$mdInteraction"];
 angular
   .module('material.components.checkbox', ['material.core'])
   .directive('mdCheckbox', MdCheckboxDirective);
@@ -49293,14 +50426,14 @@ angular
  * </hljs>
  *
  */
-function MdCheckboxDirective(inputDirective, $mdAria, $mdConstant, $mdTheming, $mdUtil, $timeout) {
+function MdCheckboxDirective(inputDirective, $mdAria, $mdConstant, $mdTheming, $mdUtil, $mdInteraction) {
   inputDirective = inputDirective[0];
 
   return {
     restrict: 'E',
     transclude: true,
-    require: '?ngModel',
-    priority: 210, // Run before ngAria
+    require: ['^?mdInputContainer', '?ngModel', '?^form'],
+    priority: $mdConstant.BEFORE_NG_ARIA,
     template:
       '<div class="md-container" md-ink-ripple md-ink-ripple-checkbox>' +
         '<div class="md-icon"></div>' +
@@ -49331,9 +50464,22 @@ function MdCheckboxDirective(inputDirective, $mdAria, $mdConstant, $mdTheming, $
       post: postLink
     };
 
-    function postLink(scope, element, attr, ngModelCtrl) {
+    function postLink(scope, element, attr, ctrls) {
       var isIndeterminate;
-      ngModelCtrl = ngModelCtrl || $mdUtil.fakeNgModel();
+      var containerCtrl = ctrls[0];
+      var ngModelCtrl = ctrls[1] || $mdUtil.fakeNgModel();
+      var formCtrl = ctrls[2];
+
+      if (containerCtrl) {
+        var isErrorGetter = containerCtrl.isErrorGetter || function() {
+          return ngModelCtrl.$invalid && (ngModelCtrl.$touched || (formCtrl && formCtrl.$submitted));
+        };
+
+        containerCtrl.input = element;
+
+        scope.$watch(isErrorGetter, containerCtrl.setInvalid);
+      }
+
       $mdTheming(element);
 
       // Redirect focus events to the root element, because IE11 is always focusing the container element instead
@@ -49369,17 +50515,10 @@ function MdCheckboxDirective(inputDirective, $mdAria, $mdConstant, $mdTheming, $
         0: {}
       }, attr, [ngModelCtrl]);
 
-      scope.mouseActive = false;
       element.on('click', listener)
         .on('keypress', keypressHandler)
-        .on('mousedown', function() {
-          scope.mouseActive = true;
-          $timeout(function() {
-            scope.mouseActive = false;
-          }, 100);
-        })
         .on('focus', function() {
-          if (scope.mouseActive === false) {
+          if ($mdInteraction.getLastInteractionType() === 'keyboard') {
             element.addClass('md-focused');
           }
         })
@@ -49439,6 +50578,22 @@ function MdCheckboxDirective(inputDirective, $mdAria, $mdConstant, $mdTheming, $
     }
   }
 }
+
+})();
+(function(){
+"use strict";
+
+/**
+ * @ngdoc module
+ * @name material.components.chips
+ */
+/*
+ * @see js folder for chips implementation
+ */
+angular.module('material.components.chips', [
+  'material.core',
+  'material.components.autocomplete'
+]);
 
 })();
 (function(){
@@ -50166,8 +51321,30 @@ function MdDialogDirective($$rAF, $mdTheming, $mdDialog) {
  * })(angular);
  * </hljs>
  *
+ * ### Multiple Dialogs
+ * Using the `multiple` option for the `$mdDialog` service allows developers to show multiple dialogs
+ * at the same time.
+ *
+ * <hljs lang="js">
+ *   // From plain options
+ *   $mdDialog.show({
+ *     multiple: true
+ *   });
+ *
+ *   // From a dialog preset
+ *   $mdDialog.show(
+ *     $mdDialog
+ *       .alert()
+ *       .multiple(true)
+ *   );
+ *
+ * </hljs>
+ *
  * ### Pre-Rendered Dialogs
  * By using the `contentElement` option, it is possible to use an already existing element in the DOM.
+ *
+ * > Pre-rendered dialogs will be not linked to any scope and will not instantiate any new controller.<br/>
+ * > You can manually link the elements to a scope or instantiate a controller from the template (`ng-controller`)
  *
  * <hljs lang="js">
  *   $scope.showPrerenderedDialog = function() {
@@ -50524,13 +51701,13 @@ function MdDialogDirective($$rAF, $mdTheming, $mdDialog) {
 function MdDialogProvider($$interimElementProvider) {
   // Elements to capture and redirect focus when the user presses tab at the dialog boundary.
   advancedDialogOptions.$inject = ["$mdDialog", "$mdConstant"];
-  dialogDefaultOptions.$inject = ["$mdDialog", "$mdAria", "$mdUtil", "$mdConstant", "$animate", "$document", "$window", "$rootElement", "$log", "$injector", "$mdTheming"];
+  dialogDefaultOptions.$inject = ["$mdDialog", "$mdAria", "$mdUtil", "$mdConstant", "$animate", "$document", "$window", "$rootElement", "$log", "$injector", "$mdTheming", "$interpolate", "$mdInteraction"];
   var topFocusTrap, bottomFocusTrap;
 
   return $$interimElementProvider('$mdDialog')
     .setDefaults({
       methods: ['disableParentScroll', 'hasBackdrop', 'clickOutsideToClose', 'escapeToClose',
-          'targetEvent', 'closeTo', 'openFrom', 'parent', 'fullscreen', 'contentElement'],
+          'targetEvent', 'closeTo', 'openFrom', 'parent', 'fullscreen', 'multiple'],
       options: dialogDefaultOptions
     })
     .addPreset('alert', {
@@ -50553,7 +51730,7 @@ function MdDialogProvider($$interimElementProvider) {
   function advancedDialogOptions($mdDialog, $mdConstant) {
     return {
       template: [
-        '<md-dialog md-theme="{{ dialog.theme }}" aria-label="{{ dialog.ariaLabel }}" ng-class="dialog.css">',
+        '<md-dialog md-theme="{{ dialog.theme || dialog.defaultTheme }}" aria-label="{{ dialog.ariaLabel }}" ng-class="dialog.css">',
         '  <md-dialog-content class="md-dialog-content" role="document" tabIndex="-1">',
         '    <h2 class="md-title">{{ dialog.title }}</h2>',
         '    <div ng-if="::dialog.mdHtmlContent" class="md-dialog-content-body" ',
@@ -50603,7 +51780,7 @@ function MdDialogProvider($$interimElementProvider) {
 
   /* @ngInject */
   function dialogDefaultOptions($mdDialog, $mdAria, $mdUtil, $mdConstant, $animate, $document, $window, $rootElement,
-                                $log, $injector, $mdTheming) {
+                                $log, $injector, $mdTheming, $interpolate, $mdInteraction) {
 
     return {
       hasBackdrop: true,
@@ -50615,7 +51792,6 @@ function MdDialogProvider($$interimElementProvider) {
       clickOutsideToClose: false,
       escapeToClose: true,
       targetEvent: null,
-      contentElement: null,
       closeTo: null,
       openFrom: null,
       focusOnOpen: true,
@@ -50627,7 +51803,10 @@ function MdDialogProvider($$interimElementProvider) {
         // an element outside of the container, and the focus trap won't work probably..
         // Also the tabindex is needed for the `escapeToClose` functionality, because
         // the keyDown event can't be triggered when the focus is outside of the container.
-        return '<div class="md-dialog-container" tabindex="-1">' + validatedTemplate(template) + '</div>';
+        var startSymbol = $interpolate.startSymbol();
+        var endSymbol = $interpolate.endSymbol();
+        var theme = startSymbol + (options.themeWatch ? '' : '::') + 'theme' + endSymbol;
+        return '<div class="md-dialog-container" tabindex="-1" md-theme="' + theme + '">' + validatedTemplate(template) + '</div>';
 
         /**
          * The specified template should contain a <md-dialog> wrapper element....
@@ -50646,27 +51825,29 @@ function MdDialogProvider($$interimElementProvider) {
       // Automatically apply the theme, if the user didn't specify a theme explicitly.
       // Those option changes need to be done, before the compilation has started, because otherwise
       // the option changes will be not available in the $mdCompilers locales.
-      detectTheming(options);
+      options.defaultTheme = $mdTheming.defaultTheme();
 
-      if (options.contentElement) {
-        options.restoreContentElement = installContentElement(options);
-      }
+      detectTheming(options);
     }
 
     function beforeShow(scope, element, options, controller) {
 
       if (controller) {
-        controller.mdHtmlContent = controller.htmlContent || options.htmlContent || '';
-        controller.mdTextContent = controller.textContent || options.textContent ||
+        var mdHtmlContent = controller.htmlContent || options.htmlContent || '';
+        var mdTextContent = controller.textContent || options.textContent ||
             controller.content || options.content || '';
 
-        if (controller.mdHtmlContent && !$injector.has('$sanitize')) {
+        if (mdHtmlContent && !$injector.has('$sanitize')) {
           throw Error('The ngSanitize module must be loaded in order to use htmlContent.');
         }
 
-        if (controller.mdHtmlContent && controller.mdTextContent) {
+        if (mdHtmlContent && mdTextContent) {
           throw Error('md-dialog cannot have both `htmlContent` and `textContent`');
         }
+
+        // Only assign the content if nothing throws, otherwise it'll still be compiled.
+        controller.mdHtmlContent = mdHtmlContent;
+        controller.mdTextContent = mdTextContent;
       }
     }
 
@@ -50679,7 +51860,7 @@ function MdDialogProvider($$interimElementProvider) {
       // Once a dialog has `ng-cloak` applied on his template the dialog animation will not work properly.
       // This is a very common problem, so we have to notify the developer about this.
       if (dialogElement.hasClass('ng-cloak')) {
-        var message = '$mdDialog: using `<md-dialog ng-cloak >` will affect the dialog opening animations.';
+        var message = '$mdDialog: using `<md-dialog ng-cloak>` will affect the dialog opening animations.';
         $log.warn( message, element[0] );
       }
 
@@ -50721,14 +51902,7 @@ function MdDialogProvider($$interimElementProvider) {
          * If we find no actions at all, log a warning to the console.
          */
         function findCloseButton() {
-          var closeButton = element[0].querySelector('.dialog-close');
-
-          if (!closeButton) {
-            var actionButtons = element[0].querySelectorAll('.md-actions button, md-dialog-actions button');
-            closeButton = actionButtons[actionButtons.length - 1];
-          }
-
-          return closeButton;
+          return element[0].querySelector('.dialog-close, md-dialog-actions button:last-child');
         }
       }
     }
@@ -50767,82 +51941,51 @@ function MdDialogProvider($$interimElementProvider) {
        */
       function detachAndClean() {
         angular.element($document[0].body).removeClass('md-dialog-is-showing');
-        // Only remove the element, if it's not provided through the contentElement option.
-        if (!options.contentElement) {
-          element.remove();
-        } else {
+
+        // Reverse the container stretch if using a content element.
+        if (options.contentElement) {
           options.reverseContainerStretch();
-          options.restoreContentElement();
         }
 
-        if (!options.$destroy) options.origin.focus();
+        // Exposed cleanup function from the $mdCompiler.
+        options.cleanupElement();
+
+        // Restores the focus to the origin element if the last interaction upon opening was a keyboard.
+        if (!options.$destroy && options.originInteraction === 'keyboard') {
+          options.origin.focus();
+        }
       }
     }
 
     function detectTheming(options) {
-      // Only detect the theming, if the developer didn't specify the theme specifically.
-      if (options.theme) return;
-
-      options.theme = $mdTheming.defaultTheme();
-
+      // Once the user specifies a targetEvent, we will automatically try to find the correct
+      // nested theme.
+      var targetEl;
       if (options.targetEvent && options.targetEvent.target) {
-        var targetEl = angular.element(options.targetEvent.target);
-
-        // Once the user specifies a targetEvent, we will automatically try to find the correct
-        // nested theme.
-        options.theme = (targetEl.controller('mdTheme') || {}).$mdTheme || options.theme;
+        targetEl = angular.element(options.targetEvent.target);
       }
 
-    }
+      var themeCtrl = targetEl && targetEl.controller('mdTheme');
 
-    /**
-     * Installs a content element to the current $$interimElement provider options.
-     * @returns {Function} Function to restore the content element at its old DOM location.
-     */
-    function installContentElement(options) {
-      var contentEl = options.contentElement;
-      var restoreFn = null;
+      if (!themeCtrl) {
+        return;
+      }
 
-      if (angular.isString(contentEl)) {
-        contentEl = document.querySelector(contentEl);
-        restoreFn = createRestoreFn(contentEl);
-      } else {
-        contentEl = contentEl[0] || contentEl;
+      options.themeWatch = themeCtrl.$shouldWatch;
 
-        // When the element is visible in the DOM, then we restore it at close of the dialog.
-        // Otherwise it will be removed from the DOM after close.
-        if (document.contains(contentEl)) {
-          restoreFn = createRestoreFn(contentEl);
-        } else {
-          restoreFn = function() {
-            contentEl.parentNode.removeChild(contentEl);
-          }
+      var theme = options.theme || themeCtrl.$mdTheme;
+
+      if (theme) {
+        options.scope.theme = theme;
+      }
+
+      var unwatch = themeCtrl.registerChanges(function (newTheme) {
+        options.scope.theme = newTheme;
+
+        if (!options.themeWatch) {
+          unwatch();
         }
-      }
-
-      // Overwrite the options to use the content element.
-      options.element = angular.element(contentEl);
-      options.skipCompile = true;
-
-      return restoreFn;
-
-      function createRestoreFn(element) {
-        var parent = element.parentNode;
-        var nextSibling = element.nextElementSibling;
-
-        return function() {
-          if (!nextSibling) {
-            // When the element didn't had any sibling, then it can be simply appended to the
-            // parent, because it plays no role, which index it had before.
-            parent.appendChild(element);
-          } else {
-            // When the element had a sibling, which marks the previous position of the element
-            // in the DOM, we insert it correctly before the sibling, to have the same index as
-            // before.
-            parent.insertBefore(element, nextSibling);
-          }
-        }
-      }
+      });
     }
 
     /**
@@ -50862,7 +52005,8 @@ function MdDialogProvider($$interimElementProvider) {
           options.openFrom = getBoundingClientRect(getDomElement(options.openFrom));
 
           if ( options.targetEvent ) {
-            options.origin   = getBoundingClientRect(options.targetEvent.target, options.origin);
+            options.origin = getBoundingClientRect(options.targetEvent.target, options.origin);
+            options.originInteraction = $mdInteraction.getLastInteractionType();
           }
 
 
@@ -51023,7 +52167,7 @@ function MdDialogProvider($$interimElementProvider) {
 
 
         if (options.disableParentScroll) {
-          options.restoreScroll();
+          options.restoreScroll && options.restoreScroll();
           delete options.restoreScroll;
         }
 
@@ -51144,8 +52288,11 @@ function MdDialogProvider($$interimElementProvider) {
         height: container.css('height')
       };
 
+      // If the body is fixed, determine the distance to the viewport in relative from the parent.
+      var parentTop = Math.abs(options.parent[0].getBoundingClientRect().top);
+
       container.css({
-        top: (isFixed ? $mdUtil.scrollTop(options.parent) : 0) + 'px',
+        top: (isFixed ? parentTop : 0) + 'px',
         height: height ? height + 'px' : '100%'
       });
 
@@ -51337,7 +52484,7 @@ function MdDividerDirective($mdTheming) {
           children.wrap('<div class="md-fab-action-item">');
         }
       }
-    }
+    };
   }
 
 })();
@@ -51355,6 +52502,7 @@ function MdDividerDirective($mdTheming) {
 
   function MdFabController($scope, $element, $animate, $mdUtil, $mdConstant, $timeout) {
     var vm = this;
+    var initialAnimationAttempts = 0;
 
     // NOTE: We use async eval(s) below to avoid conflicts with any existing digest loops
 
@@ -51375,12 +52523,23 @@ function MdDividerDirective($mdTheming) {
       $scope.$evalAsync("vm.isOpen = !vm.isOpen");
     };
 
-    setupDefaults();
-    setupListeners();
-    setupWatchers();
+    /*
+     * Angular Lifecycle hook for newer Angular versions.
+     * Bindings are not guaranteed to have been assigned in the controller, but they are in the $onInit hook.
+     */
+    vm.$onInit = function() {
+      setupDefaults();
+      setupListeners();
+      setupWatchers();
 
-    var initialAnimationAttempts = 0;
-    fireInitialAnimations();
+      fireInitialAnimations();
+    };
+
+    // For Angular 1.4 and older, where there are no lifecycle hooks but bindings are pre-assigned,
+    // manually call the $onInit hook.
+    if (angular.version.major === 1 && angular.version.minor <= 4) {
+      this.$onInit();
+    }
 
     function setupDefaults() {
       // Set the default direction to 'down' if none is specified
@@ -51728,16 +52887,16 @@ function MdDividerDirective($mdTheming) {
    * <hljs lang="html">
    * <md-fab-speed-dial md-direction="up" class="md-fling">
    *   <md-fab-trigger>
-   *     <md-button aria-label="Add..."><md-icon icon="/img/icons/plus.svg"></md-icon></md-button>
+   *     <md-button aria-label="Add..."><md-icon md-svg-src="/img/icons/plus.svg"></md-icon></md-button>
    *   </md-fab-trigger>
    *
    *   <md-fab-actions>
    *     <md-button aria-label="Add User">
-   *       <md-icon icon="/img/icons/user.svg"></md-icon>
+   *       <md-icon md-svg-src="/img/icons/user.svg"></md-icon>
    *     </md-button>
    *
    *     <md-button aria-label="Add Group">
-   *       <md-icon icon="/img/icons/group.svg"></md-icon>
+   *       <md-icon md-svg-src="/img/icons/group.svg"></md-icon>
    *     </md-button>
    *   </md-fab-actions>
    * </md-fab-speed-dial>
@@ -51857,7 +53016,7 @@ function MdDividerDirective($mdTheming) {
         runAnimation(element);
         delayDone(done);
       }
-    }
+    };
   }
 
   function MdFabSpeedDialScaleAnimation($timeout) {
@@ -51900,7 +53059,7 @@ function MdDividerDirective($mdTheming) {
         runAnimation(element);
         delayDone(done);
       }
-    }
+    };
   }
 })();
 
@@ -51941,7 +53100,7 @@ function MdDividerDirective($mdTheming) {
    *
    * @description
    *
-   * The `<md-fab-toolbar>` directive is used present a toolbar of elements (usually `<md-button>`s)
+   * The `<md-fab-toolbar>` directive is used to present a toolbar of elements (usually `<md-button>`s)
    * for quick access to common actions when a floating action button is activated (via click or
    * keyboard navigation).
    *
@@ -51960,17 +53119,17 @@ function MdDividerDirective($mdTheming) {
    * <hljs lang="html">
    * <md-fab-toolbar md-direction='left'>
    *   <md-fab-trigger>
-   *     <md-button aria-label="Add..."><md-icon icon="/img/icons/plus.svg"></md-icon></md-button>
+   *     <md-button aria-label="Add..."><md-icon md-svg-src="/img/icons/plus.svg"></md-icon></md-button>
    *   </md-fab-trigger>
    *
    *   <md-toolbar>
    *    <md-fab-actions>
    *      <md-button aria-label="Add User">
-   *        <md-icon icon="/img/icons/user.svg"></md-icon>
+   *        <md-icon md-svg-src="/img/icons/user.svg"></md-icon>
    *      </md-button>
    *
    *      <md-button aria-label="Add Group">
-   *        <md-icon icon="/img/icons/group.svg"></md-icon>
+   *        <md-icon md-svg-src="/img/icons/group.svg"></md-icon>
    *      </md-button>
    *    </md-fab-actions>
    *   </md-toolbar>
@@ -52102,7 +53261,7 @@ function MdDividerDirective($mdTheming) {
         runAnimation(element, className, done);
         done();
       }
-    }
+    };
   }
 })();
 
@@ -52901,10 +54060,10 @@ mdMaxlengthDirective.$inject = ["$animate", "$mdUtil"];
 placeholderDirective.$inject = ["$compile"];
 ngMessageDirective.$inject = ["$mdUtil"];
 mdSelectOnFocusDirective.$inject = ["$timeout"];
-mdInputInvalidMessagesAnimation.$inject = ["$$AnimateRunner", "$animateCss", "$mdUtil"];
-ngMessagesAnimation.$inject = ["$$AnimateRunner", "$animateCss", "$mdUtil"];
-ngMessageAnimation.$inject = ["$$AnimateRunner", "$animateCss", "$mdUtil"];
-angular.module('material.components.input', [
+mdInputInvalidMessagesAnimation.$inject = ["$$AnimateRunner", "$animateCss", "$mdUtil", "$log"];
+ngMessagesAnimation.$inject = ["$$AnimateRunner", "$animateCss", "$mdUtil", "$log"];
+ngMessageAnimation.$inject = ["$$AnimateRunner", "$animateCss", "$mdUtil", "$log"];
+var inputModule = angular.module('material.components.input', [
     'material.core'
   ])
   .directive('mdInputContainer', mdInputContainerDirective)
@@ -52920,12 +54079,26 @@ angular.module('material.components.input', [
 
   .animation('.md-input-invalid', mdInputInvalidMessagesAnimation)
   .animation('.md-input-messages-animation', ngMessagesAnimation)
-  .animation('.md-input-message-animation', ngMessageAnimation)
+  .animation('.md-input-message-animation', ngMessageAnimation);
+
+// If we are running inside of tests; expose some extra services so that we can test them
+if (window._mdMocksIncluded) {
+  inputModule.service('$$mdInput', function() {
+    return {
+      // special accessor to internals... useful for testing
+      messages: {
+        show        : showInputMessages,
+        hide        : hideInputMessages,
+        getElement  : getMessagesElement
+      }
+    }
+  })
 
   // Register a service for each animation so that we can easily inject them into unit tests
   .service('mdInputInvalidAnimation', mdInputInvalidMessagesAnimation)
   .service('mdInputMessagesAnimation', ngMessagesAnimation)
   .service('mdInputMessageAnimation', ngMessageAnimation);
+}
 
 /**
  * @ngdoc directive
@@ -53475,7 +54648,8 @@ function inputTextareaDirective($mdUtil, $window, $mdAria, $timeout, $mdGesture)
 
         function onDrag(ev) {
           if (!isDragging) return;
-          element.css('height', startHeight + (ev.pointer.y - dragStart) - $mdUtil.scrollTop() + 'px');
+
+          element.css('height', (startHeight + ev.pointer.distanceY) + 'px');
         }
 
         function onDragEnd(ev) {
@@ -53539,12 +54713,6 @@ function mdMaxlengthDirective($animate, $mdUtil) {
       // over the maxlength still counts as invalid.
       attr.$set('ngTrim', 'false');
 
-      ngModelCtrl.$formatters.push(renderCharCount);
-      ngModelCtrl.$viewChangeListeners.push(renderCharCount);
-      element.on('input keydown keyup', function() {
-        renderCharCount(); //make sure it's called with no args
-      });
-
       scope.$watch(attr.mdMaxlength, function(value) {
         maxlength = value;
         if (angular.isNumber(value) && value > 0) {
@@ -53561,6 +54729,11 @@ function mdMaxlengthDirective($animate, $mdUtil) {
         if (!angular.isNumber(maxlength) || maxlength < 0) {
           return true;
         }
+
+        // We always update the char count, when the modelValue has changed.
+        // Using the $validators for triggering the update works very well.
+        renderCharCount();
+
         return ( modelValue || element.val() || viewValue || '' ).length <= maxlength;
       };
     });
@@ -53793,10 +54966,10 @@ function ngMessageDirective($mdUtil) {
   }
 }
 
-var $$AnimateRunner, $animateCss, $mdUtil;
+var $$AnimateRunner, $animateCss, $mdUtil, $log;
 
-function mdInputInvalidMessagesAnimation($$AnimateRunner, $animateCss, $mdUtil) {
-  saveSharedServices($$AnimateRunner, $animateCss, $mdUtil);
+function mdInputInvalidMessagesAnimation($$AnimateRunner, $animateCss, $mdUtil, $log) {
+  saveSharedServices($$AnimateRunner, $animateCss, $mdUtil, $log);
 
   return {
     addClass: function(element, className, done) {
@@ -53807,8 +54980,8 @@ function mdInputInvalidMessagesAnimation($$AnimateRunner, $animateCss, $mdUtil) 
   };
 }
 
-function ngMessagesAnimation($$AnimateRunner, $animateCss, $mdUtil) {
-  saveSharedServices($$AnimateRunner, $animateCss, $mdUtil);
+function ngMessagesAnimation($$AnimateRunner, $animateCss, $mdUtil, $log) {
+  saveSharedServices($$AnimateRunner, $animateCss, $mdUtil, $log);
 
   return {
     enter: function(element, done) {
@@ -53834,11 +55007,11 @@ function ngMessagesAnimation($$AnimateRunner, $animateCss, $mdUtil) {
         done();
       }
     }
-  }
+  };
 }
 
-function ngMessageAnimation($$AnimateRunner, $animateCss, $mdUtil) {
-  saveSharedServices($$AnimateRunner, $animateCss, $mdUtil);
+function ngMessageAnimation($$AnimateRunner, $animateCss, $mdUtil, $log) {
+  saveSharedServices($$AnimateRunner, $animateCss, $mdUtil, $log);
 
   return {
     enter: function(element, done) {
@@ -53852,14 +55025,21 @@ function ngMessageAnimation($$AnimateRunner, $animateCss, $mdUtil) {
 
       animator.start().done(done);
     }
-  }
+  };
 }
 
 function showInputMessages(element, done) {
   var animators = [], animator;
   var messages = getMessagesElement(element);
+  var children = messages.children();
 
-  angular.forEach(messages.children(), function(child) {
+  if (messages.length == 0 || children.length == 0) {
+    $log.warn('mdInput messages show animation called on invalid messages element: ', element);
+    done();
+    return;
+  }
+
+  angular.forEach(children, function(child) {
     animator = showMessage(angular.element(child));
 
     animators.push(animator.start());
@@ -53871,8 +55051,15 @@ function showInputMessages(element, done) {
 function hideInputMessages(element, done) {
   var animators = [], animator;
   var messages = getMessagesElement(element);
+  var children = messages.children();
 
-  angular.forEach(messages.children(), function(child) {
+  if (messages.length == 0 || children.length == 0) {
+    $log.warn('mdInput messages hide animation called on invalid messages element: ', element);
+    done();
+    return;
+  }
+
+  angular.forEach(children, function(child) {
     animator = hideMessage(angular.element(child));
 
     animators.push(animator.start());
@@ -53910,7 +55097,7 @@ function hideMessage(element) {
   var styles = window.getComputedStyle(element[0]);
 
   // If we are already hidden, just return an empty animation
-  if (styles.opacity == 0) {
+  if (parseInt(styles.opacity) === 0) {
     return $animateCss(element, {});
   }
 
@@ -53931,6 +55118,11 @@ function getInputElement(element) {
 }
 
 function getMessagesElement(element) {
+  // If we ARE the messages element, just return ourself
+  if (element.hasClass('md-input-messages-animation')) {
+    return element;
+  }
+
   // If we are a ng-message element, we need to traverse up the DOM tree
   if (element.hasClass('md-input-message-animation')) {
     return angular.element($mdUtil.getClosest(element, function(node) {
@@ -53942,10 +55134,11 @@ function getMessagesElement(element) {
   return angular.element(element[0].querySelector('.md-input-messages-animation'));
 }
 
-function saveSharedServices(_$$AnimateRunner_, _$animateCss_, _$mdUtil_) {
+function saveSharedServices(_$$AnimateRunner_, _$animateCss_, _$mdUtil_, _$log_) {
   $$AnimateRunner = _$$AnimateRunner_;
   $animateCss = _$animateCss_;
   $mdUtil = _$mdUtil_;
+  $log = _$log_;
 }
 
 })();
@@ -54073,7 +55266,18 @@ function mdListDirective($mdTheming) {
  * - `md-menu` (Open)
  *
  * This means, when using a supported proxy item inside of `md-list-item`, the list item will
- * become clickable and executes the associated action of the proxy element on click.
+ * automatically become clickable and executes the associated action of the proxy element on click.
+ *
+ * It is possible to disable this behavior by applying the `md-no-proxy` class to the list item.
+ *
+ * <hljs lang="html">
+ *   <md-list-item class="md-no-proxy">
+ *     <span>No Proxy List</span>
+ *     <md-checkbox class="md-secondary"></md-checkbox>
+ *   </md-list-item>
+ * </hljs>
+ *
+ * Here are a few examples of proxy elements inside of a list item.
  *
  * <hljs lang="html">
  *   <md-list-item>
@@ -54138,7 +55342,7 @@ function mdListDirective($mdTheming) {
  *     <span>Alan Turing</span>
  * </hljs>
  *
- * When using `<md-icon>` for an avater, you have to use the `.md-avatar-icon` class.
+ * When using `<md-icon>` for an avatar, you have to use the `.md-avatar-icon` class.
  * <hljs lang="html">
  *   <md-list-item>
  *     <md-icon class="md-avatar-icon" md-svg-icon="avatars:timothy"></md-icon>
@@ -54190,18 +55394,21 @@ function mdListItemDirective($mdAria, $mdConstant, $mdUtil, $timeout) {
 
       if (tAttrs.ngClick || tAttrs.ngDblclick ||  tAttrs.ngHref || tAttrs.href || tAttrs.uiSref || tAttrs.ngAttrUiSref) {
         wrapIn('button');
-      } else {
+      } else if (!tEl.hasClass('md-no-proxy')) {
+
         for (var i = 0, type; type = proxiedTypes[i]; ++i) {
           if (proxyElement = tEl[0].querySelector(type)) {
             hasProxiedElement = true;
             break;
           }
         }
+
         if (hasProxiedElement) {
           wrapIn('div');
-        } else if (!tEl[0].querySelector('md-button:not(.md-secondary):not(.md-exclude)')) {
+        } else {
           tEl.addClass('md-no-proxy');
         }
+
       }
 
       wrapSecondaryItems();
@@ -54238,7 +55445,7 @@ function mdListItemDirective($mdAria, $mdConstant, $mdUtil, $timeout) {
           // When the proxy item is aligned at the end of the list, we have to set the origin to the end.
           xAxisPosition = 'right';
         }
-        
+
         // Set the position mode / origin of the proxied menu.
         if (!menuEl.attr('md-position-mode')) {
           menuEl.attr('md-position-mode', xAxisPosition + ' target');
@@ -54247,7 +55454,7 @@ function mdListItemDirective($mdAria, $mdConstant, $mdUtil, $timeout) {
         // Apply menu open binding to menu button
         var menuOpenButton = menuEl.children().eq(0);
         if (!hasClickEvent(menuOpenButton[0])) {
-          menuOpenButton.attr('ng-click', '$mdOpenMenu($event)');
+          menuOpenButton.attr('ng-click', '$mdMenu.open($event)');
         }
 
         if (!menuOpenButton.attr('aria-label')) {
@@ -54273,9 +55480,13 @@ function mdListItemDirective($mdAria, $mdConstant, $mdUtil, $timeout) {
             '<md-button class="md-no-style"></md-button>'
           );
 
-          buttonWrap[0].setAttribute('aria-label', tEl[0].textContent);
-
           copyAttributes(tEl[0], buttonWrap[0]);
+
+          // If there is no aria-label set on the button (previously copied over if present)
+          // we determine the label from the content and copy it to the button.
+          if (!buttonWrap.attr('aria-label')) {
+            buttonWrap.attr('aria-label', $mdAria.getText(tEl));
+          }
 
           // We allow developers to specify the `md-no-focus` class, to disable the focus style
           // on the button executor. Once more classes should be forwarded, we should probably make the
@@ -54387,12 +55598,13 @@ function mdListItemDirective($mdAria, $mdConstant, $mdUtil, $timeout) {
             firstElement  = $element[0].firstElementChild,
             isButtonWrap  = $element.hasClass('_md-button-wrap'),
             clickChild    = isButtonWrap ? firstElement.firstElementChild : firstElement,
-            hasClick      = clickChild && hasClickEvent(clickChild);
+            hasClick      = clickChild && hasClickEvent(clickChild),
+            noProxies     = $element.hasClass('md-no-proxy');
 
         computeProxies();
         computeClickable();
 
-        if ($element.hasClass('md-proxy-focus') && proxies.length) {
+        if (proxies.length) {
           angular.forEach(proxies, function(proxy) {
             proxy = angular.element(proxy);
 
@@ -54415,7 +55627,8 @@ function mdListItemDirective($mdAria, $mdConstant, $mdUtil, $timeout) {
 
 
         function computeProxies() {
-          if (firstElement && firstElement.children && !hasClick) {
+
+          if (firstElement && firstElement.children && !hasClick && !noProxies) {
 
             angular.forEach(proxiedTypes, function(type) {
 
@@ -54543,7 +55756,7 @@ angular.module('material.components.menu', [
 
 /**
  * @ngdoc module
- * @name material.components.menu-bar
+ * @name material.components.menuBar
  */
 
 angular.module('material.components.menuBar', [
@@ -54558,566 +55771,147 @@ angular.module('material.components.menuBar', [
 
 /**
  * @ngdoc module
- * @name material.components.navBar
+ * @name material.components.panel
  */
-
-
-MdNavBarController.$inject = ["$element", "$scope", "$timeout", "$mdConstant"];
-MdNavItem.$inject = ["$$rAF"];
-MdNavItemController.$inject = ["$element"];
-MdNavBar.$inject = ["$mdAria", "$mdTheming"];
-angular.module('material.components.navBar', ['material.core'])
-    .controller('MdNavBarController', MdNavBarController)
-    .directive('mdNavBar', MdNavBar)
-    .controller('MdNavItemController', MdNavItemController)
-    .directive('mdNavItem', MdNavItem);
+MdPanelService.$inject = ["presets", "$rootElement", "$rootScope", "$injector", "$window"];
+angular
+  .module('material.components.panel', [
+    'material.core',
+    'material.components.backdrop'
+  ])
+  .provider('$mdPanel', MdPanelProvider);
 
 
 /*****************************************************************************
  *                            PUBLIC DOCUMENTATION                           *
  *****************************************************************************/
+
+
 /**
- * @ngdoc directive
- * @name mdNavBar
- * @module material.components.navBar
- *
- * @restrict E
+ * @ngdoc service
+ * @name $mdPanelProvider
+ * @module material.components.panel
  *
  * @description
- * The `<md-nav-bar>` directive renders a list of material tabs that can be used
- * for top-level page navigation. Unlike `<md-tabs>`, it has no concept of a tab
- * body and no bar pagination.
- *
- * Because it deals with page navigation, certain routing concepts are built-in.
- * Route changes via via ng-href, ui-sref, or ng-click events are supported.
- * Alternatively, the user could simply watch currentNavItem for changes.
- *
- * Accessibility functionality is implemented as a site navigator with a
- * listbox, according to
- * https://www.w3.org/TR/wai-aria-practices/#Site_Navigator_Tabbed_Style
- *
- * @param {string=} mdSelectedNavItem The name of the current tab; this must
- * match the name attribute of `<md-nav-item>`
- * @param {string=} navBarAriaLabel An aria-label for the nav-bar
+ * `$mdPanelProvider` allows users to create configuration presets that will be
+ * stored within a cached presets object. When the configuration is needed, the
+ * user can request the preset by passing it as the first parameter in the
+ * `$mdPanel.create` or `$mdPanel.open` methods.
  *
  * @usage
- * <hljs lang="html">
- *  <md-nav-bar md-selected-nav-item="currentNavItem">
- *    <md-nav-item md-nav-click="goto('page1')" name="page1">Page One</md-nav-item>
- *    <md-nav-item md-nav-sref="app.page2" name="page2">Page Two</md-nav-item>
- *    <md-nav-item md-nav-href="#page3" name="page3">Page Three</md-nav-item>
- *  </md-nav-bar>
- *</hljs>
  * <hljs lang="js">
- * (function() {
- *   ‘use strict’;
+ * (function(angular, undefined) {
+ *   'use strict';
  *
- *    $rootScope.$on('$routeChangeSuccess', function(event, current) {
- *      $scope.currentLink = getCurrentLinkFromRoute(current);
- *    });
- * });
+ *   angular
+ *       .module('demoApp', ['ngMaterial'])
+ *       .config(DemoConfig)
+ *       .controller('DemoCtrl', DemoCtrl)
+ *       .controller('DemoMenuCtrl', DemoMenuCtrl);
+ *
+ *   function DemoConfig($mdPanelProvider) {
+ *     $mdPanelProvider.definePreset('demoPreset', {
+ *       attachTo: angular.element(document.body),
+ *       controller: DemoMenuCtrl,
+ *       controllerAs: 'ctrl',
+ *       template: '' +
+ *           '<div class="menu-panel" md-whiteframe="4">' +
+ *           '  <div class="menu-content">' +
+ *           '    <div class="menu-item" ng-repeat="item in ctrl.items">' +
+ *           '      <button class="md-button">' +
+ *           '        <span>{{item}}</span>' +
+ *           '      </button>' +
+ *           '    </div>' +
+ *           '    <md-divider></md-divider>' +
+ *           '    <div class="menu-item">' +
+ *           '      <button class="md-button" ng-click="ctrl.closeMenu()">' +
+ *           '        <span>Close Menu</span>' +
+ *           '      </button>' +
+ *           '    </div>' +
+ *           '  </div>' +
+ *           '</div>',
+ *       panelClass: 'menu-panel-container',
+ *       focusOnOpen: false,
+ *       zIndex: 100,
+ *       propagateContainerEvents: true,
+ *       groupName: 'menus'
+ *     });
+ *   }
+ *
+ *   function PanelProviderCtrl($mdPanel) {
+ *     this.navigation = {
+ *       name: 'navigation',
+ *       items: [
+ *         'Home',
+ *         'About',
+ *         'Contact'
+ *       ]
+ *     };
+ *     this.favorites = {
+ *       name: 'favorites',
+ *       items: [
+ *         'Add to Favorites'
+ *       ]
+ *     };
+ *     this.more = {
+ *       name: 'more',
+ *       items: [
+ *         'Account',
+ *         'Sign Out'
+ *       ]
+ *     };
+ *
+ *     $mdPanel.newPanelGroup('menus', {
+ *       maxOpen: 2
+ *     });
+ *
+ *     this.showMenu = function($event, menu) {
+ *       $mdPanel.open('demoPreset', {
+ *         id: 'menu_' + menu.name,
+ *         position: $mdPanel.newPanelPosition()
+ *             .relativeTo($event.srcElement)
+ *             .addPanelPosition(
+ *               $mdPanel.xPosition.ALIGN_START,
+ *               $mdPanel.yPosition.BELOW
+ *             ),
+ *         locals: {
+ *           items: menu.items
+ *         },
+ *         openFrom: $event
+ *       });
+ *     };
+ *   }
+ *
+ *   function PanelMenuCtrl(mdPanelRef) {
+ *     this.closeMenu = function() {
+ *       mdPanelRef && mdPanelRef.close();
+ *     };
+ *   }
+ * })(angular);
  * </hljs>
  */
 
-/*****************************************************************************
- *                            mdNavItem
- *****************************************************************************/
 /**
- * @ngdoc directive
- * @name mdNavItem
- * @module material.components.navBar
- *
- * @restrict E
- *
+ * @ngdoc method
+ * @name $mdPanelProvider#definePreset
  * @description
- * `<md-nav-item>` describes a page navigation link within the `<md-nav-bar>`
- * component. It renders an md-button as the actual link.
+ * Takes the passed in preset name and preset configuration object and adds it
+ * to the `_presets` object of the provider. This `_presets` object is then
+ * passed along to the `$mdPanel` service.
  *
- * Exactly one of the mdNavClick, mdNavHref, mdNavSref attributes are required to be
- * specified.
- *
- * @param {Function=} mdNavClick Function which will be called when the
- * link is clicked to change the page. Renders as an `ng-click`.
- * @param {string=} mdNavHref url to transition to when this link is clicked.
- * Renders as an `ng-href`.
- * @param {string=} mdNavSref Ui-router state to transition to when this link is
- * clicked. Renders as a `ui-sref`.
- * @param {string=} name The name of this link. Used by the nav bar to know
- * which link is currently selected.
- *
- * @usage
- * See `<md-nav-bar>` for usage.
+ * @param {string} name Preset name.
+ * @param {!Object} preset Specific configuration object that can contain any
+ *     and all of the parameters avaialble within the `$mdPanel.create` method.
+ *     However, parameters that pertain to id, position, animation, and user
+ *     interaction are not allowed and will be removed from the preset
+ *     configuration.
  */
 
 
 /*****************************************************************************
- *                                IMPLEMENTATION                             *
+ *                               MdPanel Service                             *
  *****************************************************************************/
 
-function MdNavBar($mdAria, $mdTheming) {
-  return {
-    restrict: 'E',
-    transclude: true,
-    controller: MdNavBarController,
-    controllerAs: 'ctrl',
-    bindToController: true,
-    scope: {
-      'mdSelectedNavItem': '=?',
-      'navBarAriaLabel': '@?',
-    },
-    template:
-      '<div class="md-nav-bar">' +
-        '<nav role="navigation">' +
-          '<ul class="_md-nav-bar-list" ng-transclude role="listbox"' +
-            'tabindex="0"' +
-            'ng-focus="ctrl.onFocus()"' +
-            'ng-blur="ctrl.onBlur()"' +
-            'ng-keydown="ctrl.onKeydown($event)"' +
-            'aria-label="{{ctrl.navBarAriaLabel}}">' +
-          '</ul>' +
-        '</nav>' +
-        '<md-nav-ink-bar></md-nav-ink-bar>' +
-      '</div>',
-    link: function(scope, element, attrs, ctrl) {
-      $mdTheming(element);
-      if (!ctrl.navBarAriaLabel) {
-        $mdAria.expectAsync(element, 'aria-label', angular.noop);
-      }
-    },
-  };
-}
-
-/**
- * Controller for the nav-bar component.
- *
- * Accessibility functionality is implemented as a site navigator with a
- * listbox, according to
- * https://www.w3.org/TR/wai-aria-practices/#Site_Navigator_Tabbed_Style
- * @param {!angular.JQLite} $element
- * @param {!angular.Scope} $scope
- * @param {!angular.Timeout} $timeout
- * @param {!Object} $mdConstant
- * @constructor
- * @final
- * @ngInject
- */
-function MdNavBarController($element, $scope, $timeout, $mdConstant) {
-  // Injected variables
-  /** @private @const {!angular.Timeout} */
-  this._$timeout = $timeout;
-
-  /** @private @const {!angular.Scope} */
-  this._$scope = $scope;
-
-  /** @private @const {!Object} */
-  this._$mdConstant = $mdConstant;
-
-  // Data-bound variables.
-  /** @type {string} */
-  this.mdSelectedNavItem;
-
-  /** @type {string} */
-  this.navBarAriaLabel;
-
-  // State variables.
-
-  /** @type {?angular.JQLite} */
-  this._navBarEl = $element[0];
-
-  /** @type {?angular.JQLite} */
-  this._inkbar;
-
-  var self = this;
-  // need to wait for transcluded content to be available
-  var deregisterTabWatch = this._$scope.$watch(function() {
-    return self._navBarEl.querySelectorAll('._md-nav-button').length;
-  },
-  function(newLength) {
-    if (newLength > 0) {
-      self._initTabs();
-      deregisterTabWatch();
-    }
-  });
-}
-
-
-
-/**
- * Initializes the tab components once they exist.
- * @private
- */
-MdNavBarController.prototype._initTabs = function() {
-  this._inkbar = angular.element(this._navBarEl.getElementsByTagName('md-nav-ink-bar')[0]);
-
-  var self = this;
-  this._$timeout(function() {
-    self._updateTabs(self.mdSelectedNavItem, undefined);
-  });
-
-  this._$scope.$watch('ctrl.mdSelectedNavItem', function(newValue, oldValue) {
-    // Wait a digest before update tabs for products doing
-    // anything dynamic in the template.
-    self._$timeout(function() {
-      self._updateTabs(newValue, oldValue);
-    });
-  });
-};
-
-/**
- * Set the current tab to be selected.
- * @param {string|undefined} newValue New current tab name.
- * @param {string|undefined} oldValue Previous tab name.
- * @private
- */
-MdNavBarController.prototype._updateTabs = function(newValue, oldValue) {
-  var self = this;
-  var tabs = this._getTabs();
-  var oldIndex = -1;
-  var newIndex = -1;
-  var newTab = this._getTabByName(newValue);
-  var oldTab = this._getTabByName(oldValue);
-
-  if (oldTab) {
-    oldTab.setSelected(false);
-    oldIndex = tabs.indexOf(oldTab);
-  }
-
-  if (newTab) {
-    newTab.setSelected(true);
-    newIndex = tabs.indexOf(newTab);
-  }
-
-  this._$timeout(function() {
-    self._updateInkBarStyles(newTab, newIndex, oldIndex);
-  });
-};
-
-/**
- * Repositions the ink bar to the selected tab.
- * @private
- */
-MdNavBarController.prototype._updateInkBarStyles = function(tab, newIndex, oldIndex) {
-  this._inkbar.toggleClass('_md-left', newIndex < oldIndex)
-      .toggleClass('_md-right', newIndex > oldIndex);
-
-  this._inkbar.css({display: newIndex < 0 ? 'none' : ''});
-
-  if(tab){
-    var tabEl = tab.getButtonEl();
-    var left = tabEl.offsetLeft;
-
-    this._inkbar.css({left: left + 'px', width: tabEl.offsetWidth + 'px'});
-  }
-};
-
-/**
- * Returns an array of the current tabs.
- * @return {!Array<!NavItemController>}
- * @private
- */
-MdNavBarController.prototype._getTabs = function() {
-  var linkArray = Array.prototype.slice.call(
-      this._navBarEl.querySelectorAll('.md-nav-item'));
-  return linkArray.map(function(el) {
-    return angular.element(el).controller('mdNavItem')
-  });
-};
-
-/**
- * Returns the tab with the specified name.
- * @param {string} name The name of the tab, found in its name attribute.
- * @return {!NavItemController|undefined}
- * @private
- */
-MdNavBarController.prototype._getTabByName = function(name) {
-  return this._findTab(function(tab) {
-    return tab.getName() == name;
-  });
-};
-
-/**
- * Returns the selected tab.
- * @return {!NavItemController|undefined}
- * @private
- */
-MdNavBarController.prototype._getSelectedTab = function() {
-  return this._findTab(function(tab) {
-    return tab.isSelected()
-  });
-};
-
-/**
- * Returns the focused tab.
- * @return {!NavItemController|undefined}
- */
-MdNavBarController.prototype.getFocusedTab = function() {
-  return this._findTab(function(tab) {
-    return tab.hasFocus()
-  });
-};
-
-/**
- * Find a tab that matches the specified function.
- * @private
- */
-MdNavBarController.prototype._findTab = function(fn) {
-  var tabs = this._getTabs();
-  for (var i = 0; i < tabs.length; i++) {
-    if (fn(tabs[i])) {
-      return tabs[i];
-    }
-  }
-
-  return null;
-};
-
-/**
- * Direct focus to the selected tab when focus enters the nav bar.
- */
-MdNavBarController.prototype.onFocus = function() {
-  var tab = this._getSelectedTab();
-  if (tab) {
-    tab.setFocused(true);
-  }
-};
-
-/**
- * Clear tab focus when focus leaves the nav bar.
- */
-MdNavBarController.prototype.onBlur = function() {
-  var tab = this.getFocusedTab();
-  if (tab) {
-    tab.setFocused(false);
-  }
-};
-
-/**
- * Move focus from oldTab to newTab.
- * @param {!NavItemController} oldTab
- * @param {!NavItemController} newTab
- * @private
- */
-MdNavBarController.prototype._moveFocus = function(oldTab, newTab) {
-  oldTab.setFocused(false);
-  newTab.setFocused(true);
-};
-
-/**
- * Responds to keypress events.
- * @param {!Event} e
- */
-MdNavBarController.prototype.onKeydown = function(e) {
-  var keyCodes = this._$mdConstant.KEY_CODE;
-  var tabs = this._getTabs();
-  var focusedTab = this.getFocusedTab();
-  if (!focusedTab) return;
-
-  var focusedTabIndex = tabs.indexOf(focusedTab);
-
-  // use arrow keys to navigate between tabs
-  switch (e.keyCode) {
-    case keyCodes.UP_ARROW:
-    case keyCodes.LEFT_ARROW:
-      if (focusedTabIndex > 0) {
-        this._moveFocus(focusedTab, tabs[focusedTabIndex - 1]);
-      }
-      break;
-    case keyCodes.DOWN_ARROW:
-    case keyCodes.RIGHT_ARROW:
-      if (focusedTabIndex < tabs.length - 1) {
-        this._moveFocus(focusedTab, tabs[focusedTabIndex + 1]);
-      }
-      break;
-    case keyCodes.SPACE:
-    case keyCodes.ENTER:
-      // timeout to avoid a "digest already in progress" console error
-      this._$timeout(function() {
-        focusedTab.getButtonEl().click();
-      });
-      break;
-  }
-};
-
-/**
- * @ngInject
- */
-function MdNavItem($$rAF) {
-  return {
-    restrict: 'E',
-    require: ['mdNavItem', '^mdNavBar'],
-    controller: MdNavItemController,
-    bindToController: true,
-    controllerAs: 'ctrl',
-    replace: true,
-    transclude: true,
-    template:
-      '<li class="md-nav-item" role="option" aria-selected="{{ctrl.isSelected()}}">' +
-        '<md-button ng-if="ctrl.mdNavSref" class="_md-nav-button md-accent"' +
-          'ng-class="ctrl.getNgClassMap()"' +
-          'tabindex="-1"' +
-          'ui-sref="{{ctrl.mdNavSref}}">' +
-          '<span ng-transclude class="_md-nav-button-text"></span>' +
-        '</md-button>' +
-        '<md-button ng-if="ctrl.mdNavHref" class="_md-nav-button md-accent"' +
-          'ng-class="ctrl.getNgClassMap()"' +
-          'tabindex="-1"' +
-          'ng-href="{{ctrl.mdNavHref}}">' +
-          '<span ng-transclude class="_md-nav-button-text"></span>' +
-        '</md-button>' +
-        '<md-button ng-if="ctrl.mdNavClick" class="_md-nav-button md-accent"' +
-          'ng-class="ctrl.getNgClassMap()"' +
-          'tabindex="-1"' +
-          'ng-click="ctrl.mdNavClick()">' +
-          '<span ng-transclude class="_md-nav-button-text"></span>' +
-        '</md-button>' +
-      '</li>',
-    scope: {
-      'mdNavClick': '&?',
-      'mdNavHref': '@?',
-      'mdNavSref': '@?',
-      'name': '@',
-    },
-    link: function(scope, element, attrs, controllers) {
-      var mdNavItem = controllers[0];
-      var mdNavBar = controllers[1];
-
-      // When accessing the element's contents synchronously, they
-      // may not be defined yet because of transclusion. There is a higher chance
-      // that it will be accessible if we wait one frame.
-      $$rAF(function() {
-        if (!mdNavItem.name) {
-          mdNavItem.name = angular.element(element[0].querySelector('._md-nav-button-text'))
-            .text().trim();
-        }
-
-        var navButton = angular.element(element[0].querySelector('._md-nav-button'));
-        navButton.on('click', function() {
-          mdNavBar.mdSelectedNavItem = mdNavItem.name;
-          scope.$apply();
-        });
-      });
-    }
-  };
-}
-
-/**
- * Controller for the nav-item component.
- * @param {!angular.JQLite} $element
- * @constructor
- * @final
- * @ngInject
- */
-function MdNavItemController($element) {
-
-  /** @private @const {!angular.JQLite} */
-  this._$element = $element;
-
-  // Data-bound variables
-  /** @const {?Function} */
-  this.mdNavClick;
-  /** @const {?string} */
-  this.mdNavHref;
-  /** @const {?string} */
-  this.name;
-
-  // State variables
-  /** @private {boolean} */
-  this._selected = false;
-
-  /** @private {boolean} */
-  this._focused = false;
-
-  var hasNavClick = !!($element.attr('md-nav-click'));
-  var hasNavHref = !!($element.attr('md-nav-href'));
-  var hasNavSref = !!($element.attr('md-nav-sref'));
-
-  // Cannot specify more than one nav attribute
-  if ((hasNavClick ? 1:0) + (hasNavHref ? 1:0) + (hasNavSref ? 1:0) > 1) {
-    throw Error(
-        'Must specify exactly one of md-nav-click, md-nav-href, ' +
-        'md-nav-sref for nav-item directive');
-  }
-}
-
-/**
- * Returns a map of class names and values for use by ng-class.
- * @return {!Object<string,boolean>}
- */
-MdNavItemController.prototype.getNgClassMap = function() {
-  return {
-    'md-active': this._selected,
-    'md-primary': this._selected,
-    'md-unselected': !this._selected,
-    'md-focused': this._focused,
-  };
-};
-
-/**
- * Get the name attribute of the tab.
- * @return {string}
- */
-MdNavItemController.prototype.getName = function() {
-  return this.name;
-};
-
-/**
- * Get the button element associated with the tab.
- * @return {!Element}
- */
-MdNavItemController.prototype.getButtonEl = function() {
-  return this._$element[0].querySelector('._md-nav-button');
-};
-
-/**
- * Set the selected state of the tab.
- * @param {boolean} isSelected
- */
-MdNavItemController.prototype.setSelected = function(isSelected) {
-  this._selected = isSelected;
-};
-
-/**
- * @return {boolean}
- */
-MdNavItemController.prototype.isSelected = function() {
-  return this._selected;
-};
-
-/**
- * Set the focused state of the tab.
- * @param {boolean} isFocused
- */
-MdNavItemController.prototype.setFocused = function(isFocused) {
-  this._focused = isFocused;
-};
-
-/**
- * @return {boolean}
- */
-MdNavItemController.prototype.hasFocus = function() {
-  return this._focused;
-};
-
-})();
-(function(){
-"use strict";
-
-/**
- * @ngdoc module
- * @name material.components.panel
- */
-MdPanelService.$inject = ["$rootElement", "$rootScope", "$injector", "$window"];
-angular
-    .module('material.components.panel', [
-      'material.core',
-      'material.components.backdrop'
-    ])
-    .service('$mdPanel', MdPanelService);
-
-
-/*****************************************************************************
- *                            PUBLIC DOCUMENTATION                           *
- *****************************************************************************/
 
 /**
  * @ngdoc service
@@ -55131,7 +55925,7 @@ angular
  * @usage
  * <hljs lang="js">
  * (function(angular, undefined) {
- *   ‘use strict’;
+ *   'use strict';
  *
  *   angular
  *       .module('demoApp', ['ngMaterial'])
@@ -55169,11 +55963,9 @@ angular
  *         });
  *   }
  *
- *   function DialogController(MdPanelRef, toppings) {
- *     var toppings;
- *
+ *   function DialogController(MdPanelRef) {
  *     function closeDialog() {
- *       MdPanelRef && MdPanelRef.close();
+ *       if (MdPanelRef) MdPanelRef.close();
  *     }
  *   }
  * })(angular);
@@ -55200,6 +55992,8 @@ angular
  *     [$sce service](https://docs.angularjs.org/api/ng/service/$sce).
  *   - `templateUrl` - `{string=}`: The URL that will be used as the content of
  *     the panel.
+ *   - `contentElement` - `{(string|!angular.JQLite|!Element)=}`: Pre-compiled
+ *     element to be used as the panel's content.
  *   - `controller` - `{(function|string)=}`: The controller to associate with
  *     the panel. The controller can inject a reference to the returned
  *     panelRef, which allows the panel to be closed, hidden, and shown. Any
@@ -55233,6 +56027,12 @@ angular
  *     outside the panel to close it. Defaults to false.
  *   - `escapeToClose` - `{boolean=}`: Whether the user can press escape to
  *     close the panel. Defaults to false.
+ *   - `onCloseSuccess` - `{function(!panelRef, string)=}`: Function that is
+ *     called after the close successfully finishes. The first parameter passed
+ *     into this function is the current panelRef and the 2nd is an optional
+ *     string explaining the close reason. The currently supported closeReasons
+ *     can be found in the MdPanelRef.closeReasons enum. These are by default
+ *     passed along by the panel.
  *   - `trapFocus` - `{boolean=}`: Whether focus should be trapped within the
  *     panel. If `trapFocus` is true, the user will not be able to interact
  *     with the rest of the page until the panel is dismissed. Defaults to
@@ -55262,10 +56062,14 @@ angular
  *     on when the panel closes. This is commonly the element which triggered
  *     the opening of the panel. If you do not use `origin`, you need to control
  *     the focus manually.
+ *   - `groupName` - `{(string|!Array<string>)=}`: A group name or an array of
+ *     group names. The group name is used for creating a group of panels. The
+ *     group is used for configuring the number of open panels and identifying
+ *     specific behaviors for groups. For instance, all tooltips could be
+ *     identified using the same groupName.
  *
  * @returns {!MdPanelRef} panelRef
  */
-
 
 /**
  * @ngdoc method
@@ -55283,7 +56087,6 @@ angular
  *     to an instance of the panel.
  */
 
-
 /**
  * @ngdoc method
  * @name $mdPanel#newPanelPosition
@@ -55294,7 +56097,6 @@ angular
  * @returns {!MdPanelPosition} panelPosition
  */
 
-
 /**
  * @ngdoc method
  * @name $mdPanel#newPanelAnimation
@@ -55303,6 +56105,37 @@ angular
  * the animation config object.
  *
  * @returns {!MdPanelAnimation} panelAnimation
+ */
+
+/**
+ * @ngdoc method
+ * @name $mdPanel#newPanelGroup
+ * @description
+ * Creates a panel group and adds it to a tracked list of panel groups.
+ *
+ * @param {string} groupName Name of the group to create.
+ * @param {!Object=} config Specific configuration object that may contain the
+ *     following properties:
+ *
+ *   - `maxOpen` - `{number=}`: The maximum number of panels that are allowed to
+ *     be open within a defined panel group.
+ *
+ * @returns {!Object<string,
+ *     {panels: !Array<!MdPanelRef>,
+ *     openPanels: !Array<!MdPanelRef>,
+ *     maxOpen: number}>} panelGroup
+ */
+
+/**
+ * @ngdoc method
+ * @name $mdPanel#setGroupMaxOpen
+ * @description
+ * Sets the maximum number of panels in a group that can be opened at a given
+ * time.
+ *
+ * @param {string} groupName The name of the group to configure.
+ * @param {number} maxOpen The maximum number of panels that can be
+ *     opened. Infinity can be passed in to remove the maxOpen limit.
  */
 
 
@@ -55458,6 +56291,74 @@ angular
  * panel.
  *
  * @param {!MdPanelPosition} position
+ */
+
+/**
+ * @ngdoc method
+ * @name MdPanelRef#addToGroup
+ * @description
+ * Adds a panel to a group if the panel does not exist within the group already.
+ * A panel can only exist within a single group.
+ *
+ * @param {string} groupName The name of the group to add the panel to.
+ */
+
+/**
+ * @ngdoc method
+ * @name MdPanelRef#removeFromGroup
+ * @description
+ * Removes a panel from a group if the panel exists within that group. The group
+ * must be created ahead of time.
+ *
+ * @param {string} groupName The name of the group.
+ */
+
+/**
+ * @ngdoc method
+ * @name MdPanelRef#registerInterceptor
+ * @description
+ * Registers an interceptor with the panel. The callback should return a promise,
+ * which will allow the action to continue when it gets resolved, or will
+ * prevent an action if it is rejected. The interceptors are called sequentially
+ * and it reverse order. `type` must be one of the following
+ * values available on `$mdPanel.interceptorTypes`:
+ * * `CLOSE` - Gets called before the panel begins closing.
+ *
+ * @param {string} type Type of interceptor.
+ * @param {!angular.$q.Promise<any>} callback Callback to be registered.
+ * @returns {!MdPanelRef}
+ */
+
+/**
+ * @ngdoc method
+ * @name MdPanelRef#removeInterceptor
+ * @description
+ * Removes a registered interceptor.
+ *
+ * @param {string} type Type of interceptor to be removed.
+ * @param {function(): !angular.$q.Promise<any>} callback Interceptor to be removed.
+ * @returns {!MdPanelRef}
+ */
+
+/**
+ * @ngdoc method
+ * @name MdPanelRef#removeAllInterceptors
+ * @description
+ * Removes all interceptors. If a type is supplied, only the
+ * interceptors of that type will be cleared.
+ *
+ * @param {string=} type Type of interceptors to be removed.
+ * @returns {!MdPanelRef}
+ */
+
+/**
+ * @ngdoc method
+ * @name MdPanelRef#updateAnimation
+ * @description
+ * Updates the animation configuration for a panel. You can use this to change
+ * the panel's animation without having to re-create it.
+ *
+ * @param {!MdPanelAnimation} animation
  */
 
 
@@ -55633,8 +56534,10 @@ angular
  * xPosition must be one of the following values available on
  * $mdPanel.xPosition:
  *
+ *
  * CENTER | ALIGN_START | ALIGN_END | OFFSET_START | OFFSET_END
  *
+ * <pre>
  *    *************
  *    *           *
  *    *   PANEL   *
@@ -55647,12 +56550,14 @@ angular
  * C: CENTER
  * D: ALIGN_END (for LTR displays)
  * E: OFFSET_END (for LTR displays)
+ * </pre>
  *
  * yPosition must be one of the following values available on
  * $mdPanel.yPosition:
  *
  * CENTER | ALIGN_TOPS | ALIGN_BOTTOMS | ABOVE | BELOW
  *
+ * <pre>
  *   F
  *   G *************
  *     *           *
@@ -55666,6 +56571,7 @@ angular
  * H: CENTER
  * I: ALIGN_BOTTOMS
  * J: ABOVE
+ * </pre>
  *
  * @param {string} xPosition
  * @param {string} yPosition
@@ -55699,22 +56605,26 @@ angular
 
 
 /**
- * @ngdoc object
+ * @ngdoc type
  * @name MdPanelAnimation
+ * @module material.components.panel
  * @description
  * Animation configuration object. To use, create an MdPanelAnimation with the
  * desired properties, then pass the object as part of $mdPanel creation.
  *
- * Example:
+ * @usage
  *
+ * <hljs lang="js">
  * var panelAnimation = new MdPanelAnimation()
  *     .openFrom(myButtonEl)
+ *     .duration(1337)
  *     .closeTo('.my-button')
  *     .withAnimation($mdPanel.animation.SCALE);
  *
  * $mdPanel.create({
  *   animation: panelAnimation
  * });
+ * </hljs>
  */
 
 /**
@@ -55763,29 +56673,127 @@ angular
  * @returns {!MdPanelAnimation}
  */
 
+/**
+ * @ngdoc method
+ * @name MdPanelAnimation#duration
+ * @description
+ * Specifies the duration of the animation in milliseconds. The `duration`
+ * method accepts either a number or an object with separate open and close
+ * durations.
+ *
+ * @param {number|{open: number, close: number}} duration
+ * @returns {!MdPanelAnimation}
+ */
+
 
 /*****************************************************************************
- *                                IMPLEMENTATION                             *
+ *                            PUBLIC DOCUMENTATION                           *
  *****************************************************************************/
 
 
-// Default z-index for the panel.
-var defaultZIndex = 80;
+var MD_PANEL_Z_INDEX = 80;
 var MD_PANEL_HIDDEN = '_md-panel-hidden';
-
 var FOCUS_TRAP_TEMPLATE = angular.element(
     '<div class="_md-panel-focus-trap" tabindex="0"></div>');
+
+var _presets = {};
+
+
+/**
+ * A provider that is used for creating presets for the panel API.
+ * @final @constructor @ngInject
+ */
+function MdPanelProvider() {
+  return {
+    'definePreset': definePreset,
+    'getAllPresets': getAllPresets,
+    'clearPresets': clearPresets,
+    '$get': $getProvider()
+  };
+}
+
+
+/**
+ * Takes the passed in panel configuration object and adds it to the `_presets`
+ * object at the specified name.
+ * @param {string} name Name of the preset to set.
+ * @param {!Object} preset Specific configuration object that can contain any
+ *     and all of the parameters avaialble within the `$mdPanel.create` method.
+ *     However, parameters that pertain to id, position, animation, and user
+ *     interaction are not allowed and will be removed from the preset
+ *     configuration.
+ */
+function definePreset(name, preset) {
+  if (!name || !preset) {
+    throw new Error('mdPanelProvider: The panel preset definition is ' +
+        'malformed. The name and preset object are required.');
+  } else if (_presets.hasOwnProperty(name)) {
+    throw new Error('mdPanelProvider: The panel preset you have requested ' +
+        'has already been defined.');
+  }
+
+  // Delete any property on the preset that is not allowed.
+  delete preset.id;
+  delete preset.position;
+  delete preset.animation;
+
+  _presets[name] = preset;
+}
+
+
+/**
+ * Gets a clone of the `_presets`.
+ * @return {!Object}
+ */
+function getAllPresets() {
+  return angular.copy(_presets);
+}
+
+
+/**
+ * Clears all of the stored presets.
+ */
+function clearPresets() {
+  _presets = {};
+}
+
+
+/**
+ * Represents the `$get` method of the Angular provider. From here, a new
+ * reference to the MdPanelService is returned where the needed arguments are
+ * passed in including the MdPanelProvider `_presets`.
+ * @param {!Object} _presets
+ * @param {!angular.JQLite} $rootElement
+ * @param {!angular.Scope} $rootScope
+ * @param {!angular.$injector} $injector
+ * @param {!angular.$window} $window
+ */
+function $getProvider() {
+  return [
+    '$rootElement', '$rootScope', '$injector', '$window',
+    function($rootElement, $rootScope, $injector, $window) {
+      return new MdPanelService(_presets, $rootElement, $rootScope,
+          $injector, $window);
+    }
+  ];
+}
+
+
+/*****************************************************************************
+ *                               MdPanel Service                             *
+ *****************************************************************************/
 
 
 /**
  * A service that is used for controlling/displaying panels on the screen.
+ * @param {!Object} presets
  * @param {!angular.JQLite} $rootElement
  * @param {!angular.Scope} $rootScope
  * @param {!angular.$injector} $injector
  * @param {!angular.$window} $window
  * @final @constructor @ngInject
  */
-function MdPanelService($rootElement, $rootScope, $injector, $window) {
+function MdPanelService(presets, $rootElement, $rootScope, $injector, $window) {
   /**
    * Default config options for the panel.
    * Anything angular related needs to be done later. Therefore
@@ -55805,11 +56813,14 @@ function MdPanelService($rootElement, $rootScope, $injector, $window) {
     propagateContainerEvents: false,
     transformTemplate: angular.bind(this, this._wrapTemplate),
     trapFocus: false,
-    zIndex: defaultZIndex
+    zIndex: MD_PANEL_Z_INDEX
   };
 
   /** @private {!Object} */
   this._config = {};
+
+  /** @private {!Object} */
+  this._presets = presets;
 
   /** @private @const */
   this._$rootElement = $rootElement;
@@ -55823,8 +56834,19 @@ function MdPanelService($rootElement, $rootScope, $injector, $window) {
   /** @private @const */
   this._$window = $window;
 
+  /** @private @const */
+  this._$mdUtil = this._$injector.get('$mdUtil');
+
   /** @private {!Object<string, !MdPanelRef>} */
   this._trackedPanels = {};
+
+  /**
+   * @private {!Object<string,
+   *     {panels: !Array<!MdPanelRef>,
+   *     openPanels: !Array<!MdPanelRef>,
+   *     maxOpen: number}>}
+   */
+  this._groups = Object.create(null);
 
   /**
    * Default animations that can be used within the panel.
@@ -55845,33 +56867,79 @@ function MdPanelService($rootElement, $rootScope, $injector, $window) {
    * @type {enum}
    */
   this.yPosition = MdPanelPosition.yPosition;
+
+  /**
+   * Possible values for the interceptors that can be registered on a panel.
+   * @type {enum}
+   */
+  this.interceptorTypes = MdPanelRef.interceptorTypes;
+
+  /**
+   * Possible values for closing of a panel.
+   * @type {enum}
+   */
+  this.closeReasons = MdPanelRef.closeReasons;
+
+  /**
+   * Possible values of absolute position.
+   * @type {enum}
+   */
+  this.absPosition = MdPanelPosition.absPosition;
 }
 
 
 /**
  * Creates a panel with the specified options.
+ * @param {string=} preset Name of a preset configuration that can be used to
+ *     extend the panel configuration.
  * @param {!Object=} config Configuration object for the panel.
  * @returns {!MdPanelRef}
  */
-MdPanelService.prototype.create = function(config) {
+MdPanelService.prototype.create = function(preset, config) {
+  if (typeof preset === 'string') {
+    preset = this._getPresetByName(preset);
+  } else if (typeof preset === 'object' &&
+      (angular.isUndefined(config) || !config)) {
+    config = preset;
+    preset = {};
+  }
+
+  preset = preset || {};
   config = config || {};
 
   // If the passed-in config contains an ID and the ID is within _trackedPanels,
-  // return the tracked panel.
+  // return the tracked panel after updating its config with the passed-in
+  // config.
   if (angular.isDefined(config.id) && this._trackedPanels[config.id]) {
-    return this._trackedPanels[config.id];
+    var trackedPanel = this._trackedPanels[config.id];
+    angular.extend(trackedPanel.config, config);
+    return trackedPanel;
   }
 
-  // If no ID is set within the passed-in config, then create an arbitrary ID.
-  this._config = {
-    id: config.id || 'panel_' + this._$injector.get('$mdUtil').nextUid(),
+  // Combine the passed-in config, the _defaultConfigOptions, and the preset
+  // configuration into the `_config`.
+  this._config = angular.extend({
+    // If no ID is set within the passed-in config, then create an arbitrary ID.
+    id: config.id || 'panel_' + this._$mdUtil.nextUid(),
     scope: this._$rootScope.$new(true),
     attachTo: this._$rootElement
-  };
-  angular.extend(this._config, this._defaultConfigOptions, config);
+  }, this._defaultConfigOptions, config, preset);
 
+  // Create the panelRef and add it to the `_trackedPanels` object.
   var panelRef = new MdPanelRef(this._config, this._$injector);
   this._trackedPanels[config.id] = panelRef;
+
+  // Add the panel to each of its requested groups.
+  if (this._config.groupName) {
+    if (angular.isString(this._config.groupName)) {
+      this._config.groupName = [this._config.groupName];
+    }
+    angular.forEach(this._config.groupName, function(group) {
+      panelRef.addToGroup(group);
+    });
+  }
+
+  this._config.scope.$on('$destroy', angular.bind(panelRef, panelRef.detach));
 
   return panelRef;
 };
@@ -55879,14 +56947,31 @@ MdPanelService.prototype.create = function(config) {
 
 /**
  * Creates and opens a panel with the specified options.
+ * @param {string=} preset Name of a preset configuration that can be used to
+ *     extend the panel configuration.
  * @param {!Object=} config Configuration object for the panel.
  * @returns {!angular.$q.Promise<!MdPanelRef>} The panel created from create.
  */
-MdPanelService.prototype.open = function(config) {
-  var panelRef = this.create(config);
+MdPanelService.prototype.open = function(preset, config) {
+  var panelRef = this.create(preset, config);
   return panelRef.open().then(function() {
     return panelRef;
   });
+};
+
+
+/**
+ * Gets a specific preset configuration object saved within `_presets`.
+ * @param {string} preset Name of the preset to search for.
+ * @returns {!Object} The preset configuration object.
+ */
+MdPanelService.prototype._getPresetByName = function(preset) {
+  if (!this._presets[preset]) {
+    throw new Error('mdPanel: The panel preset configuration that you ' +
+        'requested does not exist. Use the $mdPanelProvider to create a ' +
+        'preset before requesting one.');
+  }
+  return this._presets[preset];
 };
 
 
@@ -55911,6 +56996,76 @@ MdPanelService.prototype.newPanelAnimation = function() {
 
 
 /**
+ * Creates a panel group and adds it to a tracked list of panel groups.
+ * @param groupName {string} Name of the group to create.
+ * @param config {!Object=} Specific configuration object that may contain the
+ *     following properties:
+ *
+ *   - `maxOpen` - `{number=}`: The maximum number of panels that are allowed
+ *     open within a defined panel group.
+ *
+ * @returns {!Object<string,
+ *     {panels: !Array<!MdPanelRef>,
+ *     openPanels: !Array<!MdPanelRef>,
+ *     maxOpen: number}>} panelGroup
+ */
+MdPanelService.prototype.newPanelGroup = function(groupName, config) {
+  if (!this._groups[groupName]) {
+    config = config || {};
+    var group = {
+      panels: [],
+      openPanels: [],
+      maxOpen: config.maxOpen > 0 ? config.maxOpen : Infinity
+    };
+    this._groups[groupName] = group;
+  }
+  return this._groups[groupName];
+};
+
+
+/**
+ * Sets the maximum number of panels in a group that can be opened at a given
+ * time.
+ * @param {string} groupName The name of the group to configure.
+ * @param {number} maxOpen The maximum number of panels that can be
+ *     opened. Infinity can be passed in to remove the maxOpen limit.
+ */
+MdPanelService.prototype.setGroupMaxOpen = function(groupName, maxOpen) {
+  if (this._groups[groupName]) {
+    this._groups[groupName].maxOpen = maxOpen;
+  } else {
+    throw new Error('mdPanel: Group does not exist yet. Call newPanelGroup().');
+  }
+};
+
+
+/**
+ * Determines if the current number of open panels within a group exceeds the
+ * limit of allowed open panels.
+ * @param {string} groupName The name of the group to check.
+ * @returns {boolean} true if open count does exceed maxOpen and false if not.
+ * @private
+ */
+MdPanelService.prototype._openCountExceedsMaxOpen = function(groupName) {
+  if (this._groups[groupName]) {
+    var group = this._groups[groupName];
+    return group.maxOpen > 0 && group.openPanels.length > group.maxOpen;
+  }
+  return false;
+};
+
+
+/**
+ * Closes the first open panel within a specific group.
+ * @param {string} groupName The name of the group.
+ * @private
+ */
+MdPanelService.prototype._closeFirstOpenedPanel = function(groupName) {
+  this._groups[groupName].openPanels[0].close();
+};
+
+
+/**
  * Wraps the users template in two elements, md-panel-outer-wrapper, which
  * covers the entire attachTo element, and md-panel, which contains only the
  * template. This allows the panel control over positioning, animations,
@@ -55928,6 +57083,24 @@ MdPanelService.prototype._wrapTemplate = function(origTemplate) {
       '<div class="md-panel-outer-wrapper">' +
       '  <div class="md-panel" style="left: -9999px;">' + template + '</div>' +
       '</div>';
+};
+
+
+/**
+ * Wraps a content element in a md-panel-outer wrapper and
+ * positions it off-screen. Allows for proper control over positoning
+ * and animations.
+ * @param {!angular.JQLite} contentElement Element to be wrapped.
+ * @return {!angular.JQLite} Wrapper element.
+ * @private
+ */
+MdPanelService.prototype._wrapContentElement = function(contentElement) {
+  var wrapper = angular.element('<div class="md-panel-outer-wrapper">');
+
+  contentElement.addClass('md-panel').css('left', '-9999px');
+  wrapper.append(contentElement);
+
+  return wrapper;
 };
 
 
@@ -55956,6 +57129,9 @@ function MdPanelRef(config, $injector) {
 
   /** @private @const {!angular.$mdUtil} */
   this._$mdUtil = $injector.get('$mdUtil');
+
+  /** @private @const {!angular.$mdTheming} */
+  this._$mdTheming = $injector.get('$mdTheming');
 
   /** @private @const {!angular.Scope} */
   this._$rootScope = $injector.get('$rootScope');
@@ -56014,7 +57190,35 @@ function MdPanelRef(config, $injector) {
 
   /** @private {Function?} */
   this._restoreScroll = null;
+
+  /**
+   * Keeps track of all the panel interceptors.
+   * @private {!Object}
+   */
+  this._interceptors = Object.create(null);
+
+  /**
+   * Cleanup function, provided by `$mdCompiler` and assigned after the element
+   * has been compiled. When `contentElement` is used, the function is used to
+   * restore the element to it's proper place in the DOM.
+   * @private {!Function}
+   */
+  this._compilerCleanup = null;
+
+  /**
+   * Cache for saving and restoring element inline styles, CSS classes etc.
+   * @type {{styles: string, classes: string}}
+   */
+  this._restoreCache = {
+    styles: '',
+    classes: ''
+  };
 }
+
+
+MdPanelRef.interceptorTypes = {
+  CLOSE: 'onClose'
+};
 
 
 /**
@@ -56028,9 +57232,19 @@ MdPanelRef.prototype.open = function() {
   return this._$q(function(resolve, reject) {
     var done = self._done(resolve, self);
     var show = self._simpleBind(self.show, self);
+    var checkGroupMaxOpen = function() {
+      if (self.config.groupName) {
+        angular.forEach(self.config.groupName, function(group) {
+          if (self._$mdPanel._openCountExceedsMaxOpen(group)) {
+            self._$mdPanel._closeFirstOpenedPanel(group);
+          }
+        });
+      }
+    };
 
     self.attach()
         .then(show)
+        .then(checkGroupMaxOpen)
         .then(done)
         .catch(reject);
   });
@@ -56039,20 +57253,26 @@ MdPanelRef.prototype.open = function() {
 
 /**
  * Closes the panel.
+ * @param {string} closeReason The event type that triggered the close.
  * @returns {!angular.$q.Promise<!MdPanelRef>} A promise that is resolved when
  *     the panel is closed and animations finish.
  */
-MdPanelRef.prototype.close = function() {
+MdPanelRef.prototype.close = function(closeReason) {
   var self = this;
 
   return this._$q(function(resolve, reject) {
-    var done = self._done(resolve, self);
-    var detach = self._simpleBind(self.detach, self);
+    self._callInterceptors(MdPanelRef.interceptorTypes.CLOSE).then(function() {
+      var done = self._done(resolve, self);
+      var detach = self._simpleBind(self.detach, self);
+      var onCloseSuccess = self.config['onCloseSuccess'] || angular.noop;
+      onCloseSuccess = angular.bind(self, onCloseSuccess, self, closeReason);
 
-    self.hide()
-        .then(detach)
-        .then(done)
-        .catch(reject);
+      self.hide()
+          .then(detach)
+          .then(done)
+          .then(onCloseSuccess)
+          .catch(reject);
+    }, reject);
   });
 };
 
@@ -56072,9 +57292,9 @@ MdPanelRef.prototype.attach = function() {
     var done = self._done(resolve, self);
     var onDomAdded = self.config['onDomAdded'] || angular.noop;
     var addListeners = function(response) {
-        self.isAttached = true;
-        self._addEventListeners();
-        return response;
+      self.isAttached = true;
+      self._addEventListeners();
+      return response;
     };
 
     self._$q.all([
@@ -56115,6 +57335,14 @@ MdPanelRef.prototype.detach = function() {
       self._bottomFocusTrap.parentNode.removeChild(self._bottomFocusTrap);
     }
 
+    if (self._restoreCache.classes) {
+      self.panelEl[0].className = self._restoreCache.classes;
+    }
+
+    // Either restore the saved styles or clear the ones set by mdPanel.
+    self.panelEl[0].style.cssText = self._restoreCache.styles || '';
+
+    self._compilerCleanup();
     self.panelContainer.remove();
     self.isAttached = false;
     return self._$q.when(self);
@@ -56142,8 +57370,15 @@ MdPanelRef.prototype.detach = function() {
  * Destroys the panel. The Panel cannot be opened again after this.
  */
 MdPanelRef.prototype.destroy = function() {
+  var self = this;
+  if (this.config.groupName) {
+    angular.forEach(this.config.groupName, function(group) {
+      self.removeFromGroup(group);
+    });
+  }
   this.config.scope.$destroy();
   this.config.locals = null;
+  this._interceptors = null;
 };
 
 
@@ -56155,7 +57390,7 @@ MdPanelRef.prototype.destroy = function() {
 MdPanelRef.prototype.show = function() {
   if (!this.panelContainer) {
     return this._$q(function(resolve, reject) {
-      reject('Panel does not exist yet. Call open() or attach().');
+      reject('mdPanel: Panel does not exist yet. Call open() or attach().');
     });
   }
 
@@ -56172,11 +57407,19 @@ MdPanelRef.prototype.show = function() {
   return this._$q(function(resolve, reject) {
     var done = self._done(resolve, self);
     var onOpenComplete = self.config['onOpenComplete'] || angular.noop;
+    var addToGroupOpen = function() {
+      if (self.config.groupName) {
+        angular.forEach(self.config.groupName, function(group) {
+          self._$mdPanel._groups[group].openPanels.push(self);
+        });
+      }
+    };
 
     self._$q.all([
       self._backdropRef ? self._backdropRef.show() : self,
       animatePromise().then(function() { self._focusOnOpen(); }, reject)
     ]).then(onOpenComplete)
+      .then(addToGroupOpen)
       .then(done)
       .catch(reject);
   });
@@ -56191,7 +57434,7 @@ MdPanelRef.prototype.show = function() {
 MdPanelRef.prototype.hide = function() {
   if (!this.panelContainer) {
     return this._$q(function(resolve, reject) {
-      reject('Panel does not exist yet. Call open() or attach().');
+      reject('mdPanel: Panel does not exist yet. Call open() or attach().');
     });
   }
 
@@ -56204,7 +57447,21 @@ MdPanelRef.prototype.hide = function() {
   return this._$q(function(resolve, reject) {
     var done = self._done(resolve, self);
     var onRemoving = self.config['onRemoving'] || angular.noop;
-
+    var hidePanel = function() {
+      self.panelContainer.addClass(MD_PANEL_HIDDEN);
+    };
+    var removeFromGroupOpen = function() {
+      if (self.config.groupName) {
+        var group, index;
+        angular.forEach(self.config.groupName, function(group) {
+          group = self._$mdPanel._groups[group];
+          index = group.openPanels.indexOf(self);
+          if (index > -1) {
+            group.openPanels.splice(index, 1);
+          }
+        });
+      }
+    };
     var focusOnOrigin = function() {
       var origin = self.config['origin'];
       if (origin) {
@@ -56212,15 +57469,12 @@ MdPanelRef.prototype.hide = function() {
       }
     };
 
-    var hidePanel = function() {
-      self.panelContainer.addClass(MD_PANEL_HIDDEN);
-    };
-
     self._$q.all([
       self._backdropRef ? self._backdropRef.hide() : self,
       self._animateClose()
           .then(onRemoving)
           .then(hidePanel)
+          .then(removeFromGroupOpen)
           .then(focusOnOrigin)
           .catch(reject)
     ]).then(done, reject);
@@ -56241,13 +57495,14 @@ MdPanelRef.prototype.hide = function() {
  */
 MdPanelRef.prototype.addClass = function(newClass, toElement) {
   this._$log.warn(
-      'The addClass method is in the process of being deprecated. ' +
+      'mdPanel: The addClass method is in the process of being deprecated. ' +
       'Full deprecation is scheduled for the Angular Material 1.2 release. ' +
       'To achieve the same results, use the panelContainer or panelEl ' +
       'JQLite elements that are referenced in MdPanelRef.');
 
   if (!this.panelContainer) {
-    throw new Error('Panel does not exist yet. Call open() or attach().');
+    throw new Error(
+        'mdPanel: Panel does not exist yet. Call open() or attach().');
   }
 
   if (!toElement && !this.panelContainer.hasClass(newClass)) {
@@ -56271,13 +57526,14 @@ MdPanelRef.prototype.addClass = function(newClass, toElement) {
  */
 MdPanelRef.prototype.removeClass = function(oldClass, fromElement) {
   this._$log.warn(
-      'The removeClass method is in the process of being deprecated. ' +
+      'mdPanel: The removeClass method is in the process of being deprecated. ' +
       'Full deprecation is scheduled for the Angular Material 1.2 release. ' +
       'To achieve the same results, use the panelContainer or panelEl ' +
       'JQLite elements that are referenced in MdPanelRef.');
 
   if (!this.panelContainer) {
-    throw new Error('Panel does not exist yet. Call open() or attach().');
+    throw new Error(
+        'mdPanel: Panel does not exist yet. Call open() or attach().');
   }
 
   if (!fromElement && this.panelContainer.hasClass(oldClass)) {
@@ -56301,13 +57557,14 @@ MdPanelRef.prototype.removeClass = function(oldClass, fromElement) {
  */
 MdPanelRef.prototype.toggleClass = function(toggleClass, onElement) {
   this._$log.warn(
-      'The toggleClass method is in the process of being deprecated. ' +
+      'mdPanel: The toggleClass method is in the process of being deprecated. ' +
       'Full deprecation is scheduled for the Angular Material 1.2 release. ' +
       'To achieve the same results, use the panelContainer or panelEl ' +
       'JQLite elements that are referenced in MdPanelRef.');
 
   if (!this.panelContainer) {
-    throw new Error('Panel does not exist yet. Call open() or attach().');
+    throw new Error(
+        'mdPanel: Panel does not exist yet. Call open() or attach().');
   }
 
   if (!onElement) {
@@ -56315,6 +57572,51 @@ MdPanelRef.prototype.toggleClass = function(toggleClass, onElement) {
   } else {
     this.panelEl.toggleClass(toggleClass);
   }
+};
+
+
+/**
+ * Compiles the panel, according to the passed in config and appends it to
+ * the DOM. Helps normalize differences in the compilation process between
+ * using a string template and a content element.
+ * @returns {!angular.$q.Promise<!MdPanelRef>} Promise that is resolved when
+ *     the element has been compiled and added to the DOM.
+ * @private
+ */
+MdPanelRef.prototype._compile = function() {
+  var self = this;
+
+  // Compile the element via $mdCompiler. Note that when using a
+  // contentElement, the element isn't actually being compiled, rather the
+  // compiler saves it's place in the DOM and provides a way of restoring it.
+  return self._$mdCompiler.compile(self.config).then(function(compileData) {
+    var config = self.config;
+
+    if (config.contentElement) {
+      var panelEl = compileData.element;
+
+      // Since mdPanel modifies the inline styles and CSS classes, we need
+      // to save them in order to be able to restore on close.
+      self._restoreCache.styles = panelEl[0].style.cssText;
+      self._restoreCache.classes = panelEl[0].className;
+
+      self.panelContainer = self._$mdPanel._wrapContentElement(panelEl);
+      self.panelEl = panelEl;
+    } else {
+      self.panelContainer = compileData.link(config['scope']);
+      self.panelEl = angular.element(
+        self.panelContainer[0].querySelector('.md-panel')
+      );
+    }
+
+    // Save a reference to the cleanup function from the compiler.
+    self._compilerCleanup = compileData.cleanup;
+
+    // Attach the panel to the proper place in the DOM.
+    getElement(self.config['attachTo']).append(self.panelContainer);
+
+    return self;
+  });
 };
 
 
@@ -56333,50 +57635,48 @@ MdPanelRef.prototype._createPanel = function() {
     }
 
     self.config.locals.mdPanelRef = self;
-    self._$mdCompiler.compile(self.config)
-        .then(function(compileData) {
-          self.panelContainer = compileData.link(self.config['scope']);
-          getElement(self.config['attachTo']).append(self.panelContainer);
 
-          if (self.config['disableParentScroll']) {
-            self._restoreScroll = self._$mdUtil.disableScrollAround(
-              null,
-              self.panelContainer,
-              { disableScrollMask: true }
-            );
-          }
+    self._compile().then(function() {
+      if (self.config['disableParentScroll']) {
+        self._restoreScroll = self._$mdUtil.disableScrollAround(
+          null,
+          self.panelContainer,
+          { disableScrollMask: true }
+        );
+      }
 
-          self.panelEl = angular.element(
-              self.panelContainer[0].querySelector('.md-panel'));
+      // Add a custom CSS class to the panel element.
+      if (self.config['panelClass']) {
+        self.panelEl.addClass(self.config['panelClass']);
+      }
 
-          // Add a custom CSS class to the panel element.
-          if (self.config['panelClass']) {
-            self.panelEl.addClass(self.config['panelClass']);
-          }
+      // Handle click and touch events for the panel container.
+      if (self.config['propagateContainerEvents']) {
+        self.panelContainer.css('pointer-events', 'none');
+      }
 
-          // Handle click and touch events for the panel container.
-          if (self.config['propagateContainerEvents']) {
-            self.panelContainer.css('pointer-events', 'none');
-          }
+      // Panel may be outside the $rootElement, tell ngAnimate to animate
+      // regardless.
+      if (self._$animate.pin) {
+        self._$animate.pin(
+          self.panelContainer,
+          getElement(self.config['attachTo'])
+        );
+      }
 
-          // Panel may be outside the $rootElement, tell ngAnimate to animate
-          // regardless.
-          if (self._$animate.pin) {
-            self._$animate.pin(self.panelContainer,
-                getElement(self.config['attachTo']));
-          }
+      self._configureTrapFocus();
+      self._addStyles().then(function() {
+        resolve(self);
+      }, reject);
+    }, reject);
 
-          self._configureTrapFocus();
-          self._addStyles().then(function() {
-            resolve(self);
-          }, reject);
-        }, reject);
   });
 };
 
 
 /**
- * Adds the styles for the panel, such as positioning and z-index.
+ * Adds the styles for the panel, such as positioning and z-index. Also,
+ * themes the panel element and panel container using `$mdTheming`.
  * @returns {!angular.$q.Promise<!MdPanelRef>}
  * @private
  */
@@ -56387,9 +57687,13 @@ MdPanelRef.prototype._addStyles = function() {
     self.panelEl.css('z-index', self.config['zIndex'] + 1);
 
     var hideAndResolve = function() {
+      // Theme the element and container.
+      self._setTheming();
+
       // Remove left: -9999px and add hidden class.
       self.panelEl.css('left', '');
       self.panelContainer.addClass(MD_PANEL_HIDDEN);
+
       resolve(self);
     };
 
@@ -56405,14 +57709,28 @@ MdPanelRef.prototype._addStyles = function() {
       return; // Don't setup positioning.
     }
 
-    // Wait for angular to finish processing the template, then position it
-    // correctly. This is necessary so that the panel will have a defined height
-    // and width.
+    // Wait for angular to finish processing the template
     self._$rootScope['$$postDigest'](function() {
+      // Position it correctly. This is necessary so that the panel will have a
+      // defined height and width.
       self._updatePosition(true);
+
+      // Theme the element and container.
+      self._setTheming();
+
       resolve(self);
     });
   });
+};
+
+
+/**
+ * Sets the `$mdTheming` classes on the `panelContainer` and `panelEl`.
+ * @private
+ */
+MdPanelRef.prototype._setTheming = function() {
+  this._$mdTheming(this.panelEl);
+  this._$mdTheming(this.panelContainer);
 };
 
 
@@ -56422,7 +57740,8 @@ MdPanelRef.prototype._addStyles = function() {
  */
 MdPanelRef.prototype.updatePosition = function(position) {
   if (!this.panelContainer) {
-    throw new Error('Panel does not exist yet. Call open() or attach().');
+    throw new Error(
+        'mdPanel: Panel does not exist yet. Call open() or attach().');
   }
 
   this.config['position'] = position;
@@ -56462,10 +57781,6 @@ MdPanelRef.prototype._updatePosition = function(init) {
       MdPanelPosition.absPosition.RIGHT,
       positionConfig.getRight()
     );
-
-    // Use the vendor prefixed version of transform.
-    var prefixedTransform = this._$mdConstant.CSS.TRANSFORM;
-    this.panelEl.css(prefixedTransform, positionConfig.getTransform());
   }
 };
 
@@ -56504,6 +57819,11 @@ MdPanelRef.prototype._createBackdrop = function() {
             open: '_md-opaque-enter',
             close: '_md-opaque-leave'
           });
+
+      if (this.config.animation) {
+        backdropAnimation.duration(this.config.animation._rawDuration);
+      }
+
       var backdropConfig = {
         animation: backdropAnimation,
         attachTo: this.config.attachTo,
@@ -56511,6 +57831,7 @@ MdPanelRef.prototype._createBackdrop = function() {
         panelClass: '_md-panel-backdrop',
         zIndex: this.config.zIndex - 1
       };
+
       this._backdropRef = this._$mdPanel.create(backdropConfig);
     }
     if (!this._backdropRef.isAttached) {
@@ -56557,7 +57878,7 @@ MdPanelRef.prototype._configureEscapeToClose = function() {
         ev.stopPropagation();
         ev.preventDefault();
 
-        self.close();
+        self.close(MdPanelRef.closeReasons.ESCAPE);
       }
     };
 
@@ -56580,15 +57901,17 @@ MdPanelRef.prototype._configureEscapeToClose = function() {
  */
 MdPanelRef.prototype._configureClickOutsideToClose = function() {
   if (this.config['clickOutsideToClose']) {
-    var target = this.panelContainer;
-    var sourceElem;
+    var target = this.config['propagateContainerEvents'] ?
+        angular.element(document.body) :
+        this.panelContainer;
+    var sourceEl;
 
     // Keep track of the element on which the mouse originally went down
     // so that we can only close the backdrop when the 'click' started on it.
-    // A simple 'click' handler does not work,
-    // it sets the target object as the element the mouse went down on.
+    // A simple 'click' handler does not work, it sets the target object as the
+    // element the mouse went down on.
     var mousedownHandler = function(ev) {
-      sourceElem = ev.target;
+      sourceEl = ev.target;
     };
 
     // We check if our original element and the target is the backdrop
@@ -56596,11 +57919,19 @@ MdPanelRef.prototype._configureClickOutsideToClose = function() {
     // panel we don't want to panel to close.
     var self = this;
     var mouseupHandler = function(ev) {
-      if (sourceElem === target[0] && ev.target === target[0]) {
+      if (self.config['propagateContainerEvents']) {
+
+        // We check if the sourceEl of the event is the panel element or one
+        // of it's children. If it is not, then close the panel.
+        if (sourceEl !== self.panelEl[0] && !self.panelEl[0].contains(sourceEl)) {
+          self.close();
+        }
+
+      } else if (sourceEl === target[0] && ev.target === target[0]) {
         ev.stopPropagation();
         ev.preventDefault();
 
-        self.close();
+        self.close(MdPanelRef.closeReasons.CLICK_OUTSIDE);
       }
     };
 
@@ -56622,23 +57953,24 @@ MdPanelRef.prototype._configureClickOutsideToClose = function() {
  * @private
 */
 MdPanelRef.prototype._configureScrollListener = function() {
-  var updatePosition = angular.bind(this, this._updatePosition);
-  var debouncedUpdatePosition = this._$$rAF.throttle(updatePosition);
-  var self = this;
+  // No need to bind the event if scrolling is disabled.
+  if (!this.config['disableParentScroll']) {
+    var updatePosition = angular.bind(this, this._updatePosition);
+    var debouncedUpdatePosition = this._$$rAF.throttle(updatePosition);
+    var self = this;
 
-  var onScroll = function() {
-    if (!self.config['disableParentScroll']) {
+    var onScroll = function() {
       debouncedUpdatePosition();
-    }
-  };
+    };
 
-  // Add listeners.
-  this._$window.addEventListener('scroll', onScroll, true);
+    // Add listeners.
+    this._$window.addEventListener('scroll', onScroll, true);
 
-  // Queue remove listeners function.
-  this._removeListeners.push(function() {
-    self._$window.removeEventListener('scroll', onScroll, true);
-  });
+    // Queue remove listeners function.
+    this._removeListeners.push(function() {
+      self._$window.removeEventListener('scroll', onScroll, true);
+    });
+  }
 };
 
 
@@ -56648,7 +57980,7 @@ MdPanelRef.prototype._configureScrollListener = function() {
  * @private
  */
 MdPanelRef.prototype._configureTrapFocus = function() {
-  // Focus doesn't remain instead of the panel without this.
+  // Focus doesn't remain inside of the panel without this.
   this.panelEl.attr('tabIndex', '-1');
   if (this.config['trapFocus']) {
     var element = this.panelEl;
@@ -56681,6 +58013,19 @@ MdPanelRef.prototype._configureTrapFocus = function() {
 
 
 /**
+ * Updates the animation of a panel.
+ * @param {!MdPanelAnimation} animation
+ */
+MdPanelRef.prototype.updateAnimation = function(animation) {
+  this.config['animation'] = animation;
+
+  if (this._backdropRef) {
+    this._backdropRef.config.animation.duration(animation._rawDuration);
+  }
+};
+
+
+/**
  * Animate the panel opening.
  * @returns {!angular.$q.Promise} A promise that is resolved when the panel has
  *     animated open.
@@ -56700,7 +58045,8 @@ MdPanelRef.prototype._animateOpen = function() {
     var done = self._done(resolve, self);
     var warnAndOpen = function() {
       self._$log.warn(
-          'MdPanel Animations failed. Showing panel without animating.');
+          'mdPanel: MdPanel Animations failed. ' +
+          'Showing panel without animating.');
       done();
     };
 
@@ -56732,13 +58078,116 @@ MdPanelRef.prototype._animateClose = function() {
     };
     var warnAndClose = function() {
       self._$log.warn(
-          'MdPanel Animations failed. Hiding panel without animating.');
+          'mdPanel: MdPanel Animations failed. ' +
+          'Hiding panel without animating.');
       done();
     };
 
     animationConfig.animateClose(self.panelEl)
         .then(done, warnAndClose);
   });
+};
+
+
+/**
+ * Registers a interceptor with the panel. The callback should return a promise,
+ * which will allow the action to continue when it gets resolved, or will
+ * prevent an action if it is rejected.
+ * @param {string} type Type of interceptor.
+ * @param {!angular.$q.Promise<!any>} callback Callback to be registered.
+ * @returns {!MdPanelRef}
+ */
+MdPanelRef.prototype.registerInterceptor = function(type, callback) {
+  var error = null;
+
+  if (!angular.isString(type)) {
+    error = 'Interceptor type must be a string, instead got ' + typeof type;
+  } else if (!angular.isFunction(callback)) {
+    error = 'Interceptor callback must be a function, instead got ' + typeof callback;
+  }
+
+  if (error) {
+    throw new Error('MdPanel: ' + error);
+  }
+
+  var interceptors = this._interceptors[type] = this._interceptors[type] || [];
+
+  if (interceptors.indexOf(callback) === -1) {
+    interceptors.push(callback);
+  }
+
+  return this;
+};
+
+
+/**
+ * Removes a registered interceptor.
+ * @param {string} type Type of interceptor to be removed.
+ * @param {Function} callback Interceptor to be removed.
+ * @returns {!MdPanelRef}
+ */
+MdPanelRef.prototype.removeInterceptor = function(type, callback) {
+  var index = this._interceptors[type] ?
+    this._interceptors[type].indexOf(callback) : -1;
+
+  if (index > -1) {
+    this._interceptors[type].splice(index, 1);
+  }
+
+  return this;
+};
+
+
+/**
+ * Removes all interceptors.
+ * @param {string=} type Type of interceptors to be removed.
+ *     If ommited, all interceptors types will be removed.
+ * @returns {!MdPanelRef}
+ */
+MdPanelRef.prototype.removeAllInterceptors = function(type) {
+  if (type) {
+    this._interceptors[type] = [];
+  } else {
+    this._interceptors = Object.create(null);
+  }
+
+  return this;
+};
+
+
+/**
+ * Invokes all the interceptors of a certain type sequantially in
+ *     reverse order. Works in a similar way to `$q.all`, except it
+ *     respects the order of the functions.
+ * @param {string} type Type of interceptors to be invoked.
+ * @returns {!angular.$q.Promise<!MdPanelRef>}
+ * @private
+ */
+MdPanelRef.prototype._callInterceptors = function(type) {
+  var self = this;
+  var $q = self._$q;
+  var interceptors = self._interceptors && self._interceptors[type] || [];
+
+  return interceptors.reduceRight(function(promise, interceptor) {
+    var isPromiseLike = interceptor && angular.isFunction(interceptor.then);
+    var response = isPromiseLike ? interceptor : null;
+
+    /**
+    * For interceptors to reject/cancel subsequent portions of the chain, simply
+    * return a `$q.reject(<value>)`
+    */
+    return promise.then(function() {
+      if (!response) {
+        try {
+          response = interceptor(self);
+        } catch(e) {
+          response = $q.reject(e);
+        }
+      }
+
+     return response;
+    });
+  }, $q.resolve(self));
 };
 
 
@@ -56765,6 +58214,54 @@ MdPanelRef.prototype._done = function(callback, self) {
   return function() {
     callback(self);
   };
+};
+
+
+/**
+ * Adds a panel to a group if the panel does not exist within the group already.
+ * A panel can only exist within a single group.
+ * @param {string} groupName The name of the group.
+ */
+MdPanelRef.prototype.addToGroup = function(groupName) {
+  if (!this._$mdPanel._groups[groupName]) {
+    this._$mdPanel.newPanelGroup(groupName);
+  }
+
+  var group = this._$mdPanel._groups[groupName];
+  var index = group.panels.indexOf(this);
+
+  if (index < 0) {
+    group.panels.push(this);
+  }
+};
+
+
+/**
+ * Removes a panel from a group if the panel exists within that group. The group
+ * must be created ahead of time.
+ * @param {string} groupName The name of the group.
+ */
+MdPanelRef.prototype.removeFromGroup = function(groupName) {
+  if (!this._$mdPanel._groups[groupName]) {
+    throw new Error('mdPanel: The group ' + groupName + ' does not exist.');
+  }
+
+  var group = this._$mdPanel._groups[groupName];
+  var index = group.panels.indexOf(this);
+
+  if (index > -1) {
+    group.panels.splice(index, 1);
+  }
+};
+
+
+/**
+ * Possible default closeReasons for the close function.
+ * @enum {string}
+ */
+MdPanelRef.closeReasons = {
+  CLICK_OUTSIDE: 'clickOutsideToClose',
+  ESCAPE: 'escapeToClose',
 };
 
 
@@ -56799,6 +58296,9 @@ function MdPanelPosition($injector) {
 
   /** @private {boolean} */
   this._isRTL = $injector.get('$mdUtil').bidi() === 'rtl';
+
+  /** @private @const {!angular.$mdConstant} */
+  this._$mdConstant = $injector.get('$mdConstant');
 
   /** @private {boolean} */
   this._absolute = false;
@@ -56869,6 +58369,12 @@ MdPanelPosition.absPosition = {
   LEFT: 'left'
 };
 
+/**
+ * Margin between the edges of a panel and the viewport.
+ * @const {number}
+ */
+MdPanelPosition.viewportMargin = 8;
+
 
 /**
  * Sets absolute positioning for the panel.
@@ -56878,6 +58384,7 @@ MdPanelPosition.prototype.absolute = function() {
   this._absolute = true;
   return this;
 };
+
 
 /**
  * Sets the value of a position for the panel. Clears any previously set
@@ -56899,7 +58406,7 @@ MdPanelPosition.prototype._setPosition = function(position, value) {
     var positions = Object.keys(MdPanelPosition.absPosition).join()
         .toLowerCase();
 
-    throw new Error('Position must be one of ' + positions + '.');
+    throw new Error('mdPanel: Position must be one of ' + positions + '.');
   }
 
   this['_' +  position] = angular.isString(value) ? value : '0';
@@ -57036,8 +58543,8 @@ MdPanelPosition.prototype.relativeTo = function(element) {
  */
 MdPanelPosition.prototype.addPanelPosition = function(xPosition, yPosition) {
   if (!this._relativeToEl) {
-    throw new Error('addPanelPosition can only be used with relative ' +
-        'positioning. Set relativeTo first.');
+    throw new Error('mdPanel: addPanelPosition can only be used with ' +
+        'relative positioning. Set relativeTo first.');
   }
 
   this._validateXPosition(xPosition);
@@ -57072,8 +58579,8 @@ MdPanelPosition.prototype._validateYPosition = function(yPosition) {
     }
   }
 
-  throw new Error('Panel y position only accepts the following values:\n' +
-    positionValues.join(' | '));
+  throw new Error('mdPanel: Panel y position only accepts the following ' +
+      'values:\n' + positionValues.join(' | '));
 };
 
 
@@ -57097,15 +58604,15 @@ MdPanelPosition.prototype._validateXPosition = function(xPosition) {
     }
   }
 
-  throw new Error('Panel x Position only accepts the following values:\n' +
-      positionValues.join(' | '));
+  throw new Error('mdPanel: Panel x Position only accepts the following ' +
+      'values:\n' + positionValues.join(' | '));
 };
 
 
 /**
  * Sets the value of the offset in the x-direction. This will add to any
  * previously set offsets.
- * @param {string} offsetX
+ * @param {string|function(MdPanelPosition): string} offsetX
  * @returns {!MdPanelPosition}
  */
 MdPanelPosition.prototype.withOffsetX = function(offsetX) {
@@ -57117,7 +58624,7 @@ MdPanelPosition.prototype.withOffsetX = function(offsetX) {
 /**
  * Sets the value of the offset in the y-direction. This will add to any
  * previously set offsets.
- * @param {string} offsetY
+ * @param {string|function(MdPanelPosition): string} offsetY
  * @returns {!MdPanelPosition}
  */
 MdPanelPosition.prototype.withOffsetY = function(offsetY) {
@@ -57175,20 +58682,38 @@ MdPanelPosition.prototype.getTransform = function() {
   return (translateX + ' ' + translateY).trim();
 };
 
+
+/**
+ * Sets the `transform` value for a panel element.
+ * @param {!angular.JQLite} panelEl
+ * @returns {!angular.JQLite}
+ * @private
+ */
+MdPanelPosition.prototype._setTransform = function(panelEl) {
+  return panelEl.css(this._$mdConstant.CSS.TRANSFORM, this.getTransform());
+};
+
+
 /**
  * True if the panel is completely on-screen with this positioning; false
  * otherwise.
  * @param {!angular.JQLite} panelEl
  * @return {boolean}
+ * @private
  */
 MdPanelPosition.prototype._isOnscreen = function(panelEl) {
   // this works because we always use fixed positioning for the panel,
   // which is relative to the viewport.
-  // TODO(gmoothart): take into account _translateX and _translateY to the
-  // extent feasible.
-
   var left = parseInt(this.getLeft());
   var top = parseInt(this.getTop());
+
+  if (this._translateX.length || this._translateY.length) {
+    var prefixedTransform = this._$mdConstant.CSS.TRANSFORM;
+    var offsets = getComputedTranslations(panelEl, prefixedTransform);
+    left += offsets.x;
+    top += offsets.y;
+  }
+
   var right = left + panelEl[0].offsetWidth;
   var bottom = top + panelEl[0].offsetHeight;
 
@@ -57219,8 +58744,11 @@ MdPanelPosition.prototype.getActualPosition = function() {
 MdPanelPosition.prototype._reduceTranslateValues =
     function(translateFn, values) {
       return values.map(function(translation) {
-        return translateFn + '(' + translation + ')';
-      }).join(' ');
+        // TODO(crisbeto): this should add the units after #9609 is merged.
+        var translationValue = angular.isFunction(translation) ?
+            translation(this) : translation;
+        return translateFn + '(' + translationValue + ')';
+      }, this).join(' ');
     };
 
 
@@ -57231,23 +58759,75 @@ MdPanelPosition.prototype._reduceTranslateValues =
  * @private
  */
 MdPanelPosition.prototype._setPanelPosition = function(panelEl) {
+  // Remove the "position adjusted" class in case it has been added before.
+  panelEl.removeClass('_md-panel-position-adjusted');
+
   // Only calculate the position if necessary.
   if (this._absolute) {
+    this._setTransform(panelEl);
     return;
   }
 
   if (this._actualPosition) {
     this._calculatePanelPosition(panelEl, this._actualPosition);
+    this._setTransform(panelEl);
+    this._constrainToViewport(panelEl);
     return;
   }
 
   for (var i = 0; i < this._positions.length; i++) {
     this._actualPosition = this._positions[i];
     this._calculatePanelPosition(panelEl, this._actualPosition);
+    this._setTransform(panelEl);
+
     if (this._isOnscreen(panelEl)) {
-      break;
+      return;
     }
   }
+
+  this._constrainToViewport(panelEl);
+};
+
+
+/**
+ * Constrains a panel's position to the viewport.
+ * @param {!angular.JQLite} panelEl
+ * @private
+ */
+MdPanelPosition.prototype._constrainToViewport = function(panelEl) {
+  var margin = MdPanelPosition.viewportMargin;
+  var initialTop = this._top;
+  var initialLeft = this._left;
+
+  if (this.getTop()) {
+    var top = parseInt(this.getTop());
+    var bottom = panelEl[0].offsetHeight + top;
+    var viewportHeight = this._$window.innerHeight;
+
+    if (top < margin) {
+      this._top = margin + 'px';
+    } else if (bottom > viewportHeight) {
+      this._top = top - (bottom - viewportHeight + margin) + 'px';
+    }
+  }
+
+  if (this.getLeft()) {
+    var left = parseInt(this.getLeft());
+    var right = panelEl[0].offsetWidth + left;
+    var viewportWidth = this._$window.innerWidth;
+
+    if (left < margin) {
+      this._left = margin + 'px';
+    } else if (right > viewportWidth) {
+      this._left = left - (right - viewportWidth + margin) + 'px';
+    }
+  }
+
+  // Class that can be used to re-style the panel if it was repositioned.
+  panelEl.toggleClass(
+    '_md-panel-position-adjusted',
+    this._top !== initialTop || this._left !== initialLeft
+  );
 };
 
 
@@ -57384,6 +58964,15 @@ function MdPanelAnimation($injector) {
 
   /** @private {string|{open: string, close: string}} */
   this._animationClass = '';
+
+  /** @private {number} */
+  this._openDuration;
+
+  /** @private {number} */
+  this._closeDuration;
+
+  /** @private {number|{open: number, close: number}} */
+  this._rawDuration;
 }
 
 
@@ -57429,6 +59018,32 @@ MdPanelAnimation.prototype.openFrom = function(openFrom) {
 MdPanelAnimation.prototype.closeTo = function(closeTo) {
   this._closeTo = this._getPanelAnimationTarget(closeTo);
   return this;
+};
+
+
+/**
+ * Specifies the duration of the animation in milliseconds.
+ * @param {number|{open: number, close: number}} duration
+ * @returns {!MdPanelAnimation}
+ */
+MdPanelAnimation.prototype.duration = function(duration) {
+  if (duration) {
+    if (angular.isNumber(duration)) {
+      this._openDuration = this._closeDuration = toSeconds(duration);
+    } else if (angular.isObject(duration)) {
+      this._openDuration = toSeconds(duration.open);
+      this._closeDuration = toSeconds(duration.close);
+    }
+  }
+
+  // Save the original value so it can be passed to the backdrop.
+  this._rawDuration = duration;
+
+  return this;
+
+  function toSeconds(value) {
+    if (angular.isNumber(value)) return value / 1000;
+  }
 };
 
 
@@ -57533,6 +59148,8 @@ MdPanelAnimation.prototype.animateOpen = function(panelEl) {
       }
   }
 
+  animationOptions.duration = this._openDuration;
+
   return animator
       .translate3d(panelEl, openFrom, openTo, animationOptions);
 };
@@ -57596,6 +59213,8 @@ MdPanelAnimation.prototype.animateClose = function(panelEl) {
       }
   }
 
+  reverseAnimationOptions.duration = this._closeDuration;
+
   return animator
       .translate3d(panelEl, closeFrom, closeTo, reverseAnimationOptions);
 };
@@ -57645,6 +59264,7 @@ MdPanelAnimation.prototype._getBoundingClientRect = function(element) {
  *                                Util Methods                               *
  *****************************************************************************/
 
+
 /**
  * Returns the angular element associated with a css selector or element.
  * @param el {string|!angular.JQLite|!Element}
@@ -57655,6 +59275,618 @@ function getElement(el) {
       document.querySelector(el) : el;
   return angular.element(queryResult);
 }
+
+
+/**
+ * Gets the computed values for an element's translateX and translateY in px.
+ * @param {!angular.JQLite|!Element} el
+ * @param {string} property
+ * @return {{x: number, y: number}}
+ */
+function getComputedTranslations(el, property) {
+  // The transform being returned by `getComputedStyle` is in the format:
+  // `matrix(a, b, c, d, translateX, translateY)` if defined and `none`
+  // if the element doesn't have a transform.
+  var transform = getComputedStyle(el[0] || el)[property];
+  var openIndex = transform.indexOf('(');
+  var closeIndex = transform.lastIndexOf(')');
+  var output = { x: 0, y: 0 };
+
+  if (openIndex > -1 && closeIndex > -1) {
+    var parsedValues = transform
+      .substring(openIndex + 1, closeIndex)
+      .split(', ')
+      .slice(-2);
+
+    output.x = parseInt(parsedValues[0]);
+    output.y = parseInt(parsedValues[1]);
+  }
+
+  return output;
+}
+
+})();
+(function(){
+"use strict";
+
+/**
+ * @ngdoc module
+ * @name material.components.navBar
+ */
+
+
+MdNavBarController.$inject = ["$element", "$scope", "$timeout", "$mdConstant"];
+MdNavItem.$inject = ["$mdAria", "$$rAF"];
+MdNavItemController.$inject = ["$element"];
+MdNavBar.$inject = ["$mdAria", "$mdTheming"];
+angular.module('material.components.navBar', ['material.core'])
+    .controller('MdNavBarController', MdNavBarController)
+    .directive('mdNavBar', MdNavBar)
+    .controller('MdNavItemController', MdNavItemController)
+    .directive('mdNavItem', MdNavItem);
+
+
+/*****************************************************************************
+ *                            PUBLIC DOCUMENTATION                           *
+ *****************************************************************************/
+/**
+ * @ngdoc directive
+ * @name mdNavBar
+ * @module material.components.navBar
+ *
+ * @restrict E
+ *
+ * @description
+ * The `<md-nav-bar>` directive renders a list of material tabs that can be used
+ * for top-level page navigation. Unlike `<md-tabs>`, it has no concept of a tab
+ * body and no bar pagination.
+ *
+ * Because it deals with page navigation, certain routing concepts are built-in.
+ * Route changes via via ng-href, ui-sref, or ng-click events are supported.
+ * Alternatively, the user could simply watch currentNavItem for changes.
+ *
+ * Accessibility functionality is implemented as a site navigator with a
+ * listbox, according to
+ * https://www.w3.org/TR/wai-aria-practices/#Site_Navigator_Tabbed_Style
+ *
+ * @param {string=} mdSelectedNavItem The name of the current tab; this must
+ *     match the name attribute of `<md-nav-item>`
+ * @param {boolean=} mdNoInkBar If set to true, the ink bar will be hidden.
+ * @param {string=} navBarAriaLabel An aria-label for the nav-bar
+ *
+ * @usage
+ * <hljs lang="html">
+ *  <md-nav-bar md-selected-nav-item="currentNavItem">
+ *    <md-nav-item md-nav-click="goto('page1')" name="page1">
+ *      Page One
+ *    </md-nav-item>
+ *    <md-nav-item md-nav-href="#page2" name="page3">Page Two</md-nav-item>
+ *    <md-nav-item md-nav-sref="page3" name="page2">Page Three</md-nav-item>
+ *    <md-nav-item
+ *      md-nav-sref="app.page4"
+ *      sref-opts="{reload: true, notify: true}"
+ *      name="page4">
+ *      Page Four
+ *    </md-nav-item>
+ *  </md-nav-bar>
+ *</hljs>
+ * <hljs lang="js">
+ * (function() {
+ *   'use strict';
+ *
+ *    $rootScope.$on('$routeChangeSuccess', function(event, current) {
+ *      $scope.currentLink = getCurrentLinkFromRoute(current);
+ *    });
+ * });
+ * </hljs>
+ */
+
+/*****************************************************************************
+ *                            mdNavItem
+ *****************************************************************************/
+/**
+ * @ngdoc directive
+ * @name mdNavItem
+ * @module material.components.navBar
+ *
+ * @restrict E
+ *
+ * @description
+ * `<md-nav-item>` describes a page navigation link within the `<md-nav-bar>`
+ * component. It renders an md-button as the actual link.
+ *
+ * Exactly one of the mdNavClick, mdNavHref, mdNavSref attributes are required
+ * to be specified.
+ *
+ * @param {Function=} mdNavClick Function which will be called when the
+ *     link is clicked to change the page. Renders as an `ng-click`.
+ * @param {string=} mdNavHref url to transition to when this link is clicked.
+ *     Renders as an `ng-href`.
+ * @param {string=} mdNavSref Ui-router state to transition to when this link is
+ *     clicked. Renders as a `ui-sref`.
+ * @param {!Object=} srefOpts Ui-router options that are passed to the
+ *     `$state.go()` function. See the [Ui-router documentation for details]
+ *     (https://ui-router.github.io/docs/latest/interfaces/transition.transitionoptions.html).
+ * @param {string=} name The name of this link. Used by the nav bar to know
+ *     which link is currently selected.
+ * @param {string=} aria-label Adds alternative text for accessibility
+ *
+ * @usage
+ * See `<md-nav-bar>` for usage.
+ */
+
+
+/*****************************************************************************
+ *                                IMPLEMENTATION                             *
+ *****************************************************************************/
+
+function MdNavBar($mdAria, $mdTheming) {
+  return {
+    restrict: 'E',
+    transclude: true,
+    controller: MdNavBarController,
+    controllerAs: 'ctrl',
+    bindToController: true,
+    scope: {
+      'mdSelectedNavItem': '=?',
+      'mdNoInkBar': '=?',
+      'navBarAriaLabel': '@?',
+    },
+    template:
+      '<div class="md-nav-bar">' +
+        '<nav role="navigation">' +
+          '<ul class="_md-nav-bar-list" ng-transclude role="listbox"' +
+            'tabindex="0"' +
+            'ng-focus="ctrl.onFocus()"' +
+            'ng-keydown="ctrl.onKeydown($event)"' +
+            'aria-label="{{ctrl.navBarAriaLabel}}">' +
+          '</ul>' +
+        '</nav>' +
+        '<md-nav-ink-bar ng-hide="ctrl.mdNoInkBar"></md-nav-ink-bar>' +
+      '</div>',
+    link: function(scope, element, attrs, ctrl) {
+      $mdTheming(element);
+      if (!ctrl.navBarAriaLabel) {
+        $mdAria.expectAsync(element, 'aria-label', angular.noop);
+      }
+    },
+  };
+}
+
+/**
+ * Controller for the nav-bar component.
+ *
+ * Accessibility functionality is implemented as a site navigator with a
+ * listbox, according to
+ * https://www.w3.org/TR/wai-aria-practices/#Site_Navigator_Tabbed_Style
+ * @param {!angular.JQLite} $element
+ * @param {!angular.Scope} $scope
+ * @param {!angular.Timeout} $timeout
+ * @param {!Object} $mdConstant
+ * @constructor
+ * @final
+ * @ngInject
+ */
+function MdNavBarController($element, $scope, $timeout, $mdConstant) {
+  // Injected variables
+  /** @private @const {!angular.Timeout} */
+  this._$timeout = $timeout;
+
+  /** @private @const {!angular.Scope} */
+  this._$scope = $scope;
+
+  /** @private @const {!Object} */
+  this._$mdConstant = $mdConstant;
+
+  // Data-bound variables.
+  /** @type {string} */
+  this.mdSelectedNavItem;
+
+  /** @type {string} */
+  this.navBarAriaLabel;
+
+  // State variables.
+
+  /** @type {?angular.JQLite} */
+  this._navBarEl = $element[0];
+
+  /** @type {?angular.JQLite} */
+  this._inkbar;
+
+  var self = this;
+  // need to wait for transcluded content to be available
+  var deregisterTabWatch = this._$scope.$watch(function() {
+    return self._navBarEl.querySelectorAll('._md-nav-button').length;
+  },
+  function(newLength) {
+    if (newLength > 0) {
+      self._initTabs();
+      deregisterTabWatch();
+    }
+  });
+}
+
+
+
+/**
+ * Initializes the tab components once they exist.
+ * @private
+ */
+MdNavBarController.prototype._initTabs = function() {
+  this._inkbar = angular.element(this._navBarEl.querySelector('md-nav-ink-bar'));
+
+  var self = this;
+  this._$timeout(function() {
+    self._updateTabs(self.mdSelectedNavItem, undefined);
+  });
+
+  this._$scope.$watch('ctrl.mdSelectedNavItem', function(newValue, oldValue) {
+    // Wait a digest before update tabs for products doing
+    // anything dynamic in the template.
+    self._$timeout(function() {
+      self._updateTabs(newValue, oldValue);
+    });
+  });
+};
+
+/**
+ * Set the current tab to be selected.
+ * @param {string|undefined} newValue New current tab name.
+ * @param {string|undefined} oldValue Previous tab name.
+ * @private
+ */
+MdNavBarController.prototype._updateTabs = function(newValue, oldValue) {
+  var self = this;
+  var tabs = this._getTabs();
+
+  // this._getTabs can return null if nav-bar has not yet been initialized
+  if(!tabs)
+    return;
+
+  var oldIndex = -1;
+  var newIndex = -1;
+  var newTab = this._getTabByName(newValue);
+  var oldTab = this._getTabByName(oldValue);
+
+  if (oldTab) {
+    oldTab.setSelected(false);
+    oldIndex = tabs.indexOf(oldTab);
+  }
+
+  if (newTab) {
+    newTab.setSelected(true);
+    newIndex = tabs.indexOf(newTab);
+  }
+
+  this._$timeout(function() {
+    self._updateInkBarStyles(newTab, newIndex, oldIndex);
+  });
+};
+
+/**
+ * Repositions the ink bar to the selected tab.
+ * @private
+ */
+MdNavBarController.prototype._updateInkBarStyles = function(tab, newIndex, oldIndex) {
+  this._inkbar.toggleClass('_md-left', newIndex < oldIndex)
+      .toggleClass('_md-right', newIndex > oldIndex);
+
+  this._inkbar.css({display: newIndex < 0 ? 'none' : ''});
+
+  if (tab) {
+    var tabEl = tab.getButtonEl();
+    var left = tabEl.offsetLeft;
+
+    this._inkbar.css({left: left + 'px', width: tabEl.offsetWidth + 'px'});
+  }
+};
+
+/**
+ * Returns an array of the current tabs.
+ * @return {!Array<!NavItemController>}
+ * @private
+ */
+MdNavBarController.prototype._getTabs = function() {
+  var controllers = Array.prototype.slice.call(
+    this._navBarEl.querySelectorAll('.md-nav-item'))
+    .map(function(el) {
+      return angular.element(el).controller('mdNavItem')
+    });
+  return controllers.indexOf(undefined) ? controllers : null;
+};
+
+/**
+ * Returns the tab with the specified name.
+ * @param {string} name The name of the tab, found in its name attribute.
+ * @return {!NavItemController|undefined}
+ * @private
+ */
+MdNavBarController.prototype._getTabByName = function(name) {
+  return this._findTab(function(tab) {
+    return tab.getName() == name;
+  });
+};
+
+/**
+ * Returns the selected tab.
+ * @return {!NavItemController|undefined}
+ * @private
+ */
+MdNavBarController.prototype._getSelectedTab = function() {
+  return this._findTab(function(tab) {
+    return tab.isSelected();
+  });
+};
+
+/**
+ * Returns the focused tab.
+ * @return {!NavItemController|undefined}
+ */
+MdNavBarController.prototype.getFocusedTab = function() {
+  return this._findTab(function(tab) {
+    return tab.hasFocus();
+  });
+};
+
+/**
+ * Find a tab that matches the specified function.
+ * @private
+ */
+MdNavBarController.prototype._findTab = function(fn) {
+  var tabs = this._getTabs();
+  for (var i = 0; i < tabs.length; i++) {
+    if (fn(tabs[i])) {
+      return tabs[i];
+    }
+  }
+
+  return null;
+};
+
+/**
+ * Direct focus to the selected tab when focus enters the nav bar.
+ */
+MdNavBarController.prototype.onFocus = function() {
+  var tab = this._getSelectedTab();
+  if (tab) {
+    tab.setFocused(true);
+  }
+};
+
+/**
+ * Move focus from oldTab to newTab.
+ * @param {!NavItemController} oldTab
+ * @param {!NavItemController} newTab
+ * @private
+ */
+MdNavBarController.prototype._moveFocus = function(oldTab, newTab) {
+  oldTab.setFocused(false);
+  newTab.setFocused(true);
+};
+
+/**
+ * Responds to keypress events.
+ * @param {!Event} e
+ */
+MdNavBarController.prototype.onKeydown = function(e) {
+  var keyCodes = this._$mdConstant.KEY_CODE;
+  var tabs = this._getTabs();
+  var focusedTab = this.getFocusedTab();
+  if (!focusedTab) return;
+
+  var focusedTabIndex = tabs.indexOf(focusedTab);
+
+  // use arrow keys to navigate between tabs
+  switch (e.keyCode) {
+    case keyCodes.UP_ARROW:
+    case keyCodes.LEFT_ARROW:
+      if (focusedTabIndex > 0) {
+        this._moveFocus(focusedTab, tabs[focusedTabIndex - 1]);
+      }
+      break;
+    case keyCodes.DOWN_ARROW:
+    case keyCodes.RIGHT_ARROW:
+      if (focusedTabIndex < tabs.length - 1) {
+        this._moveFocus(focusedTab, tabs[focusedTabIndex + 1]);
+      }
+      break;
+    case keyCodes.SPACE:
+    case keyCodes.ENTER:
+      // timeout to avoid a "digest already in progress" console error
+      this._$timeout(function() {
+        focusedTab.getButtonEl().click();
+      });
+      break;
+  }
+};
+
+/**
+ * @ngInject
+ */
+function MdNavItem($mdAria, $$rAF) {
+  return {
+    restrict: 'E',
+    require: ['mdNavItem', '^mdNavBar'],
+    controller: MdNavItemController,
+    bindToController: true,
+    controllerAs: 'ctrl',
+    replace: true,
+    transclude: true,
+    template: function(tElement, tAttrs) {
+      var hasNavClick = tAttrs.mdNavClick;
+      var hasNavHref = tAttrs.mdNavHref;
+      var hasNavSref = tAttrs.mdNavSref;
+      var hasSrefOpts = tAttrs.srefOpts;
+      var navigationAttribute;
+      var navigationOptions;
+      var buttonTemplate;
+
+      // Cannot specify more than one nav attribute
+      if ((hasNavClick ? 1:0) + (hasNavHref ? 1:0) + (hasNavSref ? 1:0) > 1) {
+        throw Error(
+          'Must not specify more than one of the md-nav-click, md-nav-href, ' +
+          'or md-nav-sref attributes per nav-item directive.'
+        );
+      }
+
+      if (hasNavClick) {
+        navigationAttribute = 'ng-click="ctrl.mdNavClick()"';
+      } else if (hasNavHref) {
+        navigationAttribute = 'ng-href="{{ctrl.mdNavHref}}"';
+      } else if (hasNavSref) {
+        navigationAttribute = 'ui-sref="{{ctrl.mdNavSref}}"';
+      }
+
+      navigationOptions = hasSrefOpts ? 'ui-sref-opts="{{ctrl.srefOpts}}" ' : '';
+
+      if (navigationAttribute) {
+        buttonTemplate = '' +
+          '<md-button class="_md-nav-button md-accent" ' +
+            'ng-class="ctrl.getNgClassMap()" ' +
+            'ng-blur="ctrl.setFocused(false)" ' +
+            'tabindex="-1" ' +
+            navigationOptions +
+            navigationAttribute + '>' +
+            '<span ng-transclude class="_md-nav-button-text"></span>' +
+          '</md-button>';
+      }
+
+      return '' +
+        '<li class="md-nav-item" ' +
+          'role="option" ' +
+          'aria-selected="{{ctrl.isSelected()}}">' +
+          (buttonTemplate || '') +
+        '</li>';
+    },
+    scope: {
+      'mdNavClick': '&?',
+      'mdNavHref': '@?',
+      'mdNavSref': '@?',
+      'srefOpts': '=?',
+      'name': '@',
+    },
+    link: function(scope, element, attrs, controllers) {
+      // When accessing the element's contents synchronously, they
+      // may not be defined yet because of transclusion. There is a higher
+      // chance that it will be accessible if we wait one frame.
+      $$rAF(function() {
+        var mdNavItem = controllers[0];
+        var mdNavBar = controllers[1];
+        var navButton = angular.element(element[0].querySelector('._md-nav-button'));
+
+        if (!mdNavItem.name) {
+          mdNavItem.name = angular.element(element[0]
+              .querySelector('._md-nav-button-text')).text().trim();
+        }
+
+        navButton.on('click', function() {
+          mdNavBar.mdSelectedNavItem = mdNavItem.name;
+          scope.$apply();
+        });
+
+        $mdAria.expectWithText(element, 'aria-label');
+      });
+    }
+  };
+}
+
+/**
+ * Controller for the nav-item component.
+ * @param {!angular.JQLite} $element
+ * @constructor
+ * @final
+ * @ngInject
+ */
+function MdNavItemController($element) {
+
+  /** @private @const {!angular.JQLite} */
+  this._$element = $element;
+
+  // Data-bound variables
+
+  /** @const {?Function} */
+  this.mdNavClick;
+
+  /** @const {?string} */
+  this.mdNavHref;
+
+  /** @const {?string} */
+  this.mdNavSref;
+  /** @const {?Object} */
+  this.srefOpts;
+  /** @const {?string} */
+  this.name;
+
+  // State variables
+  /** @private {boolean} */
+  this._selected = false;
+
+  /** @private {boolean} */
+  this._focused = false;
+}
+
+/**
+ * Returns a map of class names and values for use by ng-class.
+ * @return {!Object<string,boolean>}
+ */
+MdNavItemController.prototype.getNgClassMap = function() {
+  return {
+    'md-active': this._selected,
+    'md-primary': this._selected,
+    'md-unselected': !this._selected,
+    'md-focused': this._focused,
+  };
+};
+
+/**
+ * Get the name attribute of the tab.
+ * @return {string}
+ */
+MdNavItemController.prototype.getName = function() {
+  return this.name;
+};
+
+/**
+ * Get the button element associated with the tab.
+ * @return {!Element}
+ */
+MdNavItemController.prototype.getButtonEl = function() {
+  return this._$element[0].querySelector('._md-nav-button');
+};
+
+/**
+ * Set the selected state of the tab.
+ * @param {boolean} isSelected
+ */
+MdNavItemController.prototype.setSelected = function(isSelected) {
+  this._selected = isSelected;
+};
+
+/**
+ * @return {boolean}
+ */
+MdNavItemController.prototype.isSelected = function() {
+  return this._selected;
+};
+
+/**
+ * Set the focused state of the tab.
+ * @param {boolean} isFocused
+ */
+MdNavItemController.prototype.setFocused = function(isFocused) {
+  this._focused = isFocused;
+
+  if (isFocused) {
+    this.getButtonEl().focus();
+  }
+};
+
+/**
+ * @return {boolean}
+ */
+MdNavItemController.prototype.hasFocus = function() {
+  return this._focused;
+};
 
 })();
 (function(){
@@ -57946,7 +60178,7 @@ function mdRadioGroupDirective($mdUtil, $mdConstant, $mdTheming, $timeout) {
   function linkRadioGroup(scope, element, attr, ctrls) {
     element.addClass('_md');     // private md component indicator for styling
     $mdTheming(element);
-    
+
     var rgCtrl = ctrls[0];
     var ngModelCtrl = ctrls[1] || $mdUtil.fakeNgModel();
 
@@ -58089,8 +60321,6 @@ function mdRadioGroupDirective($mdUtil, $mdConstant, $mdTheming, $timeout) {
 
       // Activate radioButton's click listener (triggerHandler won't create a real click event)
       angular.element(target).triggerHandler('click');
-
-
     }
   }
 
@@ -58156,10 +60386,18 @@ function mdRadioButtonDirective($mdAria, $mdUtil, $mdTheming) {
     $mdTheming(element);
     configureAria(element, scope);
 
-    initialize();
+    // ngAria overwrites the aria-checked inside a $watch for ngValue.
+    // We should defer the initialization until all the watches have fired.
+    // This can also be fixed by removing the `lastChecked` check, but that'll
+    // cause more DOM manipulation on each digest.
+    if (attr.ngValue) {
+      $mdUtil.nextTick(initialize, false);
+    } else {
+      initialize();
+    }
 
     /**
-     *
+     * Initializes the component.
      */
     function initialize() {
       if (!rgCtrl) {
@@ -58177,7 +60415,7 @@ function mdRadioButtonDirective($mdAria, $mdUtil, $mdTheming) {
     }
 
     /**
-     *
+     * On click functionality.
      */
     function listener(ev) {
       if (element[0].hasAttribute('disabled') || rgCtrl.isDisabled()) return;
@@ -58192,58 +60430,37 @@ function mdRadioButtonDirective($mdAria, $mdUtil, $mdTheming) {
      *  Update the `aria-activedescendant` attribute.
      */
     function render() {
-      var checked = (rgCtrl.getViewValue() == attr.value);
-      if (checked === lastChecked) {
-        return;
+      var checked = rgCtrl.getViewValue() == attr.value;
+
+      if (checked === lastChecked) return;
+
+      if (element[0].parentNode.nodeName.toLowerCase() !== 'md-radio-group') {
+        // If the radioButton is inside a div, then add class so highlighting will work
+        element.parent().toggleClass(CHECKED_CSS, checked);
+      }
+
+      if (checked) {
+        rgCtrl.setActiveDescendant(element.attr('id'));
       }
 
       lastChecked = checked;
-      element.attr('aria-checked', checked);
 
-      if (checked) {
-        markParentAsChecked(true);
-        element.addClass(CHECKED_CSS);
-
-        rgCtrl.setActiveDescendant(element.attr('id'));
-
-      } else {
-        markParentAsChecked(false);
-        element.removeClass(CHECKED_CSS);
-      }
-
-      /**
-       * If the radioButton is inside a div, then add class so highlighting will work...
-       */
-      function markParentAsChecked(addClass ) {
-        if ( element.parent()[0].nodeName != "MD-RADIO-GROUP") {
-          element.parent()[ !!addClass ? 'addClass' : 'removeClass'](CHECKED_CSS);
-        }
-
-      }
+      element
+        .attr('aria-checked', checked)
+        .toggleClass(CHECKED_CSS, checked);
     }
 
     /**
      * Inject ARIA-specific attributes appropriate for each radio button
      */
-    function configureAria( element, scope ){
-      scope.ariaId = buildAriaID();
-
+    function configureAria(element, scope){
       element.attr({
-        'id' :  scope.ariaId,
-        'role' : 'radio',
-        'aria-checked' : 'false'
+        id: attr.id || 'radio_' + $mdUtil.nextUid(),
+        role: 'radio',
+        'aria-checked': 'false'
       });
 
       $mdAria.expectWithText(element, 'aria-label');
-
-      /**
-       * Build a unique ID for each radio button that will be used with aria-activedescendant.
-       * Preserve existing ID if already specified.
-       * @returns {*|string}
-       */
-      function buildAriaID() {
-        return attr.id || ( 'radio' + "_" + $mdUtil.nextUid() );
-      }
     }
   }
 }
@@ -58264,7 +60481,7 @@ function mdRadioButtonDirective($mdAria, $mdUtil, $mdTheming) {
 
  ***************************************************/
 
-SelectDirective.$inject = ["$mdSelect", "$mdUtil", "$mdConstant", "$mdTheming", "$mdAria", "$compile", "$parse"];
+SelectDirective.$inject = ["$mdSelect", "$mdUtil", "$mdConstant", "$mdTheming", "$mdAria", "$parse", "$sce", "$injector"];
 SelectMenuDirective.$inject = ["$parse", "$mdUtil", "$mdConstant", "$mdTheming"];
 OptionDirective.$inject = ["$mdButtonInkRipple", "$mdUtil"];
 SelectProvider.$inject = ["$$interimElementProvider"];
@@ -58328,12 +60545,17 @@ angular.module('material.components.select', [
  * `value="null"` will require the test `ng-if="myValue != 'null'"` rather than `ng-if="!myValue"`.
  *
  * @param {expression} ng-model The model!
- * @param {boolean=} multiple Whether it's multiple.
+ * @param {boolean=} multiple When set to true, allows for more than one option to be selected. The model is an array with the selected choices.
  * @param {expression=} md-on-close Expression to be evaluated when the select is closed.
  * @param {expression=} md-on-open Expression to be evaluated when opening the select.
  * Will hide the select options and show a spinner until the evaluated promise resolves.
  * @param {expression=} md-selected-text Expression to be evaluated that will return a string
- * to be displayed as a placeholder in the select input box when it is closed.
+ * to be displayed as a placeholder in the select input box when it is closed. The value
+ * will be treated as *text* (not html).
+ * @param {expression=} md-selected-html Expression to be evaluated that will return a string
+ * to be displayed as a placeholder in the select input box when it is closed. The value
+ * will be treated as *html*. The value must either be explicitly marked as trustedHtml or
+ * the ngSanitize module must be loaded.
  * @param {string=} placeholder Placeholder hint text.
  * @param md-no-asterisk {boolean=} When set to true, an asterisk will not be appended to the
  * floating label. **Note:** This attribute is only evaluated once; it is not watched.
@@ -58432,7 +60654,8 @@ angular.module('material.components.select', [
  * </div>
  * </hljs>
  */
-function SelectDirective($mdSelect, $mdUtil, $mdConstant, $mdTheming, $mdAria, $compile, $parse) {
+function SelectDirective($mdSelect, $mdUtil, $mdConstant, $mdTheming, $mdAria, $parse, $sce,
+    $injector) {
   var keyCodes = $mdConstant.KEY_CODE;
   var NAVIGATION_KEYS = [keyCodes.SPACE, keyCodes.ENTER, keyCodes.UP_ARROW, keyCodes.DOWN_ARROW];
 
@@ -58595,17 +60818,39 @@ function SelectDirective($mdSelect, $mdUtil, $mdConstant, $mdTheming, $mdAria, $
       mdSelectCtrl.setLabelText = function(text) {
         mdSelectCtrl.setIsPlaceholder(!text);
 
-        if (attr.mdSelectedText) {
-          text = $parse(attr.mdSelectedText)(scope);
-        } else {
+        // Whether the select label has been given via user content rather than the internal
+        // template of <md-option>
+        var isSelectLabelFromUser = false;
+
+        if (attr.mdSelectedText && attr.mdSelectedHtml) {
+          throw Error('md-select cannot have both `md-selected-text` and `md-selected-html`');
+        }
+
+        if (attr.mdSelectedText || attr.mdSelectedHtml) {
+          text = $parse(attr.mdSelectedText || attr.mdSelectedHtml)(scope);
+          isSelectLabelFromUser = true;
+        } else if (!text) {
           // Use placeholder attribute, otherwise fallback to the md-input-container label
           var tmpPlaceholder = attr.placeholder ||
               (containerCtrl && containerCtrl.label ? containerCtrl.label.text() : '');
-          text = text || tmpPlaceholder || '';
+
+          text = tmpPlaceholder || '';
+          isSelectLabelFromUser = true;
         }
 
         var target = valueEl.children().eq(0);
-        target.html(text);
+
+        if (attr.mdSelectedHtml) {
+            // Using getTrustedHtml will run the content through $sanitize if it is not already
+            // explicitly trusted. If the ngSanitize module is not loaded, this will
+            // *correctly* throw an sce error.
+            target.html($sce.getTrustedHtml(text));
+        } else if (isSelectLabelFromUser) {
+          target.text(text);
+        } else {
+          // If we've reached this point, the text is not user-provided.
+          target.html(text);
+        }
       };
 
       mdSelectCtrl.setIsPlaceholder = function(isPlaceholder) {
@@ -58666,7 +60911,7 @@ function SelectDirective($mdSelect, $mdUtil, $mdConstant, $mdTheming, $mdAria, $
       }
 
       scope.$watch(function() {
-          return selectMenuCtrl.selectedLabels();
+        return selectMenuCtrl.selectedLabels();
       }, syncLabelText);
 
       function syncLabelText() {
@@ -58993,9 +61238,11 @@ function SelectMenuDirective($parse, $mdUtil, $mdConstant, $mdTheming) {
 
       // Allow users to provide `ng-model="foo" ng-model-options="{trackBy: 'foo.id'}"` so
       // that we can properly compare objects set on the model to the available options
-      if (ngModel.$options && ngModel.$options.trackBy) {
+      var trackByOption = $mdUtil.getModelOption(ngModel, 'trackBy');
+
+      if (trackByOption) {
         var trackByLocals = {};
-        var trackByParsed = $parse(ngModel.$options.trackBy);
+        var trackByParsed = $parse(trackByOption);
         self.hashGetter = function(value, valueScope) {
           trackByLocals.$value = value;
           return trackByParsed(valueScope || $scope, trackByLocals);
@@ -59049,7 +61296,9 @@ function SelectMenuDirective($parse, $mdUtil, $mdConstant, $mdTheming) {
         } else if (mode == 'aria') {
           mapFn = function(el) { return el.hasAttribute('aria-label') ? el.getAttribute('aria-label') : el.textContent; };
         }
-        return selectedOptionEls.map(mapFn).join(', ');
+
+        // Ensure there are no duplicates; see https://github.com/angular/material/issues/9442
+        return $mdUtil.uniq(selectedOptionEls.map(mapFn)).join(', ');
       } else {
         return '';
       }
@@ -59111,12 +61360,12 @@ function SelectMenuDirective($parse, $mdUtil, $mdConstant, $mdTheming) {
           values.push(self.selected[hashKey]);
         }
       }
-      var usingTrackBy = self.ngModel.$options && self.ngModel.$options.trackBy;
+      var usingTrackBy = $mdUtil.getModelOption(self.ngModel, 'trackBy');
 
       var newVal = self.isMultiple ? values : values[0];
       var prevVal = self.ngModel.$modelValue;
 
-      if (usingTrackBy ? !angular.equals(prevVal, newVal) : prevVal != newVal) {
+      if (usingTrackBy ? !angular.equals(prevVal, newVal) : (prevVal + '') !== newVal) {
         self.ngModel.$setViewValue(newVal);
         self.ngModel.$render();
       }
@@ -59969,8 +62218,8 @@ function createDirective(name, targetValue) {
  * A Sidenav QP component.
  */
 SidenavService.$inject = ["$mdComponentRegistry", "$mdUtil", "$q", "$log"];
-SidenavDirective.$inject = ["$mdMedia", "$mdUtil", "$mdConstant", "$mdTheming", "$animate", "$compile", "$parse", "$log", "$q", "$document"];
-SidenavController.$inject = ["$scope", "$element", "$attrs", "$mdComponentRegistry", "$q"];
+SidenavDirective.$inject = ["$mdMedia", "$mdUtil", "$mdConstant", "$mdTheming", "$mdInteraction", "$animate", "$compile", "$parse", "$log", "$q", "$document", "$window", "$$rAF"];
+SidenavController.$inject = ["$scope", "$attrs", "$mdComponentRegistry", "$q", "$interpolate"];
 angular
   .module('material.components.sidenav', [
     'material.core',
@@ -60209,7 +62458,8 @@ function SidenavFocusDirective() {
  *   - `<md-sidenav md-is-locked-open="$mdMedia('min-width: 1000px')"></md-sidenav>`
  *   - `<md-sidenav md-is-locked-open="$mdMedia('sm')"></md-sidenav>` (locks open on small screens)
  */
-function SidenavDirective($mdMedia, $mdUtil, $mdConstant, $mdTheming, $animate, $compile, $parse, $log, $q, $document) {
+function SidenavDirective($mdMedia, $mdUtil, $mdConstant, $mdTheming, $mdInteraction, $animate,
+                          $compile, $parse, $log, $q, $document, $window, $$rAF) {
   return {
     restrict: 'E',
     scope: {
@@ -60217,8 +62467,7 @@ function SidenavDirective($mdMedia, $mdUtil, $mdConstant, $mdTheming, $animate, 
     },
     controller: '$mdSidenavController',
     compile: function(element) {
-      element.addClass('md-closed');
-      element.attr('tabIndex', '-1');
+      element.addClass('md-closed').attr('tabIndex', '-1');
       return postLink;
     }
   };
@@ -60230,10 +62479,12 @@ function SidenavDirective($mdMedia, $mdUtil, $mdConstant, $mdTheming, $animate, 
     var lastParentOverFlow;
     var backdrop;
     var disableScrollTarget = null;
+    var triggeringInteractionType;
     var triggeringElement = null;
     var previousContainerStyles;
     var promise = $q.when(true);
     var isLockedOpenParsed = $parse(attr.mdIsLockedOpen);
+    var ngWindow = angular.element($window);
     var isLocked = function() {
       return isLockedOpenParsed(scope.$parent, {
         $media: function(arg) {
@@ -60320,6 +62571,7 @@ function SidenavDirective($mdMedia, $mdUtil, $mdConstant, $mdTheming, $animate, 
       if ( isOpen ) {
         // Capture upon opening..
         triggeringElement = $document[0].activeElement;
+        triggeringInteractionType = $mdInteraction.getLastInteractionType();
       }
 
       disableParentScroll(isOpen);
@@ -60331,6 +62583,12 @@ function SidenavDirective($mdMedia, $mdUtil, $mdConstant, $mdTheming, $animate, 
       ]).then(function() {
         // Perform focus when animations are ALL done...
         if (scope.isOpen) {
+          $$rAF(function() {
+            // Notifies child components that the sidenav was opened. Should wait
+            // a frame in order to allow for the element height to be computed.
+            ngWindow.triggerHandler('resize');
+          });
+
           focusEl && focusEl.focus();
         }
 
@@ -60417,9 +62675,9 @@ function SidenavDirective($mdMedia, $mdUtil, $mdConstant, $mdTheming, $animate, 
             // When the current `updateIsOpen()` animation finishes
             promise.then(function(result) {
 
-              if ( !scope.isOpen ) {
+              if ( !scope.isOpen && triggeringElement && triggeringInteractionType === 'keyboard') {
                 // reset focus to originating element (if available) upon close
-                triggeringElement && triggeringElement.focus();
+                triggeringElement.focus();
                 triggeringElement = null;
               }
 
@@ -60460,9 +62718,8 @@ function SidenavDirective($mdMedia, $mdUtil, $mdConstant, $mdTheming, $animate, 
  * @ngdoc controller
  * @name SidenavController
  * @module material.components.sidenav
- *
  */
-function SidenavController($scope, $element, $attrs, $mdComponentRegistry, $q) {
+function SidenavController($scope, $attrs, $mdComponentRegistry, $q, $interpolate) {
 
   var self = this;
 
@@ -60484,7 +62741,23 @@ function SidenavController($scope, $element, $attrs, $mdComponentRegistry, $q) {
   self.toggle = function() { return self.$toggleOpen( !$scope.isOpen );  };
   self.$toggleOpen = function(value) { return $q.when($scope.isOpen = value); };
 
-  self.destroy = $mdComponentRegistry.register(self, $attrs.mdComponentId);
+  // Evaluate the component id.
+  var rawId = $attrs.mdComponentId;
+  var hasDataBinding = rawId && rawId.indexOf($interpolate.startSymbol()) > -1;
+  var componentId = hasDataBinding ? $interpolate(rawId)($scope.$parent) : rawId;
+
+  // Register the component.
+  self.destroy = $mdComponentRegistry.register(self, componentId);
+
+  // Watch and update the component, if the id has changed.
+  if (hasDataBinding) {
+    $attrs.$observe('mdComponentId', function(id) {
+      if (id && id !== self.$$mdHandle) {
+        self.destroy(); // `destroy` only deregisters the old component id so we can add the new one.
+        self.destroy = $mdComponentRegistry.register(self, id);
+      }
+    });
+  }
 }
 
 })();
@@ -61468,7 +63741,7 @@ function MdSticky($mdConstant, $$rAF, $mdUtil, $compile) {
  *  > To improve the visual grouping of content, use the system color for your subheaders.
  *
  */
-MdSubheaderDirective.$inject = ["$mdSticky", "$compile", "$mdTheming", "$mdUtil"];
+MdSubheaderDirective.$inject = ["$mdSticky", "$compile", "$mdTheming", "$mdUtil", "$mdAria"];
 angular
   .module('material.components.subheader', [
     'material.core',
@@ -61505,7 +63778,7 @@ angular
  * </hljs>
  */
 
-function MdSubheaderDirective($mdSticky, $compile, $mdTheming, $mdUtil) {
+function MdSubheaderDirective($mdSticky, $compile, $mdTheming, $mdUtil, $mdAria) {
   return {
     restrict: 'E',
     replace: true,
@@ -61531,6 +63804,12 @@ function MdSubheaderDirective($mdSticky, $compile, $mdTheming, $mdUtil) {
         return angular.element(el[0].querySelector('.md-subheader-content'));
       }
 
+      // Set the ARIA attributes on the original element since it keeps it's original place in
+      // the DOM, whereas the clones are in reverse order. Should be done after the outerHTML,
+      // in order to avoid having multiple element be marked as headers.
+      attr.$set('role', 'heading');
+      $mdAria.expect(element, 'aria-level', '2');
+
       // Transclude the user-given contents of the subheader
       // the conventional way.
       transclude(scope, function(clone) {
@@ -61545,7 +63824,7 @@ function MdSubheaderDirective($mdSticky, $compile, $mdTheming, $mdUtil) {
           // compiled clone below will only be a comment tag (since they replace their elements with
           // a comment) which cannot be properly passed to the $mdSticky; so we wrap it in our own
           // DIV to ensure we have something $mdSticky can use
-          var wrapper = $compile('<div class="md-subheader-wrapper">' + outerHTML + '</div>')(scope);
+          var wrapper = $compile('<div class="md-subheader-wrapper" aria-hidden="true">' + outerHTML + '</div>')(scope);
 
           // Delay initialization until after any `ng-if`/`ng-repeat`/etc has finished before
           // attempting to create the clone
@@ -61657,6 +63936,8 @@ function getDirective(name) {
   function DirectiveFactory($parse) {
       return { restrict: 'A', link: postLink };
       function postLink(scope, element, attr) {
+        element.css('touch-action', 'none');
+
         var fn = $parse(attr[directiveName]);
         element.on(eventName, function(ev) {
           scope.$applyAsync(function() { fn(scope, { $event: ev }); });
@@ -61703,6 +63984,7 @@ angular.module('material.components.switch', [
  * @param {expression=} ng-disabled En/Disable based on the expression.
  * @param {boolean=} md-no-ink Use of attribute indicates use of ripple ink effects.
  * @param {string=} aria-label Publish the button label used by screen-readers for accessibility. Defaults to the switch's text.
+ * @param {boolean=} md-invert When set to true, the switch will be inverted.
  *
  * @usage
  * <hljs lang="html">
@@ -61725,7 +64007,7 @@ function MdSwitch(mdCheckboxDirective, $mdUtil, $mdConstant, $parse, $$rAF, $mdG
 
   return {
     restrict: 'E',
-    priority: 210, // Run before ngAria
+    priority: $mdConstant.BEFORE_NG_ARIA,
     transclude: true,
     template:
       '<div class="md-container">' +
@@ -61735,7 +64017,7 @@ function MdSwitch(mdCheckboxDirective, $mdUtil, $mdConstant, $parse, $$rAF, $mdG
         '</div>'+
       '</div>' +
       '<div ng-transclude class="md-label"></div>',
-    require: '?ngModel',
+    require: ['^?mdInputContainer', '?ngModel', '?^form'],
     compile: mdSwitchCompile
   };
 
@@ -61744,8 +64026,10 @@ function MdSwitch(mdCheckboxDirective, $mdUtil, $mdConstant, $parse, $$rAF, $mdG
     // No transition on initial load.
     element.addClass('md-dragging');
 
-    return function (scope, element, attr, ngModel) {
-      ngModel = ngModel || $mdUtil.fakeNgModel();
+    return function (scope, element, attr, ctrls) {
+      var containerCtrl = ctrls[0];
+      var ngModel = ctrls[1] || $mdUtil.fakeNgModel();
+      var formCtrl = ctrls[2];
 
       var disabledGetter = null;
       if (attr.disabled != null) {
@@ -61756,19 +64040,29 @@ function MdSwitch(mdCheckboxDirective, $mdUtil, $mdConstant, $parse, $$rAF, $mdG
 
       var thumbContainer = angular.element(element[0].querySelector('.md-thumb-container'));
       var switchContainer = angular.element(element[0].querySelector('.md-container'));
+      var labelContainer = angular.element(element[0].querySelector('.md-label'));
 
       // no transition on initial load
       $$rAF(function() {
         element.removeClass('md-dragging');
       });
 
-      checkboxLink(scope, element, attr, ngModel);
+      checkboxLink(scope, element, attr, ctrls);
 
       if (disabledGetter) {
         scope.$watch(disabledGetter, function(isDisabled) {
           element.attr('tabindex', isDisabled ? -1 : 0);
         });
       }
+
+      attr.$observe('mdInvert', function(newValue) {
+        var isInverted = $mdUtil.parseAttributeBoolean(newValue);
+
+        isInverted ? element.prepend(labelContainer) : element.prepend(switchContainer);
+
+        // Toggle a CSS class to update the margin.
+        element.toggleClass('md-inverted', isInverted);
+      });
 
       // These events are triggered by setup drag
       $mdGesture.register(switchContainer, 'drag');
@@ -61837,38 +64131,6 @@ function MdSwitch(mdCheckboxDirective, $mdUtil, $mdConstant, $parse, $$rAF, $mdG
 
 
 }
-
-})();
-(function(){
-"use strict";
-
-/**
- * @ngdoc module
- * @name material.components.tabs
- * @description
- *
- *  Tabs, created with the `<md-tabs>` directive provide *tabbed* navigation with different styles.
- *  The Tabs component consists of clickable tabs that are aligned horizontally side-by-side.
- *
- *  Features include support for:
- *
- *  - static or dynamic tabs,
- *  - responsive designs,
- *  - accessibility support (ARIA),
- *  - tab pagination,
- *  - external or internal tab content,
- *  - focus indicators and arrow-key navigations,
- *  - programmatic lookup and access to tab controllers, and
- *  - dynamic transitions through different tab contents.
- *
- */
-/*
- * @see js folder for tabs implementation
- */
-angular.module('material.components.tabs', [
-  'material.core',
-  'material.components.icon'
-]);
 
 })();
 (function(){
@@ -62360,6 +64622,38 @@ function MdToastProvider($$interimElementProvider) {
 
 /**
  * @ngdoc module
+ * @name material.components.tabs
+ * @description
+ *
+ *  Tabs, created with the `<md-tabs>` directive provide *tabbed* navigation with different styles.
+ *  The Tabs component consists of clickable tabs that are aligned horizontally side-by-side.
+ *
+ *  Features include support for:
+ *
+ *  - static or dynamic tabs,
+ *  - responsive designs,
+ *  - accessibility support (ARIA),
+ *  - tab pagination,
+ *  - external or internal tab content,
+ *  - focus indicators and arrow-key navigations,
+ *  - programmatic lookup and access to tab controllers, and
+ *  - dynamic transitions through different tab contents.
+ *
+ */
+/*
+ * @see js folder for tabs implementation
+ */
+angular.module('material.components.tabs', [
+  'material.core',
+  'material.components.icon'
+]);
+
+})();
+(function(){
+"use strict";
+
+/**
+ * @ngdoc module
  * @name material.components.toolbar
  */
 mdToolbarDirective.$inject = ["$$rAF", "$mdConstant", "$mdUtil", "$mdTheming", "$animate"];
@@ -62389,10 +64683,7 @@ angular.module('material.components.toolbar', [
  *   <md-toolbar>
  *
  *     <div class="md-toolbar-tools">
- *       <span>My App's Title</span>
- *
- *       <!-- fill up the space between left and right area -->
- *       <span flex></span>
+ *       <h2 md-truncate flex>My App's Title</h2>
  *
  *       <md-button>
  *         Right Bar Button
@@ -62405,6 +64696,30 @@ angular.module('material.components.toolbar', [
  *   </md-content>
  * </div>
  * </hljs>
+ *
+ * <i><b>Note:</b> The code above shows usage with the `md-truncate` component which provides an
+ * ellipsis if the title is longer than the width of the Toolbar.</i>
+ *
+ * ## CSS & Styles
+ *
+ * The `<md-toolbar>` provides a few custom CSS classes that you may use to enhance the
+ * functionality of your toolbar.
+ *
+ * <div>
+ * <docs-css-api-table>
+ *
+ *   <docs-css-selector code="md-toolbar .md-toolbar-tools">
+ *     The `md-toolbar-tools` class provides quite a bit of automatic styling for your toolbar
+ *     buttons and text. When applied, it will center the buttons and text vertically for you.
+ *   </docs-css-selector>
+ *
+ * </docs-css-api-table>
+ * </div>
+ *
+ * ### Private Classes
+ *
+ * Currently, the only private class is the `md-toolbar-transitions` class. All other classes are
+ * considered public.
  *
  * @param {boolean=} md-scroll-shrink Whether the header should shrink away as
  * the user scrolls down, and reveal itself as the user scrolls up.
@@ -62419,6 +64734,7 @@ angular.module('material.components.toolbar', [
  * @param {number=} md-shrink-speed-factor How much to change the speed of the toolbar's
  * shrinking by. For example, if 0.25 is given then the toolbar will shrink
  * at one fourth the rate at which the user scrolls down. Default 0.5.
+ *
  */
 
 function mdToolbarDirective($$rAF, $mdConstant, $mdUtil, $mdTheming, $animate) {
@@ -62604,158 +64920,306 @@ function mdToolbarDirective($$rAF, $mdConstant, $mdUtil, $mdTheming, $animate) {
  * @ngdoc module
  * @name material.components.tooltip
  */
-MdTooltipDirective.$inject = ["$timeout", "$window", "$$rAF", "$document", "$mdUtil", "$mdTheming", "$rootElement", "$animate", "$q", "$interpolate"];
+MdTooltipDirective.$inject = ["$timeout", "$window", "$$rAF", "$document", "$interpolate", "$mdUtil", "$mdPanel", "$$mdTooltipRegistry"];
 angular
-    .module('material.components.tooltip', [ 'material.core' ])
-    .directive('mdTooltip', MdTooltipDirective);
+    .module('material.components.tooltip', [
+      'material.core',
+      'material.components.panel'
+    ])
+    .directive('mdTooltip', MdTooltipDirective)
+    .service('$$mdTooltipRegistry', MdTooltipRegistry);
+
 
 /**
  * @ngdoc directive
  * @name mdTooltip
  * @module material.components.tooltip
  * @description
- * Tooltips are used to describe elements that are interactive and primarily graphical (not textual).
+ * Tooltips are used to describe elements that are interactive and primarily
+ * graphical (not textual).
  *
  * Place a `<md-tooltip>` as a child of the element it describes.
  *
- * A tooltip will activate when the user focuses, hovers over, or touches the parent.
+ * A tooltip will activate when the user hovers over, focuses, or touches the
+ * parent element.
  *
  * @usage
  * <hljs lang="html">
- * <md-button class="md-fab md-accent" aria-label="Play">
- *   <md-tooltip>
- *     Play Music
- *   </md-tooltip>
- *   <md-icon icon="img/icons/ic_play_arrow_24px.svg"></md-icon>
- * </md-button>
+ *   <md-button class="md-fab md-accent" aria-label="Play">
+ *     <md-tooltip>Play Music</md-tooltip>
+ *     <md-icon md-svg-src="img/icons/ic_play_arrow_24px.svg"></md-icon>
+ *   </md-button>
  * </hljs>
  *
- * @param {expression=} md-visible Boolean bound to whether the tooltip is currently visible.
- * @param {number=} md-delay How many milliseconds to wait to show the tooltip after the user focuses, hovers, or touches the
- * parent. Defaults to 0ms on non-touch devices and 75ms on touch.
- * @param {boolean=} md-autohide If present or provided with a boolean value, the tooltip will hide on mouse leave, regardless of focus
- * @param {string=} md-direction Which direction would you like the tooltip to go?  Supports left, right, top, and bottom.  Defaults to bottom.
+ * @param {number=} md-z-index The visual level that the tooltip will appear
+ *     in comparison with the rest of the elements of the application.
+ * @param {expression=} md-visible Boolean bound to whether the tooltip is
+ *     currently visible.
+ * @param {number=} md-delay How many milliseconds to wait to show the tooltip
+ *     after the user hovers over, focuses, or touches the parent element.
+ *     Defaults to 0ms on non-touch devices and 75ms on touch.
+ * @param {boolean=} md-autohide If present or provided with a boolean value,
+ *     the tooltip will hide on mouse leave, regardless of focus.
+ * @param {string=} md-direction The direction that the tooltip is shown,
+ *     relative to the parent element. Supports top, right, bottom, and left.
+ *     Defaults to bottom.
  */
-function MdTooltipDirective($timeout, $window, $$rAF, $document, $mdUtil, $mdTheming, $rootElement,
-                            $animate, $q, $interpolate) {
+function MdTooltipDirective($timeout, $window, $$rAF, $document, $interpolate,
+    $mdUtil, $mdPanel, $$mdTooltipRegistry) {
 
   var ENTER_EVENTS = 'focus touchstart mouseenter';
   var LEAVE_EVENTS = 'blur touchcancel mouseleave';
-  var SHOW_CLASS = 'md-show';
-  var TOOLTIP_SHOW_DELAY = 0;
-  var TOOLTIP_WINDOW_EDGE_SPACE = 8;
+  var TOOLTIP_DEFAULT_Z_INDEX = 100;
+  var TOOLTIP_DEFAULT_SHOW_DELAY = 0;
+  var TOOLTIP_DEFAULT_DIRECTION = 'bottom';
+  var TOOLTIP_DIRECTIONS = {
+    top: { x: $mdPanel.xPosition.CENTER, y: $mdPanel.yPosition.ABOVE },
+    right: { x: $mdPanel.xPosition.OFFSET_END, y: $mdPanel.yPosition.CENTER },
+    bottom: { x: $mdPanel.xPosition.CENTER, y: $mdPanel.yPosition.BELOW },
+    left: { x: $mdPanel.xPosition.OFFSET_START, y: $mdPanel.yPosition.CENTER }
+  };
 
   return {
     restrict: 'E',
-    transclude: true,
     priority: 210, // Before ngAria
-    template: '<div class="md-content _md" ng-transclude></div>',
     scope: {
-      delay: '=?mdDelay',
-      visible: '=?mdVisible',
-      autohide: '=?mdAutohide',
-      direction: '@?mdDirection'    // only expect raw or interpolated string value; not expression
+      mdZIndex: '=?mdZIndex',
+      mdDelay: '=?mdDelay',
+      mdVisible: '=?mdVisible',
+      mdAutohide: '=?mdAutohide',
+      mdDirection: '@?mdDirection' // Do not expect expressions.
     },
-    compile: function(tElement, tAttr) {
-      if (!tAttr.mdDirection) {
-        tAttr.$set('mdDirection', 'bottom');
-      }
-
-      return postLink;
-    }
+    link: linkFunc
   };
 
-  function postLink(scope, element, attr) {
+  function linkFunc(scope, element, attr) {
+    // Set constants.
+    var parent = $mdUtil.getParentWithPointerEvents(element);
+    var debouncedOnResize = $$rAF.throttle(updatePosition);
+    var mouseActive = false;
+    var origin, position, panelPosition, panelRef, autohide, showTimeout,
+        elementFocusedOnWindowBlur = null;
 
-    $mdTheming(element);
-
-    var parent        = $mdUtil.getParentWithPointerEvents(element),
-        content       = angular.element(element[0].getElementsByClassName('md-content')[0]),
-        tooltipParent = angular.element(document.body),
-        showTimeout   = null,
-        debouncedOnResize = $$rAF.throttle(function () { updatePosition(); });
-
-    if ($animate.pin) $animate.pin(element, parent);
-
-    // Initialize element
-
+    // Set defaults
     setDefaults();
-    manipulateElement();
-    bindEvents();
 
-    // Default origin transform point is 'center top'
-    // positionTooltip() is always relative to center top
-    updateContentOrigin();
-
-    configureWatchers();
+    // Set parent aria-label.
     addAriaLabel();
 
+    // Remove the element from its current DOM position.
+    element.detach();
 
-    function setDefaults () {
-      scope.delay = scope.delay || TOOLTIP_SHOW_DELAY;
-    }
+    updatePosition();
+    bindEvents();
+    configureWatchers();
 
-    function updateContentOrigin() {
-      var origin = 'center top';
-      switch (scope.direction) {
-        case 'left'  : origin =  'right center';  break;
-        case 'right' : origin =  'left center';   break;
-        case 'top'   : origin =  'center bottom'; break;
-        case 'bottom': origin =  'center top';    break;
+    function setDefaults() {
+      scope.mdZIndex = scope.mdZIndex || TOOLTIP_DEFAULT_Z_INDEX;
+      scope.mdDelay = scope.mdDelay || TOOLTIP_DEFAULT_SHOW_DELAY;
+      if (!TOOLTIP_DIRECTIONS[scope.mdDirection]) {
+        scope.mdDirection = TOOLTIP_DEFAULT_DIRECTION;
       }
-      content.css('transform-origin', origin);
     }
 
-    function onVisibleChanged (isVisible) {
-      if (isVisible) showTooltip();
-      else hideTooltip();
+    function addAriaLabel(override) {
+      if (override || !parent.attr('aria-label')) {
+        // Only interpolate the text from the HTML element because otherwise the custom text
+        // could be interpolated twice and cause XSS violations.
+        var interpolatedText = override || $interpolate(element.text().trim())(scope.$parent);
+        parent.attr('aria-label', interpolatedText);
+      }
     }
 
-    function configureWatchers () {
-      if (element[0] && 'MutationObserver' in $window) {
+    function updatePosition() {
+      setDefaults();
+
+      // If the panel has already been created, remove the current origin
+      // class from the panel element.
+      if (panelRef && panelRef.panelEl) {
+        panelRef.panelEl.removeClass(origin);
+      }
+
+      // Set the panel element origin class based off of the current
+      // mdDirection.
+      origin = 'md-origin-' + scope.mdDirection;
+
+      // Create the position of the panel based off of the mdDirection.
+      position = TOOLTIP_DIRECTIONS[scope.mdDirection];
+
+      // Using the newly created position object, use the MdPanel
+      // panelPosition API to build the panel's position.
+      panelPosition = $mdPanel.newPanelPosition()
+          .relativeTo(parent)
+          .addPanelPosition(position.x, position.y);
+
+      // If the panel has already been created, add the new origin class to
+      // the panel element and update it's position with the panelPosition.
+      if (panelRef && panelRef.panelEl) {
+        panelRef.panelEl.addClass(origin);
+        panelRef.updatePosition(panelPosition);
+      }
+    }
+
+    function bindEvents() {
+      // Add a mutationObserver where there is support for it and the need
+      // for it in the form of viable host(parent[0]).
+      if (parent[0] && 'MutationObserver' in $window) {
+        // Use a mutationObserver to tackle #2602.
         var attributeObserver = new MutationObserver(function(mutations) {
-          mutations
-            .forEach(function (mutation) {
-              if (mutation.attributeName === 'md-visible') {
-                if (!scope.visibleWatcher)
-                  scope.visibleWatcher = scope.$watch('visible', onVisibleChanged );
-              }
-              if (mutation.attributeName === 'md-direction') {
-                updatePosition(scope.direction);
-              }
+          if (isDisabledMutation(mutations)) {
+            $mdUtil.nextTick(function() {
+              setVisible(false);
             });
+          }
         });
 
-        attributeObserver.observe(element[0], { attributes: true });
-
-        // build watcher only if mdVisible is being used
-        if (attr.hasOwnProperty('mdVisible')) {
-          scope.visibleWatcher = scope.$watch('visible', onVisibleChanged );
-        }
-      } else { // MutationObserver not supported
-        scope.visibleWatcher = scope.$watch('visible', onVisibleChanged );
-        scope.$watch('direction', updatePosition );
+        attributeObserver.observe(parent[0], {
+          attributes: true
+        });
       }
 
-      var onElementDestroy = function() {
-        scope.$destroy();
-      };
+      elementFocusedOnWindowBlur = false;
+
+      $$mdTooltipRegistry.register('scroll', windowScrollEventHandler, true);
+      $$mdTooltipRegistry.register('blur', windowBlurEventHandler);
+      $$mdTooltipRegistry.register('resize', debouncedOnResize);
+
+      scope.$on('$destroy', onDestroy);
+
+      // To avoid 'synthetic clicks', we listen to mousedown instead of
+      // 'click'.
+      parent.on('mousedown', mousedownEventHandler);
+      parent.on(ENTER_EVENTS, enterEventHandler);
+
+      function isDisabledMutation(mutations) {
+        mutations.some(function(mutation) {
+          return mutation.attributeName === 'disabled' && parent[0].disabled;
+        });
+        return false;
+      }
+
+      function windowScrollEventHandler() {
+        setVisible(false);
+      }
+
+      function windowBlurEventHandler() {
+        elementFocusedOnWindowBlur = document.activeElement === parent[0];
+      }
+
+      function enterEventHandler($event) {
+        // Prevent the tooltip from showing when the window is receiving
+        // focus.
+        if ($event.type === 'focus' && elementFocusedOnWindowBlur) {
+          elementFocusedOnWindowBlur = false;
+        } else if (!scope.mdVisible) {
+          parent.on(LEAVE_EVENTS, leaveEventHandler);
+          setVisible(true);
+
+          // If the user is on a touch device, we should bind the tap away
+          // after the 'touched' in order to prevent the tooltip being
+          // removed immediately.
+          if ($event.type === 'touchstart') {
+            parent.one('touchend', function() {
+              $mdUtil.nextTick(function() {
+                $document.one('touchend', leaveEventHandler);
+              }, false);
+            });
+          }
+        }
+      }
+
+      function leaveEventHandler() {
+        autohide = scope.hasOwnProperty('mdAutohide') ?
+            scope.mdAutohide :
+            attr.hasOwnProperty('mdAutohide');
+
+        if (autohide || mouseActive ||
+            $document[0].activeElement !== parent[0]) {
+          // When a show timeout is currently in progress, then we have
+          // to cancel it, otherwise the tooltip will remain showing
+          // without focus or hover.
+          if (showTimeout) {
+            $timeout.cancel(showTimeout);
+            setVisible.queued = false;
+            showTimeout = null;
+          }
+
+          parent.off(LEAVE_EVENTS, leaveEventHandler);
+          parent.triggerHandler('blur');
+          setVisible(false);
+        }
+        mouseActive = false;
+      }
+
+      function mousedownEventHandler() {
+        mouseActive = true;
+      }
+
+      function onDestroy() {
+        $$mdTooltipRegistry.deregister('scroll', windowScrollEventHandler, true);
+        $$mdTooltipRegistry.deregister('blur', windowBlurEventHandler);
+        $$mdTooltipRegistry.deregister('resize', debouncedOnResize);
+
+        parent
+            .off(ENTER_EVENTS, enterEventHandler)
+            .off(LEAVE_EVENTS, leaveEventHandler)
+            .off('mousedown', mousedownEventHandler);
+
+        // Trigger the handler in case any of the tooltips are
+        // still visible.
+        leaveEventHandler();
+        attributeObserver && attributeObserver.disconnect();
+      }
+    }
+
+    function configureWatchers() {
+      if (element[0] && 'MutationObserver' in $window) {
+        var attributeObserver = new MutationObserver(function(mutations) {
+          mutations.forEach(function(mutation) {
+            if (mutation.attributeName === 'md-visible' &&
+                !scope.visibleWatcher ) {
+              scope.visibleWatcher = scope.$watch('mdVisible',
+                  onVisibleChanged);
+            }
+          });
+        });
+
+        attributeObserver.observe(element[0], {
+          attributes: true
+        });
+
+        // Build watcher only if mdVisible is being used.
+        if (attr.hasOwnProperty('mdVisible')) {
+          scope.visibleWatcher = scope.$watch('mdVisible',
+              onVisibleChanged);
+        }
+      } else {
+        // MutationObserver not supported
+        scope.visibleWatcher = scope.$watch('mdVisible', onVisibleChanged);
+      }
+
+      // Direction watcher
+      scope.$watch('mdDirection', updatePosition);
 
       // Clean up if the element or parent was removed via jqLite's .remove.
       // A couple of notes:
-      // - In these cases the scope might not have been destroyed, which is why we
-      // destroy it manually. An example of this can be having `md-visible="false"` and
-      // adding tooltips while they're invisible. If `md-visible` becomes true, at some
-      // point, you'd usually get a lot of inputs.
-      // - We use `.one`, not `.on`, because this only needs to fire once. If we were
-      // using `.on`, it would get thrown into an infinite loop.
-      // - This kicks off the scope's `$destroy` event which finishes the cleanup.
+      //   - In these cases the scope might not have been destroyed, which
+      //     is why we destroy it manually. An example of this can be having
+      //     `md-visible="false"` and adding tooltips while they're
+      //     invisible. If `md-visible` becomes true, at some point, you'd
+      //     usually get a lot of tooltips.
+      //   - We use `.one`, not `.on`, because this only needs to fire once.
+      //     If we were using `.on`, it would get thrown into an infinite
+      //     loop.
+      //   - This kicks off the scope's `$destroy` event which finishes the
+      //     cleanup.
       element.one('$destroy', onElementDestroy);
       parent.one('$destroy', onElementDestroy);
       scope.$on('$destroy', function() {
         setVisible(false);
-        element.remove();
+        panelRef && panelRef.destroy();
         attributeObserver && attributeObserver.disconnect();
+        element.remove();
       });
 
       // Updates the aria-label when the element text changes. This watch
@@ -62766,228 +65230,252 @@ function MdTooltipDirective($timeout, $window, $$rAF, $document, $mdUtil, $mdThe
           return element.text().trim();
         }, addAriaLabel);
       }
-    }
 
-    function addAriaLabel (override) {
-      if ((override || !parent.attr('aria-label')) && !parent.text().trim()) {
-        var rawText = override || element.text().trim();
-        var interpolatedText = $interpolate(rawText)(parent.scope());
-        parent.attr('aria-label', interpolatedText);
+      function onElementDestroy() {
+        scope.$destroy();
       }
     }
 
-    function manipulateElement () {
-      element.detach();
-      element.attr('role', 'tooltip');
-    }
-
-    function bindEvents () {
-      var mouseActive = false;
-
-      // add an mutationObserver when there is support for it
-      // and the need for it in the form of viable host(parent[0])
-      if (parent[0] && 'MutationObserver' in $window) {
-        // use an mutationObserver to tackle #2602
-        var attributeObserver = new MutationObserver(function(mutations) {
-          if (mutations.some(function (mutation) {
-              return (mutation.attributeName === 'disabled' && parent[0].disabled);
-            })) {
-              $mdUtil.nextTick(function() {
-                setVisible(false);
-              });
-          }
-        });
-
-        attributeObserver.observe(parent[0], { attributes: true});
+    function setVisible(value) {
+      // Break if passed value is already in queue or there is no queue and
+      // passed value is current in the controller.
+      if (setVisible.queued && setVisible.value === !!value ||
+          !setVisible.queued && scope.mdVisible === !!value) {
+        return;
       }
-
-      // Store whether the element was focused when the window loses focus.
-      var windowBlurHandler = function() {
-        elementFocusedOnWindowBlur = document.activeElement === parent[0];
-      };
-      var elementFocusedOnWindowBlur = false;
-
-      function windowScrollHandler() {
-        setVisible(false);
-      }
-
-      angular.element($window)
-        .on('blur', windowBlurHandler)
-        .on('resize', debouncedOnResize);
-
-      document.addEventListener('scroll', windowScrollHandler, true);
-      scope.$on('$destroy', function() {
-        angular.element($window)
-          .off('blur', windowBlurHandler)
-          .off('resize', debouncedOnResize);
-
-        parent
-          .off(ENTER_EVENTS, enterHandler)
-          .off(LEAVE_EVENTS, leaveHandler)
-          .off('mousedown', mousedownHandler);
-
-        // Trigger the handler in case any the tooltip was still visible.
-        leaveHandler();
-        document.removeEventListener('scroll', windowScrollHandler, true);
-        attributeObserver && attributeObserver.disconnect();
-      });
-
-      var enterHandler = function(e) {
-        // Prevent the tooltip from showing when the window is receiving focus.
-        if (e.type === 'focus' && elementFocusedOnWindowBlur) {
-          elementFocusedOnWindowBlur = false;
-        } else if (!scope.visible) {
-          parent.on(LEAVE_EVENTS, leaveHandler);
-          setVisible(true);
-
-          // If the user is on a touch device, we should bind the tap away after
-          // the `touched` in order to prevent the tooltip being removed immediately.
-          if (e.type === 'touchstart') {
-            parent.one('touchend', function() {
-              $mdUtil.nextTick(function() {
-                $document.one('touchend', leaveHandler);
-              }, false);
-            });
-          }
-        }
-      };
-      var leaveHandler = function () {
-        var autohide = scope.hasOwnProperty('autohide') ? scope.autohide : attr.hasOwnProperty('mdAutohide');
-
-        if (autohide || mouseActive || $document[0].activeElement !== parent[0]) {
-          // When a show timeout is currently in progress, then we have to cancel it.
-          // Otherwise the tooltip will remain showing without focus or hover.
-          if (showTimeout) {
-            $timeout.cancel(showTimeout);
-            setVisible.queued = false;
-            showTimeout = null;
-          }
-
-          parent.off(LEAVE_EVENTS, leaveHandler);
-          parent.triggerHandler('blur');
-          setVisible(false);
-        }
-        mouseActive = false;
-      };
-      var mousedownHandler = function() {
-        mouseActive = true;
-      };
-
-      // to avoid `synthetic clicks` we listen to mousedown instead of `click`
-      parent.on('mousedown', mousedownHandler);
-      parent.on(ENTER_EVENTS, enterHandler);
-    }
-
-    function setVisible (value) {
-      // break if passed value is already in queue or there is no queue and passed value is current in the scope
-      if (setVisible.queued && setVisible.value === !!value || !setVisible.queued && scope.visible === !!value) return;
       setVisible.value = !!value;
 
       if (!setVisible.queued) {
         if (value) {
           setVisible.queued = true;
           showTimeout = $timeout(function() {
-            scope.visible = setVisible.value;
+            scope.mdVisible = setVisible.value;
             setVisible.queued = false;
             showTimeout = null;
-
             if (!scope.visibleWatcher) {
-              onVisibleChanged(scope.visible);
+              onVisibleChanged(scope.mdVisible);
             }
-          }, scope.delay);
+          }, scope.mdDelay);
         } else {
           $mdUtil.nextTick(function() {
-            scope.visible = false;
-            if (!scope.visibleWatcher)
+            scope.mdVisible = false;
+            if (!scope.visibleWatcher) {
               onVisibleChanged(false);
+            }
           });
         }
       }
     }
 
+    function onVisibleChanged(isVisible) {
+      isVisible ? showTooltip() : hideTooltip();
+    }
+
     function showTooltip() {
-      //  Do not show the tooltip if the text is empty.
-      if (!element[0].textContent.trim()) return;
-
-      // Insert the element and position at top left, so we can get the position
-      // and check if we should display it
-      element.css({top: 0, left: 0});
-      tooltipParent.append(element);
-
-      // Check if we should display it or not.
-      // This handles hide-* and show-* along with any user defined css
-      if ( $mdUtil.hasComputedStyle(element, 'display', 'none')) {
-        scope.visible = false;
-        element.detach();
-        return;
+      // Do not show the tooltip if the text is empty.
+      if (!element[0].textContent.trim()) {
+        throw new Error('Text for the tooltip has not been provided. ' +
+            'Please include text within the mdTooltip element.');
       }
 
-      updatePosition();
+      if (!panelRef) {
+        var id = 'tooltip-' + $mdUtil.nextUid();
+        var attachTo = angular.element(document.body);
+        var panelAnimation = $mdPanel.newPanelAnimation()
+            .openFrom(parent)
+            .closeTo(parent)
+            .withAnimation({
+              open: 'md-show',
+              close: 'md-hide'
+            });
 
-      $animate.addClass(content, SHOW_CLASS).then(function() {
-        element.addClass(SHOW_CLASS);
+        var panelConfig = {
+          id: id,
+          attachTo: attachTo,
+          contentElement: element,
+          propagateContainerEvents: true,
+          panelClass: 'md-tooltip ' + origin,
+          animation: panelAnimation,
+          position: panelPosition,
+          zIndex: scope.mdZIndex,
+          focusOnOpen: false
+        };
+
+        panelRef = $mdPanel.create(panelConfig);
+      }
+
+      panelRef.open().then(function() {
+        panelRef.panelEl.attr('role', 'tooltip');
       });
     }
 
     function hideTooltip() {
-      $animate.removeClass(content, SHOW_CLASS).then(function(){
-        element.removeClass(SHOW_CLASS);
-        if (!scope.visible) element.detach();
-      });
+      panelRef && panelRef.close();
     }
-
-    function updatePosition() {
-      if ( !scope.visible ) return;
-
-      updateContentOrigin();
-      positionTooltip();
-    }
-
-    function positionTooltip() {
-      var tipRect = $mdUtil.offsetRect(element, tooltipParent);
-      var parentRect = $mdUtil.offsetRect(parent, tooltipParent);
-      var newPosition = getPosition(scope.direction);
-      var offsetParent = element.prop('offsetParent');
-
-      // If the user provided a direction, just nudge the tooltip onto the screen
-      // Otherwise, recalculate based on 'top' since default is 'bottom'
-      if (scope.direction) {
-        newPosition = fitInParent(newPosition);
-      } else if (offsetParent && newPosition.top > offsetParent.scrollHeight - tipRect.height - TOOLTIP_WINDOW_EDGE_SPACE) {
-        newPosition = fitInParent(getPosition('top'));
-      }
-
-      element.css({
-        left: newPosition.left + 'px',
-        top: newPosition.top + 'px'
-      });
-
-      function fitInParent (pos) {
-        var newPosition = { left: pos.left, top: pos.top };
-        newPosition.left = Math.min( newPosition.left, tooltipParent.prop('scrollWidth') - tipRect.width - TOOLTIP_WINDOW_EDGE_SPACE );
-        newPosition.left = Math.max( newPosition.left, TOOLTIP_WINDOW_EDGE_SPACE );
-        newPosition.top  = Math.min( newPosition.top,  tooltipParent.prop('scrollHeight') - tipRect.height - TOOLTIP_WINDOW_EDGE_SPACE );
-        newPosition.top  = Math.max( newPosition.top,  TOOLTIP_WINDOW_EDGE_SPACE );
-        return newPosition;
-      }
-
-      function getPosition (dir) {
-        return dir === 'left'
-          ? { left: parentRect.left - tipRect.width - TOOLTIP_WINDOW_EDGE_SPACE,
-              top: parentRect.top + parentRect.height / 2 - tipRect.height / 2 }
-          : dir === 'right'
-          ? { left: parentRect.left + parentRect.width + TOOLTIP_WINDOW_EDGE_SPACE,
-              top: parentRect.top + parentRect.height / 2 - tipRect.height / 2 }
-          : dir === 'top'
-          ? { left: parentRect.left + parentRect.width / 2 - tipRect.width / 2,
-              top: parentRect.top - tipRect.height - TOOLTIP_WINDOW_EDGE_SPACE }
-          : { left: parentRect.left + parentRect.width / 2 - tipRect.width / 2,
-              top: parentRect.top + parentRect.height + TOOLTIP_WINDOW_EDGE_SPACE };
-      }
-    }
-
   }
 
+}
+
+
+/**
+ * Service that is used to reduce the amount of listeners that are being
+ * registered on the `window` by the tooltip component. Works by collecting
+ * the individual event handlers and dispatching them from a global handler.
+ *
+ * @ngInject
+ */
+function MdTooltipRegistry() {
+  var listeners = {};
+  var ngWindow = angular.element(window);
+
+  return {
+    register: register,
+    deregister: deregister
+  };
+
+  /**
+   * Global event handler that dispatches the registered handlers in the
+   * service.
+   * @param {!Event} event Event object passed in by the browser
+   */
+  function globalEventHandler(event) {
+    if (listeners[event.type]) {
+      listeners[event.type].forEach(function(currentHandler) {
+        currentHandler.call(this, event);
+      }, this);
+    }
+  }
+
+  /**
+   * Registers a new handler with the service.
+   * @param {string} type Type of event to be registered.
+   * @param {!Function} handler Event handler.
+   * @param {boolean} useCapture Whether to use event capturing.
+   */
+  function register(type, handler, useCapture) {
+    var handlers = listeners[type] = listeners[type] || [];
+
+    if (!handlers.length) {
+      useCapture ? window.addEventListener(type, globalEventHandler, true) :
+          ngWindow.on(type, globalEventHandler);
+    }
+
+    if (handlers.indexOf(handler) === -1) {
+      handlers.push(handler);
+    }
+  }
+
+  /**
+   * Removes an event handler from the service.
+   * @param {string} type Type of event handler.
+   * @param {!Function} handler The event handler itself.
+   * @param {boolean} useCapture Whether the event handler used event capturing.
+   */
+  function deregister(type, handler, useCapture) {
+    var handlers = listeners[type];
+    var index = handlers ? handlers.indexOf(handler) : -1;
+
+    if (index > -1) {
+      handlers.splice(index, 1);
+
+      if (handlers.length === 0) {
+        useCapture ? window.removeEventListener(type, globalEventHandler, true) :
+            ngWindow.off(type, globalEventHandler);
+      }
+    }
+  }
+}
+
+})();
+(function(){
+"use strict";
+
+/**
+ * @ngdoc module
+ * @name material.components.truncate
+ */
+MdTruncateController.$inject = ["$element"];
+angular.module('material.components.truncate', ['material.core'])
+  .directive('mdTruncate', MdTruncateDirective);
+
+/**
+ * @ngdoc directive
+ * @name mdTruncate
+ * @module material.components.truncate
+ * @restrict AE
+ * @description
+ *
+ * The `md-truncate` component displays a label that will automatically clip text which is wider
+ * than the component. By default, it displays an ellipsis, but you may apply the `md-clip` CSS
+ * class to override this default and use a standard "clipping" approach.
+ *
+ * <i><b>Note:</b> The `md-truncate` component does not automatically adjust it's width. You must
+ * provide the `flex` attribute, or some other CSS-based width management. See the
+ * <a ng-href="./demo/truncate">demos</a> for examples.</i>
+ *
+ * @usage
+ *
+ * ### As an Element
+ *
+ * <hljs lang="html">
+ *   <div layout="row">
+ *     <md-button>Back</md-button>
+ *
+ *     <md-truncate flex>Chapter 1 - The Way of the Old West</md-truncate>
+ *
+ *     <md-button>Forward</md-button>
+ *   </div>
+ * </hljs>
+ *
+ * ### As an Attribute
+ *
+ * <hljs lang="html">
+ *   <h2 md-truncate style="max-width: 100px;">Some Title With a Lot of Text</h2>
+ * </hljs>
+ *
+ * ## CSS & Styles
+ *
+ * `<md-truncate>` provides two CSS classes that you may use to control the type of clipping.
+ *
+ * <i><b>Note:</b> The `md-truncate` also applies a setting of `width: 0;` when used with the `flex`
+ * attribute to fix an issue with the flex element not shrinking properly.</i>
+ *
+ * <div>
+ * <docs-css-api-table>
+ *
+ *   <docs-css-selector code=".md-ellipsis">
+ *     Assigns the "ellipsis" behavior (default) which will cut off mid-word and append an ellipsis
+ *     (&hellip;) to the end of the text.
+ *   </docs-css-selector>
+ *
+ *   <docs-css-selector code=".md-clip">
+ *     Assigns the "clipping" behavior which will simply chop off the text. This may happen
+ *     mid-word or even mid-character.
+ *   </docs-css-selector>
+ *
+ * </docs-css-api-table>
+ * </div>
+ */
+function MdTruncateDirective() {
+  return {
+    restrict: 'AE',
+
+    controller: MdTruncateController,
+    controllerAs: '$ctrl',
+    bindToController: true
+  }
+}
+
+/**
+ * Controller for the <md-truncate> component.
+ *
+ * @param $element The md-truncate element.
+ *
+ * @constructor
+ * @ngInject
+ */
+function MdTruncateController($element) {
+  $element.addClass('md-truncate');
 }
 
 })();
@@ -62998,7 +65486,7 @@ function MdTooltipDirective($timeout, $window, $$rAF, $document, $mdUtil, $mdThe
  * @ngdoc module
  * @name material.components.virtualRepeat
  */
-VirtualRepeatContainerController.$inject = ["$$rAF", "$mdUtil", "$parse", "$rootScope", "$window", "$scope", "$element", "$attrs"];
+VirtualRepeatContainerController.$inject = ["$$rAF", "$mdUtil", "$mdConstant", "$parse", "$rootScope", "$window", "$scope", "$element", "$attrs"];
 VirtualRepeatController.$inject = ["$scope", "$element", "$attrs", "$browser", "$document", "$rootScope", "$$rAF", "$mdUtil"];
 VirtualRepeatDirective.$inject = ["$parse"];
 angular.module('material.components.virtualRepeat', [
@@ -63025,8 +65513,13 @@ angular.module('material.components.virtualRepeat', [
  *
  * ### Common Issues
  *
- * > When having one-time bindings inside of the view template, the VirtualRepeat will not properly
- * > update the bindings for new items, since the view will be recycled.
+ * - When having one-time bindings inside of the view template, the VirtualRepeat will not properly
+ *   update the bindings for new items, since the view will be recycled.
+ *
+ * - Directives inside of a VirtualRepeat will be only compiled (linked) once, because those
+ *   are will be recycled items and used for other items.
+ *   The VirtualRepeat just updates the scope bindings.
+ *
  *
  * ### Notes
  *
@@ -63080,15 +65573,6 @@ function virtualRepeatContainerTemplate($element) {
 }
 
 /**
- * Maximum size, in pixels, that can be explicitly set to an element. The actual value varies
- * between browsers, but IE11 has the very lowest size at a mere 1,533,917px. Ideally we could
- * *compute* this value, but Firefox always reports an element to have a size of zero if it
- * goes over the max, meaning that we'd have to binary search for the value.
- * @const {number}
- */
-var MAX_ELEMENT_SIZE = 1533917;
-
-/**
  * Number of additional elements to render above and below the visible area inside
  * of the virtual repeat container. A higher number results in less flicker when scrolling
  * very quickly in Safari, but comes with a higher rendering and dirty-checking cost.
@@ -63097,8 +65581,8 @@ var MAX_ELEMENT_SIZE = 1533917;
 var NUM_EXTRA = 3;
 
 /** @ngInject */
-function VirtualRepeatContainerController(
-    $$rAF, $mdUtil, $parse, $rootScope, $window, $scope, $element, $attrs) {
+function VirtualRepeatContainerController($$rAF, $mdUtil, $mdConstant, $parse, $rootScope, $window, $scope,
+                                          $element, $attrs) {
   this.$rootScope = $rootScope;
   this.$scope = $scope;
   this.$element = $element;
@@ -63124,6 +65608,8 @@ function VirtualRepeatContainerController(
   this.offsetSize = parseInt(this.$attrs.mdOffsetSize, 10) || 0;
   /** @type {?string} height or width element style on the container prior to auto-shrinking. */
   this.oldElementSize = null;
+  /** @type {!number} Maximum amount of pixels allowed for a single DOM element */
+  this.maxElementPixels = $mdConstant.ELEMENT_MAX_PIXELS;
 
   if (this.$attrs.mdTopIndex) {
     /** @type {function(angular.Scope): number} Binds to topIndex on Angular scope */
@@ -63261,18 +65747,18 @@ VirtualRepeatContainerController.prototype.sizeScroller_ = function(size) {
   // If the size falls within the browser's maximum explicit size for a single element, we can
   // set the size and be done. Otherwise, we have to create children that add up the the desired
   // size.
-  if (size < MAX_ELEMENT_SIZE) {
+  if (size < this.maxElementPixels) {
     this.sizer.style[dimension] = size + 'px';
   } else {
     this.sizer.style[dimension] = 'auto';
     this.sizer.style[crossDimension] = 'auto';
 
     // Divide the total size we have to render into N max-size pieces.
-    var numChildren = Math.floor(size / MAX_ELEMENT_SIZE);
+    var numChildren = Math.floor(size / this.maxElementPixels);
 
     // Element template to clone for each max-size piece.
     var sizerChild = document.createElement('div');
-    sizerChild.style[dimension] = MAX_ELEMENT_SIZE + 'px';
+    sizerChild.style[dimension] = this.maxElementPixels + 'px';
     sizerChild.style[crossDimension] = '1px';
 
     for (var i = 0; i < numChildren; i++) {
@@ -63280,7 +65766,7 @@ VirtualRepeatContainerController.prototype.sizeScroller_ = function(size) {
     }
 
     // Re-use the element template for the remainder.
-    sizerChild.style[dimension] = (size - (numChildren * MAX_ELEMENT_SIZE)) + 'px';
+    sizerChild.style[dimension] = (size - (numChildren * this.maxElementPixels)) + 'px';
     this.sizer.appendChild(sizerChild);
   }
 };
@@ -63377,8 +65863,7 @@ VirtualRepeatContainerController.prototype.resetScroll = function() {
 
 
 VirtualRepeatContainerController.prototype.handleScroll_ = function() {
-  var doc = angular.element(document)[0];
-  var ltr = doc.dir != 'rtl' && doc.body.dir != 'rtl';
+  var ltr = document.dir != 'rtl' && document.body.dir != 'rtl';
   if(!ltr && !this.maxSize) {
     this.scroller.scrollLeft = this.scrollSize;
     this.maxSize = this.scroller.scrollLeft;
@@ -63423,9 +65908,43 @@ VirtualRepeatContainerController.prototype.handleScroll_ = function() {
  * `md-virtual-repeat` specifies an element to repeat using virtual scrolling.
  *
  * Virtual repeat is a limited substitute for ng-repeat that renders only
- * enough dom nodes to fill the container and recycling them as the user scrolls.
+ * enough DOM nodes to fill the container and recycling them as the user scrolls.
+ *
  * Arrays, but not objects are supported for iteration.
  * Track by, as alias, and (key, value) syntax are not supported.
+ *
+ * ### On-Demand Async Item Loading
+ *
+ * When using the `md-on-demand` attribute and loading some asynchronous data, the `getItemAtIndex` function will
+ * mostly return nothing.
+ *
+ * <hljs lang="js">
+ *   DynamicItems.prototype.getItemAtIndex = function(index) {
+ *     if (this.pages[index]) {
+ *       return this.pages[index];
+ *     } else {
+ *       // This is an asynchronous action and does not return any value.
+ *       this.loadPage(index);
+ *     }
+ *   };
+ * </hljs>
+ *
+ * This means that the VirtualRepeat will not have any value for the given index.<br/>
+ * After the data loading completed, the user expects the VirtualRepeat to recognize the change.
+ *
+ * To make sure that the VirtualRepeat properly detects any change, you need to run the operation
+ * in another digest.
+ *
+ * <hljs lang="js">
+ *   DynamicItems.prototype.loadPage = function(index) {
+ *     var self = this;
+ *
+ *     // Trigger a new digest by using $timeout
+ *     $timeout(function() {
+ *       self.pages[index] = Data;
+ *     });
+ *   };
+ * </hljs>
  *
  * > <b>Note:</b> Please also review the
  *   <a ng-href="api/directive/mdVirtualRepeatContainer">VirtualRepeatContainer</a> documentation
@@ -63952,11 +66471,6 @@ VirtualRepeatModelArrayLike.prototype.$$includeIndexes = function(start, end) {
   this.length = this.model.getLength();
 };
 
-
-function abstractMethod() {
-  throw Error('Non-overridden abstract method called.');
-}
-
 })();
 (function(){
 "use strict";
@@ -64038,17 +66552,17 @@ function MdWhiteframeDirective($log) {
 "use strict";
 
 
-MdAutocompleteCtrl.$inject = ["$scope", "$element", "$mdUtil", "$mdConstant", "$mdTheming", "$window", "$animate", "$rootElement", "$attrs", "$q", "$log"];angular
+MdAutocompleteCtrl.$inject = ["$scope", "$element", "$mdUtil", "$mdConstant", "$mdTheming", "$window", "$animate", "$rootElement", "$attrs", "$q", "$log", "$mdLiveAnnouncer"];angular
     .module('material.components.autocomplete')
     .controller('MdAutocompleteCtrl', MdAutocompleteCtrl);
 
-var ITEM_HEIGHT   = 41,
-    MAX_HEIGHT    = 5.5 * ITEM_HEIGHT,
+var ITEM_HEIGHT   = 48,
+    MAX_ITEMS     = 5,
     MENU_PADDING  = 8,
     INPUT_PADDING = 2; // Padding provided by `md-input-container`
 
 function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming, $window,
-                             $animate, $rootElement, $attrs, $q, $log) {
+                             $animate, $rootElement, $attrs, $q, $log, $mdLiveAnnouncer) {
 
   // Internal Variables.
   var ctrl                 = this,
@@ -64059,10 +66573,10 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
       noBlur               = false,
       selectedItemWatchers = [],
       hasFocus             = false,
-      lastCount            = 0,
       fetchesInProgress    = 0,
       enableWrapScroll     = null,
-      inputModelCtrl       = null;
+      inputModelCtrl       = null,
+      debouncedOnResize    = $mdUtil.debounce(onWindowResize);
 
   // Public Exported Variables with handlers
   defineProperty('hidden', handleHiddenChange, true);
@@ -64075,7 +66589,6 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
   ctrl.loading    = false;
   ctrl.hidden     = true;
   ctrl.index      = null;
-  ctrl.messages   = [];
   ctrl.id         = $mdUtil.nextUid();
   ctrl.isDisabled = null;
   ctrl.isRequired = null;
@@ -64098,6 +66611,15 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
   ctrl.loadingIsVisible              = loadingIsVisible;
   ctrl.positionDropdown              = positionDropdown;
 
+  /**
+   * Report types to be used for the $mdLiveAnnouncer
+   * @enum {number} Unique flag id.
+   */
+  var ReportType = {
+    Count: 1,
+    Selected: 2
+  };
+
   return init();
 
   //-- initialization methods
@@ -64106,7 +66628,13 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
    * Initialize the controller, setup watchers, gather elements
    */
   function init () {
-    $mdUtil.initOptionalProperties($scope, $attrs, { searchText: '', selectedItem: null });
+
+    $mdUtil.initOptionalProperties($scope, $attrs, {
+      searchText: '',
+      selectedItem: null,
+      clearButton: false
+    });
+
     $mdTheming($element);
     configureWatchers();
     $mdUtil.nextTick(function () {
@@ -64124,7 +66652,7 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
   function updateModelValidators() {
     if (!$scope.requireMatch || !inputModelCtrl) return;
 
-    inputModelCtrl.$setValidity('md-require-match', !!$scope.selectedItem);
+    inputModelCtrl.$setValidity('md-require-match', !!$scope.selectedItem || !$scope.searchText);
   }
 
   /**
@@ -64132,7 +66660,12 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
    * @returns {*}
    */
   function positionDropdown () {
-    if (!elements) return $mdUtil.nextTick(positionDropdown, false, $scope);
+    if (!elements) {
+      return $mdUtil.nextTick(positionDropdown, false, $scope);
+    }
+
+    var dropdownHeight = ($scope.dropdownItems || MAX_ITEMS) * ITEM_HEIGHT;
+
     var hrect  = elements.wrap.getBoundingClientRect(),
         vrect  = elements.snap.getBoundingClientRect(),
         root   = elements.root.getBoundingClientRect(),
@@ -64141,7 +66674,13 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
         left   = hrect.left - root.left,
         width  = hrect.width,
         offset = getVerticalOffset(),
+        position = $scope.dropdownPosition,
         styles;
+
+    // Automatically determine dropdown placement based on available space in viewport.
+    if (!position) {
+      position = (top > bot && root.height - hrect.bottom - MENU_PADDING < dropdownHeight) ? 'top' : 'bottom';
+    }
     // Adjust the width to account for the padding provided by `md-input-container`
     if ($attrs.mdFloatingLabel) {
       left += INPUT_PADDING;
@@ -64152,14 +66691,17 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
       minWidth: width + 'px',
       maxWidth: Math.max(hrect.right - root.left, root.right - hrect.left) - MENU_PADDING + 'px'
     };
-    if (top > bot && root.height - hrect.bottom - MENU_PADDING < MAX_HEIGHT) {
+
+    if (position === 'top') {
       styles.top       = 'auto';
       styles.bottom    = bot + 'px';
-      styles.maxHeight = Math.min(MAX_HEIGHT, hrect.top - root.top - MENU_PADDING) + 'px';
+      styles.maxHeight = Math.min(dropdownHeight, hrect.top - root.top - MENU_PADDING) + 'px';
     } else {
+      var bottomSpace = root.bottom - hrect.bottom - MENU_PADDING + $mdUtil.getViewportTop();
+
       styles.top       = (top - offset) + 'px';
       styles.bottom    = 'auto';
-      styles.maxHeight = Math.min(MAX_HEIGHT, root.bottom + $mdUtil.scrollTop() - hrect.bottom - MENU_PADDING) + 'px';
+      styles.maxHeight = Math.min(dropdownHeight, bottomSpace) + 'px';
     }
 
     elements.$.scrollContainer.css(styles);
@@ -64219,12 +66761,16 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
    */
   function configureWatchers () {
     var wait = parseInt($scope.delay, 10) || 0;
+
     $attrs.$observe('disabled', function (value) { ctrl.isDisabled = $mdUtil.parseAttributeBoolean(value, false); });
     $attrs.$observe('required', function (value) { ctrl.isRequired = $mdUtil.parseAttributeBoolean(value, false); });
     $attrs.$observe('readonly', function (value) { ctrl.isReadonly = $mdUtil.parseAttributeBoolean(value, false); });
+
     $scope.$watch('searchText', wait ? $mdUtil.debounce(handleSearchText, wait) : handleSearchText);
     $scope.$watch('selectedItem', selectedItemChange);
-    angular.element($window).on('resize', positionDropdown);
+
+    angular.element($window).on('resize', debouncedOnResize);
+
     $scope.$on('$destroy', cleanup);
   }
 
@@ -64236,7 +66782,8 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
       $mdUtil.enableScrolling();
     }
 
-    angular.element($window).off('resize', positionDropdown);
+    angular.element($window).off('resize', debouncedOnResize);
+
     if ( elements ){
       var items = ['ul', 'scroller', 'scrollContainer', 'input'];
       angular.forEach(items, function(key){
@@ -64246,35 +66793,62 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
   }
 
   /**
+   * Event handler to be called whenever the window resizes.
+   */
+  function onWindowResize() {
+    if (!ctrl.hidden) {
+      positionDropdown();
+    }
+  }
+
+  /**
    * Gathers all of the elements needed for this controller
    */
   function gatherElements () {
+
+    var snapWrap = gatherSnapWrap();
+
     elements = {
       main:  $element[0],
       scrollContainer: $element[0].querySelector('.md-virtual-repeat-container'),
       scroller: $element[0].querySelector('.md-virtual-repeat-scroller'),
       ul:    $element.find('ul')[0],
       input: $element.find('input')[0],
-      wrap:  $element.find('md-autocomplete-wrap')[0],
+      wrap:  snapWrap.wrap,
+      snap:  snapWrap.snap,
       root:  document.body
     };
 
     elements.li   = elements.ul.getElementsByTagName('li');
-    elements.snap = getSnapTarget();
     elements.$    = getAngularElements(elements);
 
     inputModelCtrl = elements.$.input.controller('ngModel');
   }
 
   /**
-   * Finds the element that the menu will base its position on
-   * @returns {*}
+   * Gathers the snap and wrap elements
+   *
    */
-  function getSnapTarget () {
-    for (var element = $element; element.length; element = element.parent()) {
-      if (angular.isDefined(element.attr('md-autocomplete-snap'))) return element[ 0 ];
+  function gatherSnapWrap() {
+    var element;
+    var value;
+    for (element = $element; element.length; element = element.parent()) {
+      value = element.attr('md-autocomplete-snap');
+      if (angular.isDefined(value)) break;
     }
-    return elements.wrap;
+
+    if (element.length) {
+      return {
+        snap: element[0],
+        wrap: (value.toLowerCase() === 'width') ? element[0] : $element.find('md-autocomplete-wrap')[0]
+      };
+    }
+
+    var wrap = $element.find('md-autocomplete-wrap')[0];
+    return {
+      snap: wrap,
+      wrap: wrap
+    };
   }
 
   /**
@@ -64300,6 +66874,10 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
   function handleHiddenChange (hidden, oldHidden) {
     if (!hidden && oldHidden) {
       positionDropdown();
+
+      // Report in polite mode, because the screenreader should finish the default description of
+      // the input. element.
+      reportMessages(true, ReportType.Count | ReportType.Selected);
 
       if (elements) {
         $mdUtil.disableScrollAround(elements.ul);
@@ -64375,7 +66953,8 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
         // Clear the searchText, when the selectedItem is set to null.
         // Do not clear the searchText, when the searchText isn't matching with the previous
         // selected item.
-        if (displayValue.toString().toLowerCase() === $scope.searchText.toLowerCase()) {
+        if (angular.isString($scope.searchText)
+          && displayValue.toString().toLowerCase() === $scope.searchText.toLowerCase()) {
           $scope.searchText = '';
         }
       });
@@ -64447,14 +67026,17 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
       if (searchText !== val) {
         $scope.selectedItem = null;
 
+
         // trigger change event if available
         if (searchText !== previousSearchText) announceTextChange();
 
         // cancel results if search text is not long enough
         if (!isMinLengthMet()) {
           ctrl.matches = [];
+
           setLoading(false);
-          updateMessages();
+          reportMessages(false, ReportType.Count);
+
         } else {
           handleQuery();
         }
@@ -64514,7 +67096,7 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
         event.preventDefault();
         ctrl.index   = Math.min(ctrl.index + 1, ctrl.matches.length - 1);
         updateScroll();
-        updateMessages();
+        reportMessages(false, ReportType.Selected);
         break;
       case $mdConstant.KEY_CODE.UP_ARROW:
         if (ctrl.loading) return;
@@ -64522,7 +67104,7 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
         event.preventDefault();
         ctrl.index   = ctrl.index < 0 ? ctrl.matches.length - 1 : Math.max(0, ctrl.index - 1);
         updateScroll();
-        updateMessages();
+        reportMessages(false, ReportType.Selected);
         break;
       case $mdConstant.KEY_CODE.TAB:
         // If we hit tab, assume that we've left the list so it will close
@@ -64839,13 +67421,29 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
     }
   }
 
+
   /**
-   * Updates the ARIA messages
+   * Reports given message types to supported screenreaders.
+   * @param {boolean} isPolite Whether the announcement should be polite.
+   * @param {!number} types Message flags to be reported to the screenreader.
    */
-  function updateMessages () {
-    getCurrentDisplayValue().then(function (msg) {
-      ctrl.messages = [ getCountMessage(), msg ];
+  function reportMessages(isPolite, types) {
+
+    var politeness = isPolite ? 'polite' : 'assertive';
+    var messages = [];
+
+    if (types & ReportType.Selected && ctrl.index !== -1) {
+      messages.push(getCurrentDisplayValue());
+    }
+
+    if (types & ReportType.Count) {
+      messages.push($q.resolve(getCountMessage()));
+    }
+
+    $q.all(messages).then(function(data) {
+      $mdLiveAnnouncer.announce(data.join(' '), politeness);
     });
+
   }
 
   /**
@@ -64853,8 +67451,6 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
    * @returns {*}
    */
   function getCountMessage () {
-    if (lastCount === ctrl.matches.length) return '';
-    lastCount = ctrl.matches.length;
     switch (ctrl.matches.length) {
       case 0:
         return 'There are no matches available.';
@@ -64929,8 +67525,8 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
 
     if ($scope.selectOnMatch) selectItemOnMatch();
 
-    updateMessages();
     positionDropdown();
+    reportMessages(true, ReportType.Count);
   }
 
   /**
@@ -65006,15 +67602,51 @@ MdAutocomplete.$inject = ["$$mdSvgRegistry"];angular
  *
  * There is an example below of how this should look.
  *
+ * ### Snapping Drop-Down
+ *
+ * You can cause the autocomplete drop-down to snap to an ancestor element by applying the
+ *     `md-autocomplete-snap` attribute to that element. You can also snap to the width of
+ *     the `md-autocomplete-snap` element by setting the attribute's value to `width`
+ *     (ie. `md-autocomplete-snap="width"`).
+ *
  * ### Notes
+ *
+ * **Autocomplete Dropdown Items Rendering**
+ *
  * The `md-autocomplete` uses the the <a ng-href="api/directive/mdVirtualRepeatContainer">VirtualRepeat</a>
  * directive for displaying the results inside of the dropdown.<br/>
+ *
  * > When encountering issues regarding the item template please take a look at the
  *   <a ng-href="api/directive/mdVirtualRepeatContainer">VirtualRepeatContainer</a> documentation.
  *
+ * **Autocomplete inside of a Virtual Repeat**
  *
- * @param {expression} md-items An expression in the format of `item in items` to iterate over
- *     matches for your search.
+ * When using the `md-autocomplete` directive inside of a
+ * <a ng-href="api/directive/mdVirtualRepeatContainer">VirtualRepeatContainer</a> the dropdown items might
+ * not update properly, because caching of the results is enabled by default.
+ *
+ * The autocomplete will then show invalid dropdown items, because the VirtualRepeat only updates the
+ * scope bindings, rather than re-creating the `md-autocomplete` and the previous cached results will be used.
+ *
+ * > To avoid such problems ensure that the autocomplete does not cache any results.
+ *
+ * <hljs lang="html">
+ *   <md-autocomplete
+ *       md-no-cache="true"
+ *       md-selected-item="selectedItem"
+ *       md-items="item in items"
+ *       md-search-text="searchText"
+ *       md-item-text="item.display">
+ *     <span>{{ item.display }}</span>
+ *   </md-autocomplete>
+ * </hljs>
+ *
+ *
+ *
+ * @param {expression} md-items An expression in the format of `item in results` to iterate over
+ *     matches for your search.<br/><br/>
+ *     The `results` expression can be also a function, which returns the results synchronously
+ *     or asynchronously (per Promise)
  * @param {expression=} md-selected-item-change An expression to be run each time a new item is
  *     selected
  * @param {expression=} md-search-text-change An expression to be run each time the search text
@@ -65031,6 +67663,7 @@ MdAutocomplete.$inject = ["$$mdSvgRegistry"];angular
  *     make suggestions
  * @param {number=} md-delay Specifies the amount of time (in milliseconds) to wait before looking
  *     for results
+ * @param {boolean=} md-clear-button Whether the clear button for the autocomplete input should show up or not.
  * @param {boolean=} md-autofocus If true, the autocomplete will be automatically focused when a `$mdDialog`,
  *     `$mdBottomsheet` or `$mdSidenav`, which contains the autocomplete, is opening. <br/><br/>
  *     Also the autocomplete will immediately focus the input element.
@@ -65054,6 +67687,15 @@ MdAutocomplete.$inject = ["$$mdSvgRegistry"];angular
  *     will select on case-insensitive match
  * @param {string=} md-escape-options Override escape key logic. Default is `blur clear`.<br/>
  *     Options: `blur | clear`, `none`
+ * @param {string=} md-dropdown-items Specifies the maximum amount of items to be shown in
+ *     the dropdown.<br/><br/>
+ *     When the dropdown doesn't fit into the viewport, the dropdown will shrink
+ *     as less as possible.
+ * @param {string=} md-dropdown-position Overrides the default dropdown position. Options: `top`, `bottom`.
+ * @param {string=} ng-trim If set to false, the search text will be not trimmed automatically.
+ *     Defaults to true.
+ * @param {string=} ng-pattern Adds the pattern validator to the ngModel of the search text.
+ *     [ngPattern Directive](https://docs.angularjs.org/api/ng/directive/ngPattern)
  *
  * @usage
  * ### Basic Example
@@ -65086,6 +67728,17 @@ MdAutocomplete.$inject = ["$$mdSvgRegistry"];angular
  * In this example, our code utilizes `md-item-template` and `md-not-found` to specify the
  *     different parts that make up our component.
  *
+ * ### Clear button for the input
+ * By default, for floating label autocomplete's the clear button is not showing up
+ * ([See specs](https://material.google.com/components/text-fields.html#text-fields-auto-complete-text-field))
+ *
+ * Nevertheless, developers are able to explicitly toggle the clear button for all types of autocomplete's.
+ *
+ * <hljs lang="html">
+ *   <md-autocomplete ... md-clear-button="true"></md-autocomplete>
+ *   <md-autocomplete ... md-clear-button="false"></md-autocomplete>
+ * </hljs>
+ *
  * ### Example with validation
  * <hljs lang="html">
  * <form name="autocompleteForm">
@@ -65108,6 +67761,34 @@ MdAutocomplete.$inject = ["$$mdSvgRegistry"];angular
  *
  * In this example, our code utilizes `md-item-template` and `ng-messages` to specify
  *     input validation for the field.
+ *
+ * ### Asynchronous Results
+ * The autocomplete items expression also supports promises, which will resolve with the query results.
+ *
+ * <hljs lang="js">
+ *   function AppController($scope, $http) {
+ *     $scope.query = function(searchText) {
+ *       return $http
+ *         .get(BACKEND_URL + '/items/' + searchText)
+ *         .then(function(data) {
+ *           // Map the response object to the data object.
+ *           return data;
+ *         });
+ *     };
+ *   }
+ * </hljs>
+ *
+ * <hljs lang="html">
+ *   <md-autocomplete
+ *       md-selected-item="selectedItem"
+ *       md-search-text="searchText"
+ *       md-items="item in query(searchText)">
+ *     <md-item-template>
+ *       <span md-highlight-text="searchText">{{item}}</span>
+ *     </md-item-template>
+ * </md-autocomplete>
+ * </hljs>
+ *
  */
 
 function MdAutocomplete ($$mdSvgRegistry) {
@@ -65137,12 +67818,33 @@ function MdAutocomplete ($$mdSvgRegistry) {
       autoselect:       '=?mdAutoselect',
       menuClass:        '@?mdMenuClass',
       inputId:          '@?mdInputId',
-      escapeOptions:    '@?mdEscapeOptions'
+      escapeOptions:    '@?mdEscapeOptions',
+      dropdownItems:    '=?mdDropdownItems',
+      dropdownPosition: '@?mdDropdownPosition',
+      clearButton:      '=?mdClearButton'
     },
-    link: function(scope, element, attrs, controller) {
-      // Retrieve the state of using a md-not-found template by using our attribute, which will
-      // be added to the element in the template function.
-      controller.hasNotFound = !!element.attr('md-has-not-found');
+    compile: function(tElement, tAttrs) {
+      var attributes = ['md-select-on-focus', 'md-no-asterisk', 'ng-trim', 'ng-pattern'];
+      var input = tElement.find('input');
+
+      attributes.forEach(function(attribute) {
+        var attrValue = tAttrs[tAttrs.$normalize(attribute)];
+
+        if (attrValue !== null) {
+          input.attr(attribute, attrValue);
+        }
+      });
+
+      return function(scope, element, attrs, ctrl) {
+        // Retrieve the state of using a md-not-found template by using our attribute, which will
+        // be added to the element in the template function.
+        ctrl.hasNotFound = !!element.attr('md-has-not-found');
+
+        // By default the inset autocomplete should show the clear button when not explicitly overwritten.
+        if (!angular.isDefined(attrs.mdClearButton) && !scope.floatingLabel) {
+          scope.clearButton = true;
+        }
+      }
     },
     template:     function (element, attr) {
       var noItemsTemplate = getNoItemsTemplate(),
@@ -65161,8 +67863,11 @@ function MdAutocomplete ($$mdSvgRegistry) {
 
       return '\
         <md-autocomplete-wrap\
-            ng-class="{ \'md-whiteframe-z1\': !floatingLabel, \'md-menu-showing\': !$mdAutocompleteCtrl.hidden }">\
+            ng-class="{ \'md-whiteframe-z1\': !floatingLabel, \
+                        \'md-menu-showing\': !$mdAutocompleteCtrl.hidden, \
+                        \'md-show-clear-button\': !!clearButton }">\
           ' + getInputElement() + '\
+          ' + getClearButton() + '\
           <md-progress-linear\
               class="' + (attr.mdFloatingLabel ? 'md-inline' : '') + '"\
               ng-if="$mdAutocompleteCtrl.loadingIsVisible()"\
@@ -65188,13 +67893,7 @@ function MdAutocomplete ($$mdSvgRegistry) {
                   </li>' + noItemsTemplate + '\
             </ul>\
           </md-virtual-repeat-container>\
-        </md-autocomplete-wrap>\
-        <aria-status\
-            class="md-visually-hidden"\
-            role="status"\
-            aria-live="assertive">\
-          <p ng-repeat="message in $mdAutocompleteCtrl.messages track by $index" ng-if="message">{{message}}</p>\
-        </aria-status>';
+        </md-autocomplete-wrap>';
 
       function getItemTemplate() {
         var templateTag = element.find('md-item-template').detach(),
@@ -65234,8 +67933,6 @@ function MdAutocomplete ($$mdSvgRegistry) {
                   ng-blur="$mdAutocompleteCtrl.blur($event)"\
                   ng-focus="$mdAutocompleteCtrl.focus($event)"\
                   aria-owns="ul-{{$mdAutocompleteCtrl.id}}"\
-                  ' + (attr.mdNoAsterisk != null ? 'md-no-asterisk="' + attr.mdNoAsterisk + '"' : '') + '\
-                  ' + (attr.mdSelectOnFocus != null ? 'md-select-on-focus=""' : '') + '\
                   aria-label="{{floatingLabel}}"\
                   aria-autocomplete="list"\
                   role="combobox"\
@@ -65255,30 +67952,34 @@ function MdAutocomplete ($$mdSvgRegistry) {
                 ng-required="$mdAutocompleteCtrl.isRequired"\
                 ng-disabled="$mdAutocompleteCtrl.isDisabled"\
                 ng-readonly="$mdAutocompleteCtrl.isReadonly"\
+                ng-minlength="inputMinlength"\
+                ng-maxlength="inputMaxlength"\
                 ng-model="$mdAutocompleteCtrl.scope.searchText"\
                 ng-keydown="$mdAutocompleteCtrl.keydown($event)"\
                 ng-blur="$mdAutocompleteCtrl.blur($event)"\
                 ng-focus="$mdAutocompleteCtrl.focus($event)"\
                 placeholder="{{placeholder}}"\
                 aria-owns="ul-{{$mdAutocompleteCtrl.id}}"\
-                ' + (attr.mdSelectOnFocus != null ? 'md-select-on-focus=""' : '') + '\
                 aria-label="{{placeholder}}"\
                 aria-autocomplete="list"\
                 role="combobox"\
                 aria-haspopup="true"\
                 aria-activedescendant=""\
-                aria-expanded="{{!$mdAutocompleteCtrl.hidden}}"/>\
-            <button\
-                type="button"\
-                tabindex="-1"\
-                ng-if="$mdAutocompleteCtrl.scope.searchText && !$mdAutocompleteCtrl.isDisabled"\
-                ng-click="$mdAutocompleteCtrl.clear($event)">\
-              <md-icon md-svg-src="' + $$mdSvgRegistry.mdClose + '"></md-icon>\
-              <span class="md-visually-hidden">Clear</span>\
-            </button>\
-                ';
+                aria-expanded="{{!$mdAutocompleteCtrl.hidden}}"/>';
         }
       }
+
+      function getClearButton() {
+        return '' +
+          '<button ' +
+              'type="button" ' +
+              'aria-label="Clear Input" ' +
+              'tabindex="-1" ' +
+              'ng-if="clearButton && $mdAutocompleteCtrl.scope.searchText && !$mdAutocompleteCtrl.isDisabled" ' +
+              'ng-click="$mdAutocompleteCtrl.clear($event)">' +
+            '<md-icon md-svg-src="' + $$mdSvgRegistry.mdClose + '"></md-icon>' +
+          '</button>';
+        }
     }
   };
 }
@@ -65743,9 +68444,9 @@ MdChipCtrl.prototype.chipMouseDown = function() {
 "use strict";
 
 
-MdChip.$inject = ["$mdTheming", "$mdUtil"];angular
-    .module('material.components.chips')
-    .directive('mdChip', MdChip);
+MdChip.$inject = ["$mdTheming", "$mdUtil", "$compile", "$timeout"];angular
+  .module('material.components.chips')
+  .directive('mdChip', MdChip);
 
 /**
  * @ngdoc directive
@@ -65778,37 +68479,47 @@ var DELETE_HINT_TEMPLATE = '\
  * @param $mdUtil
  * @ngInject
  */
-function MdChip($mdTheming, $mdUtil) {
-  var hintTemplate = $mdUtil.processTemplate(DELETE_HINT_TEMPLATE);
+function MdChip($mdTheming, $mdUtil, $compile, $timeout) {
+  var deleteHintTemplate = $mdUtil.processTemplate(DELETE_HINT_TEMPLATE);
 
   return {
     restrict: 'E',
     require: ['^?mdChips', 'mdChip'],
-    compile:  compile,
+    link: postLink,
     controller: 'MdChipCtrl'
   };
 
-  function compile(element, attr) {
-    // Append the delete template
-    element.append($mdUtil.processTemplate(hintTemplate));
+  function postLink(scope, element, attr, ctrls) {
+    var chipsController = ctrls.shift();
+    var chipController = ctrls.shift();
+    var chipContentElement = angular.element(element[0].querySelector('.md-chip-content'));
 
-    return function postLink(scope, element, attr, ctrls) {
-      var chipsController = ctrls.shift();
-      var chipController  = ctrls.shift();
-      $mdTheming(element);
+    $mdTheming(element);
 
-      if (chipsController) {
-        chipController.init(chipsController);
+    if (chipsController) {
+      chipController.init(chipsController);
 
-        angular
-          .element(element[0]
-          .querySelector('.md-chip-content'))
-          .on('blur', function () {
-            chipsController.resetSelectedChip();
-            chipsController.$scope.$applyAsync();
-          });
+      // Append our delete hint to the div.md-chip-content (which does not exist at compile time)
+      chipContentElement.append($compile(deleteHintTemplate)(scope));
+
+      // When a chip is blurred, make sure to unset (or reset) the selected chip so that tabbing
+      // through elements works properly
+      chipContentElement.on('blur', function() {
+        chipsController.resetSelectedChip();
+        chipsController.$scope.$applyAsync();
+      });
+    }
+
+    // Use $timeout to ensure we run AFTER the element has been added to the DOM so we can focus it.
+    $timeout(function() {
+      if (!chipsController) {
+        return;
       }
-    };
+
+      if (chipsController.shouldFocusLastChip) {
+        chipsController.focusLastChipThenInput();
+      }
+    });
   }
 }
 
@@ -65911,8 +68622,15 @@ function MdChipTransclude ($compile) {
 (function(){
 "use strict";
 
+/**
+ * The default chip append delay.
+ *
+ * @type {number}
+ */
+MdChipsCtrl.$inject = ["$scope", "$attrs", "$mdConstant", "$log", "$element", "$timeout", "$mdUtil"];
+var DEFAULT_CHIP_APPEND_DELAY = 300;
 
-MdChipsCtrl.$inject = ["$scope", "$attrs", "$mdConstant", "$log", "$element", "$timeout", "$mdUtil"];angular
+angular
     .module('material.components.chips')
     .controller('MdChipsCtrl', MdChipsCtrl);
 
@@ -65943,11 +68661,17 @@ function MdChipsCtrl ($scope, $attrs, $mdConstant, $log, $element, $timeout, $md
   /** @type {angular.$scope} */
   this.parent = $scope.$parent;
 
+  /** @type {$mdUtil} */
+  this.$mdUtil = $mdUtil;
+
   /** @type {$log} */
   this.$log = $log;
 
   /** @type {$element} */
   this.$element = $element;
+
+  /** @type {$attrs} */
+  this.$attrs = $attrs;
 
   /** @type {angular.NgModelController} */
   this.ngModelCtrl = null;
@@ -65972,6 +68696,20 @@ function MdChipsCtrl ($scope, $attrs, $mdConstant, $log, $element, $timeout, $md
 
   /** @type {string} */
   this.addOnBlur = $mdUtil.parseAttributeBoolean($attrs.mdAddOnBlur);
+
+  /**
+   * The text to be used as the aria-label for the input.
+   * @type {string}
+   */
+  this.inputAriaLabel = 'Chips input.';
+
+  /**
+   * Hidden hint text to describe the chips container. Used to give context to screen readers when
+   * the chips are readonly and the input cannot be selected.
+   *
+   * @type {string}
+   */
+  this.containerHint = 'Chips container. Use arrow keys to select chips.';
 
   /**
    * Hidden hint text for how to delete a chip. Used to give context to screen readers.
@@ -66011,11 +68749,106 @@ function MdChipsCtrl ($scope, $attrs, $mdConstant, $log, $element, $timeout, $md
   this.useOnRemove = false;
 
   /**
-   * Whether to use the onSelect expression to notify the component's user
-   * after selecting a chip from the list.
-   * @type {boolean}
+   * The ID of the chips wrapper which is used to build unique IDs for the chips and the aria-owns
+   * attribute.
+   *
+   * Defaults to '_md-chips-wrapper-' plus a unique number.
+   *
+   * @type {string}
    */
+  this.wrapperId = '';
+
+  /**
+   * Array of unique numbers which will be auto-generated any time the items change, and is used to
+   * create unique IDs for the aria-owns attribute.
+   *
+   * @type {Array}
+   */
+  this.contentIds = [];
+
+  /**
+   * The index of the chip that should have it's tabindex property set to 0 so it is selectable
+   * via the keyboard.
+   *
+   * @type {int}
+   */
+  this.ariaTabIndex = null;
+
+  /**
+   * After appending a chip, the chip will be focused for this number of milliseconds before the
+   * input is refocused.
+   *
+   * **Note:** This is **required** for compatibility with certain screen readers in order for
+   * them to properly allow keyboard access.
+   *
+   * @type {number}
+   */
+  this.chipAppendDelay = DEFAULT_CHIP_APPEND_DELAY;
+
+  this.init();
 }
+
+/**
+ * Initializes variables and sets up watchers
+ */
+MdChipsCtrl.prototype.init = function() {
+  var ctrl = this;
+
+  // Set the wrapper ID
+  ctrl.wrapperId = '_md-chips-wrapper-' + ctrl.$mdUtil.nextUid();
+
+  // Setup a watcher which manages the role and aria-owns attributes
+  ctrl.$scope.$watchCollection('$mdChipsCtrl.items', function() {
+    // Make sure our input and wrapper have the correct ARIA attributes
+    ctrl.setupInputAria();
+    ctrl.setupWrapperAria();
+  });
+
+  ctrl.$attrs.$observe('mdChipAppendDelay', function(newValue) {
+    ctrl.chipAppendDelay = parseInt(newValue) || DEFAULT_CHIP_APPEND_DELAY;
+  });
+};
+
+/**
+ * If we have an input, ensure it has the appropriate ARIA attributes.
+ */
+MdChipsCtrl.prototype.setupInputAria = function() {
+  var input = this.$element.find('input');
+
+  // If we have no input, just return
+  if (!input) {
+    return;
+  }
+
+  input.attr('role', 'textbox');
+  input.attr('aria-multiline', true);
+};
+
+/**
+ * Ensure our wrapper has the appropriate ARIA attributes.
+ */
+MdChipsCtrl.prototype.setupWrapperAria = function() {
+  var ctrl = this,
+      wrapper = this.$element.find('md-chips-wrap');
+
+  if (this.items && this.items.length) {
+    // Dynamically add the listbox role on every change because it must be removed when there are
+    // no items.
+    wrapper.attr('role', 'listbox');
+
+    // Generate some random (but unique) IDs for each chip
+    this.contentIds = this.items.map(function() {
+      return ctrl.wrapperId + '-chip-' + ctrl.$mdUtil.nextUid();
+    });
+
+    // Use the contentIDs above to generate the aria-owns attribute
+    wrapper.attr('aria-owns', this.contentIds.join(' '));
+  } else {
+    // If we have no items, then the role and aria-owns attributes MUST be removed
+    wrapper.removeAttr('role');
+    wrapper.removeAttr('aria-owns');
+  }
+};
 
 /**
  * Handles the keydown event on the input element: by default <enter> appends
@@ -66063,6 +68896,8 @@ MdChipsCtrl.prototype.inputKeydown = function(event) {
 
     this.appendChip(chipBuffer.trim());
     this.resetChipBuffer();
+
+    return false;
   }
 };
 
@@ -66107,7 +68942,7 @@ MdChipsCtrl.prototype.updateChipContents = function(chipIndex, chipContents){
  * @return {boolean}
  */
 MdChipsCtrl.prototype.isEditingChip = function() {
-  return !!this.$element[0].getElementsByClassName('_md-chip-editing').length;
+  return !!this.$element[0].querySelector('._md-chip-editing');
 };
 
 
@@ -66129,7 +68964,7 @@ MdChipsCtrl.prototype.isRemovable = function() {
 MdChipsCtrl.prototype.chipKeydown = function (event) {
   if (this.getChipBuffer()) return;
   if (this.isEditingChip()) return;
-  
+
   switch (event.keyCode) {
     case this.$mdConstant.KEY_CODE.BACKSPACE:
     case this.$mdConstant.KEY_CODE.DELETE:
@@ -66141,7 +68976,11 @@ MdChipsCtrl.prototype.chipKeydown = function (event) {
       break;
     case this.$mdConstant.KEY_CODE.LEFT_ARROW:
       event.preventDefault();
-      if (this.selectedChip < 0) this.selectedChip = this.items.length;
+      // By default, allow selection of -1 which will focus the input; if we're readonly, don't go
+      // below 0
+      if (this.selectedChip < 0 || (this.readonly && this.selectedChip == 0)) {
+        this.selectedChip = this.items.length;
+      }
       if (this.items.length) this.selectAndFocusChipSafe(this.selectedChip - 1);
       break;
     case this.$mdConstant.KEY_CODE.RIGHT_ARROW:
@@ -66174,11 +69013,22 @@ MdChipsCtrl.prototype.getPlaceholder = function() {
  * @param index
  */
 MdChipsCtrl.prototype.removeAndSelectAdjacentChip = function(index) {
-  var selIndex = this.getAdjacentChipIndex(index);
-  this.removeChip(index);
-  this.$timeout(angular.bind(this, function () {
-      this.selectAndFocusChipSafe(selIndex);
-  }));
+  var self = this;
+  var selIndex = self.getAdjacentChipIndex(index);
+  var wrap = this.$element[0].querySelector('md-chips-wrap');
+  var chip = this.$element[0].querySelector('md-chip[index="' + index + '"]');
+
+  self.removeChip(index);
+
+  // The dobule-timeout is currently necessary to ensure that the DOM has finalized and the select()
+  // will find the proper chip since the selection is index-based.
+  //
+  // TODO: Investigate calling from within chip $scope.$on('$destroy') to reduce/remove timeouts
+  self.$timeout(function() {
+    self.$timeout(function() {
+      self.selectAndFocusChipSafe(selIndex);
+    });
+  });
 };
 
 /**
@@ -66186,6 +69036,7 @@ MdChipsCtrl.prototype.removeAndSelectAdjacentChip = function(index) {
  */
 MdChipsCtrl.prototype.resetSelectedChip = function() {
   this.selectedChip = -1;
+  this.ariaTabIndex = null;
 };
 
 /**
@@ -66210,6 +69061,7 @@ MdChipsCtrl.prototype.getAdjacentChipIndex = function(index) {
  * @param newChip
  */
 MdChipsCtrl.prototype.appendChip = function(newChip) {
+  this.shouldFocusLastChip = true;
   if (this.useTransformChip && this.transformChip) {
     var transformedChip = this.transformChip({'$chip': newChip});
 
@@ -66232,7 +69084,8 @@ MdChipsCtrl.prototype.appendChip = function(newChip) {
   if (newChip == null || this.items.indexOf(newChip) + 1) return;
 
   // Append the new chip onto our list
-  var index = this.items.push(newChip);
+  var length = this.items.push(newChip);
+  var index = length - 1;
 
   // Update model validation
   this.ngModelCtrl.$setDirty();
@@ -66294,12 +69147,15 @@ MdChipsCtrl.prototype.useOnSelectExpression = function() {
  * model of an {@code md-autocomplete}, or, through some magic, the model
  * bound to any inpput or text area element found within a
  * {@code md-input-container} element.
- * @return {Object|string}
+ * @return {string}
  */
 MdChipsCtrl.prototype.getChipBuffer = function() {
-  return !this.userInputElement ? this.chipBuffer :
-      this.userInputNgModelCtrl ? this.userInputNgModelCtrl.$viewValue :
-          this.userInputElement[0].value;
+  var chipBuffer =  !this.userInputElement ? this.chipBuffer :
+                     this.userInputNgModelCtrl ? this.userInputNgModelCtrl.$viewValue :
+                     this.userInputElement[0].value;
+
+  // Ensure that the chip buffer is always a string. For example, the input element buffer might be falsy.
+  return angular.isString(chipBuffer) ? chipBuffer : '';
 };
 
 /**
@@ -66366,16 +69222,44 @@ MdChipsCtrl.prototype.removeChipAndFocusInput = function (index) {
  * @param index
  */
 MdChipsCtrl.prototype.selectAndFocusChipSafe = function(index) {
-  if (!this.items.length) {
-    this.selectChip(-1);
-    this.onFocus();
-    return;
+  // If we have no chips, or are asked to select a chip before the first, just focus the input
+  if (!this.items.length || index === -1) {
+    return this.focusInput();
   }
-  if (index === this.items.length) return this.onFocus();
+
+  // If we are asked to select a chip greater than the number of chips...
+  if (index >= this.items.length) {
+    if (this.readonly) {
+      // If we are readonly, jump back to the start (because we have no input)
+      index = 0;
+    } else {
+      // If we are not readonly, we should attempt to focus the input
+      return this.onFocus();
+    }
+  }
+
   index = Math.max(index, 0);
   index = Math.min(index, this.items.length - 1);
+
   this.selectChip(index);
   this.focusChip(index);
+};
+
+MdChipsCtrl.prototype.focusLastChipThenInput = function() {
+  var ctrl = this;
+
+  ctrl.shouldFocusLastChip = false;
+
+  ctrl.focusChip(this.items.length - 1);
+
+  ctrl.$timeout(function() {
+    ctrl.focusInput();
+  }, ctrl.chipAppendDelay);
+};
+
+MdChipsCtrl.prototype.focusInput = function() {
+  this.selectChip(-1);
+  this.onFocus();
 };
 
 /**
@@ -66388,7 +69272,7 @@ MdChipsCtrl.prototype.selectChip = function(index) {
 
     // Fire the onSelect if provided
     if (this.useOnSelect && this.onSelect) {
-      this.onSelect({'$chip': this.items[this.selectedChip] });
+      this.onSelect({'$chip': this.items[index] });
     }
   } else {
     this.$log.warn('Selected Chip index out of bounds; ignoring.');
@@ -66410,7 +69294,11 @@ MdChipsCtrl.prototype.selectAndFocusChip = function(index) {
  * Call `focus()` on the chip at `index`
  */
 MdChipsCtrl.prototype.focusChip = function(index) {
-  this.$element[0].querySelector('md-chip[index="' + index + '"] .md-chip-content').focus();
+  var chipContent = this.$element[0].querySelector('md-chip[index="' + index + '"] .md-chip-content');
+
+  this.ariaTabIndex = index;
+
+  chipContent.focus();
 };
 
 /**
@@ -66436,26 +69324,19 @@ MdChipsCtrl.prototype.onFocus = function () {
 
 MdChipsCtrl.prototype.onInputFocus = function () {
   this.inputHasFocus = true;
+
+  // Make sure we have the appropriate ARIA attributes
+  this.setupInputAria();
+
+  // Make sure we don't have any chips selected
   this.resetSelectedChip();
 };
 
 MdChipsCtrl.prototype.onInputBlur = function () {
   this.inputHasFocus = false;
 
-  var chipBuffer = this.getChipBuffer().trim();
-
-  // Update the custom chip validators.
-  this.validateModel();
-
-  var isModelValid = this.ngModelCtrl.$valid;
-
-  if (this.userInputNgModelCtrl) {
-    isModelValid &= this.userInputNgModelCtrl.$valid;
-  }
-
-  // Only append the chip and reset the chip buffer if the chips and input ngModel is valid.
-  if (this.addOnBlur && chipBuffer && isModelValid) {
-    this.appendChip(chipBuffer);
+  if (this.shouldAddOnBlur()) {
+    this.appendChip(this.getChipBuffer().trim());
     this.resetChipBuffer();
   }
 };
@@ -66510,8 +69391,32 @@ MdChipsCtrl.prototype.configureAutocomplete = function(ctrl) {
   }
 };
 
+/**
+ * Whether the current chip buffer should be added on input blur or not.
+ * @returns {boolean}
+ */
+MdChipsCtrl.prototype.shouldAddOnBlur = function() {
+
+  // Update the custom ngModel validators from the chips component.
+  this.validateModel();
+
+  var chipBuffer = this.getChipBuffer().trim();
+  var isModelValid = this.ngModelCtrl.$valid;
+  var isAutocompleteShowing = this.autocompleteCtrl && !this.autocompleteCtrl.hidden;
+
+  if (this.userInputNgModelCtrl) {
+    isModelValid = isModelValid && this.userInputNgModelCtrl.$valid;
+  }
+
+  return this.addOnBlur && !this.requireMatch && chipBuffer && isModelValid && !isAutocompleteShowing;
+};
+
 MdChipsCtrl.prototype.hasFocus = function () {
   return this.inputHasFocus || this.selectedChip >= 0;
+};
+
+MdChipsCtrl.prototype.contentIdFor = function(index) {
+  return this.contentIds[index];
 };
 
 })();
@@ -66547,6 +69452,9 @@ MdChipsCtrl.prototype.hasFocus = function () {
    * is also placed as a sibling to the chip content (on which there are also click listeners) to
    * avoid a nested ng-click situation.
    *
+   * <!-- Note: We no longer want to include this in the site docs; but it should remain here for
+   * future developers and those looking at the documentation.
+   *
    * <h3> Pending Features </h3>
    * <ul style="padding-left:20px;">
    *
@@ -66577,10 +69485,7 @@ MdChipsCtrl.prototype.hasFocus = function () {
    *   </ul>
    * </ul>
    *
-   * <span style="font-size:.8em;text-align:center">
-   *   Warning: This component is a WORK IN PROGRESS. If you use it now,
-   *   it will probably break on you in the future.
-   * </span>
+   * //-->
    *
    * Sometimes developers want to limit the amount of possible chips.<br/>
    * You can specify the maximum amount of chips by using the following markup.
@@ -66603,7 +69508,21 @@ MdChipsCtrl.prototype.hasFocus = function () {
    *   </md-chips>
    * </hljs>
    *
-   * @param {string=|object=} ng-model A model to bind the list of items to
+   * ### Accessibility
+   *
+   * The `md-chips` component supports keyboard and screen reader users since Version 1.1.2. In
+   * order to achieve this, we modified the chips behavior to select newly appended chips for
+   * `300ms` before re-focusing the input and allowing the user to type.
+   *
+   * For most users, this delay is small enough that it will not be noticeable but allows certain
+   * screen readers to function properly (JAWS and NVDA in particular).
+   *
+   * We introduced a new `md-chip-append-delay` option to allow developers to better control this
+   * behavior.
+   *
+   * Please refer to the documentation of this option (below) for more information.
+   *
+   * @param {string=|object=} ng-model A model to which the list of items will be bound.
    * @param {string=} placeholder Placeholder text that will be forwarded to the input.
    * @param {string=} secondary-placeholder Placeholder text that will be forwarded to the input,
    *    displayed when there is at least one item in the list
@@ -66633,11 +69552,28 @@ MdChipsCtrl.prototype.hasFocus = function () {
    * @param {expression=} md-on-select An expression which will be called when a chip is selected.
    * @param {boolean} md-require-match If true, and the chips template contains an autocomplete,
    *    only allow selection of pre-defined chips (i.e. you cannot add new ones).
+   * @param {string=} input-aria-label A string read by screen readers to identify the input.
+   * @param {string=} container-hint A string read by screen readers informing users of how to
+   *    navigate the chips. Used in readonly mode.
    * @param {string=} delete-hint A string read by screen readers instructing users that pressing
    *    the delete key will remove the chip.
    * @param {string=} delete-button-label A label for the delete button. Also hidden and read by
    *    screen readers.
    * @param {expression=} md-separator-keys An array of key codes used to separate chips.
+   * @param {string=} md-chip-append-delay The number of milliseconds that the component will select
+   *    a newly appended chip before allowing a user to type into the input. This is **necessary**
+   *    for keyboard accessibility for screen readers. It defaults to 300ms and any number less than
+   *    300 can cause issues with screen readers (particularly JAWS and sometimes NVDA).
+   *
+   *    _Available since Version 1.1.2._
+   *
+   *    **Note:** You can safely set this to `0` in one of the following two instances:
+   *
+   *    1. You are targeting an iOS or Safari-only application (where users would use VoiceOver) or
+   *    only ChromeVox users.
+   *
+   *    2. If you have utilized the `md-separator-keys` to disable the `enter` keystroke in
+   *    favor of another one (such as `,` or `;`).
    *
    * @usage
    * <hljs lang="html">
@@ -66667,25 +69603,34 @@ MdChipsCtrl.prototype.hasFocus = function () {
    *
    */
 
-
   var MD_CHIPS_TEMPLATE = '\
       <md-chips-wrap\
+          id="{{$mdChipsCtrl.wrapperId}}"\
+          tabindex="{{$mdChipsCtrl.readonly ? 0 : -1}}"\
           ng-keydown="$mdChipsCtrl.chipKeydown($event)"\
           ng-class="{ \'md-focused\': $mdChipsCtrl.hasFocus(), \
                       \'md-readonly\': !$mdChipsCtrl.ngModelCtrl || $mdChipsCtrl.readonly,\
                       \'md-removable\': $mdChipsCtrl.isRemovable() }"\
+          aria-setsize="{{$mdChipsCtrl.items.length}}"\
           class="md-chips">\
+        <span ng-if="$mdChipsCtrl.readonly" class="md-visually-hidden">\
+          {{$mdChipsCtrl.containerHint}}\
+        </span>\
         <md-chip ng-repeat="$chip in $mdChipsCtrl.items"\
             index="{{$index}}"\
             ng-class="{\'md-focused\': $mdChipsCtrl.selectedChip == $index, \'md-readonly\': !$mdChipsCtrl.ngModelCtrl || $mdChipsCtrl.readonly}">\
           <div class="md-chip-content"\
-              tabindex="-1"\
-              aria-hidden="true"\
+              tabindex="{{$mdChipsCtrl.ariaTabIndex == $index ? 0 : -1}}"\
+              id="{{$mdChipsCtrl.contentIdFor($index)}}"\
+              role="option"\
+              aria-selected="{{$mdChipsCtrl.selectedChip == $index}}" \
+              aria-posinset="{{$index}}"\
               ng-click="!$mdChipsCtrl.readonly && $mdChipsCtrl.focusChip($index)"\
               ng-focus="!$mdChipsCtrl.readonly && $mdChipsCtrl.selectChip($index)"\
               md-chip-transclude="$mdChipsCtrl.chipContentsTemplate"></div>\
           <div ng-if="$mdChipsCtrl.isRemovable()"\
                class="md-chip-remove-container"\
+               tabindex="-1"\
                md-chip-transclude="$mdChipsCtrl.chipRemoveTemplate"></div>\
         </md-chip>\
         <div class="md-chip-input-container" ng-if="!$mdChipsCtrl.readonly && $mdChipsCtrl.ngModelCtrl">\
@@ -66697,8 +69642,8 @@ MdChipsCtrl.prototype.hasFocus = function () {
         <input\
             class="md-input"\
             tabindex="0"\
+            aria-label="{{$mdChipsCtrl.inputAriaLabel}}" \
             placeholder="{{$mdChipsCtrl.getPlaceholder()}}"\
-            aria-label="{{$mdChipsCtrl.getPlaceholder()}}"\
             ng-model="$mdChipsCtrl.chipBuffer"\
             ng-focus="$mdChipsCtrl.onInputFocus()"\
             ng-blur="$mdChipsCtrl.onInputBlur()"\
@@ -66713,7 +69658,6 @@ MdChipsCtrl.prototype.hasFocus = function () {
           ng-if="$mdChipsCtrl.isRemovable()"\
           ng-click="$mdChipsCtrl.removeChipAndFocusInput($$replacedScope.$index)"\
           type="button"\
-          aria-hidden="true"\
           tabindex="-1">\
         <md-icon md-svg-src="{{ $mdChipsCtrl.mdCloseIcon }}"></md-icon>\
         <span class="md-visually-hidden">\
@@ -66754,10 +69698,13 @@ MdChipsCtrl.prototype.hasFocus = function () {
         onAdd: '&mdOnAdd',
         onRemove: '&mdOnRemove',
         onSelect: '&mdOnSelect',
+        inputAriaLabel: '@',
+        containerHint: '@',
         deleteHint: '@',
         deleteButtonLabel: '@',
         separatorKeys: '=?mdSeparatorKeys',
-        requireMatch: '=?mdRequireMatch'
+        requireMatch: '=?mdRequireMatch',
+        chipAppendDelayString: '@?mdChipAppendDelay'
       }
     };
 
@@ -66844,7 +69791,7 @@ MdChipsCtrl.prototype.hasFocus = function () {
         mdChipsCtrl.mdCloseIcon = $$mdSvgRegistry.mdClose;
 
         element
-            .attr({ 'aria-hidden': true, tabindex: -1 })
+            .attr({ tabindex: -1 })
             .on('focus', function () { mdChipsCtrl.onFocus(); });
 
         if (attr.ngModel) {
@@ -66946,19 +69893,12 @@ function MdContactChipsCtrl () {
 
 
 MdContactChipsCtrl.prototype.queryContact = function(searchText) {
-  var results = this.contactQuery({'$query': searchText});
-  return this.filterSelected ?
-      results.filter(angular.bind(this, this.filterSelectedContacts)) : results;
+  return this.contactQuery({'$query': searchText});
 };
 
 
 MdContactChipsCtrl.prototype.itemName = function(item) {
   return item[this.contactName];
-};
-
-
-MdContactChipsCtrl.prototype.filterSelectedContacts = function(contact) {
-  return this.contacts.indexOf(contact) == -1;
 };
 
 })();
@@ -66997,10 +69937,13 @@ MdContactChips.$inject = ["$mdTheming", "$mdUtil"];angular
  *    contact's email address.
  * @param {string} md-contact-image The field name of the contact object representing the
  *    contact's image.
- *
+ * @param {number=} md-min-length Specifies the minimum length of text before autocomplete will
+ *    make suggestions
  *
  * @param {expression=} filter-selected Whether to filter selected contacts from the list of
- *    suggestions shown in the autocomplete. This attribute has been removed but may come back.
+ *    suggestions shown in the autocomplete.
+ *
+ *    ***Note:** This attribute has been removed but may come back.*
  *
  *
  *
@@ -67023,6 +69966,7 @@ var MD_CONTACT_CHIPS_TEMPLATE = '\
       <md-chips class="md-contact-chips"\
           ng-model="$mdContactChipsCtrl.contacts"\
           md-require-match="$mdContactChipsCtrl.requireMatch"\
+          md-chip-append-delay="{{$mdContactChipsCtrl.chipAppendDelay}}" \
           md-autocomplete-snap>\
           <md-autocomplete\
               md-menu-class="md-contact-chips-suggestions"\
@@ -67031,6 +69975,7 @@ var MD_CONTACT_CHIPS_TEMPLATE = '\
               md-items="item in $mdContactChipsCtrl.queryContact($mdContactChipsCtrl.searchText)"\
               md-item-text="$mdContactChipsCtrl.itemName(item)"\
               md-no-cache="true"\
+              md-min-length="$mdContactChipsCtrl.minLength"\
               md-autoselect\
               placeholder="{{$mdContactChipsCtrl.contacts.length == 0 ?\
                   $mdContactChipsCtrl.placeholder : $mdContactChipsCtrl.secondaryPlaceholder}}">\
@@ -67086,17 +70031,24 @@ function MdContactChips($mdTheming, $mdUtil) {
       contactEmail: '@mdContactEmail',
       contacts: '=ngModel',
       requireMatch: '=?mdRequireMatch',
-      highlightFlags: '@?mdHighlightFlags'
+      minLength: '=?mdMinLength',
+      highlightFlags: '@?mdHighlightFlags',
+      chipAppendDelay: '@?mdChipAppendDelay'
     }
   };
 
   function compile(element, attr) {
     return function postLink(scope, element, attrs, controllers) {
+      var contactChipsController = controllers;
 
       $mdUtil.initOptionalProperties(scope, attr);
       $mdTheming(element);
 
       element.attr('tabindex', '-1');
+
+      attrs.$observe('mdChipAppendDelay', function(newValue) {
+        contactChipsController.chipAppendDelay = newValue;
+      });
     };
   }
 }
@@ -67219,19 +70171,14 @@ function MdContactChips($mdTheming, $mdUtil) {
     /** @final */
     this.$$rAF = $$rAF;
 
+    /** @final */
+    this.$mdDateLocale = $mdDateLocale;
+
     /** @final {Date} */
     this.today = this.dateUtil.createDateAtMidnight();
 
     /** @type {!angular.NgModelController} */
     this.ngModelCtrl = null;
-
-    /**
-     * The currently visible calendar view. Note the prefix on the scope value,
-     * which is necessary, because the datepicker seems to reset the real one value if the
-     * calendar is open, but the value on the datepicker's scope is empty.
-     * @type {String}
-     */
-    this.currentView = this._currentView || 'month';
 
     /** @type {String} Class applied to the selected date cell. */
     this.SELECTED_DATE_CLASS = 'md-calendar-selected-date';
@@ -67305,26 +70252,64 @@ function MdContactChips($mdTheming, $mdUtil) {
 
     var boundKeyHandler = angular.bind(this, this.handleKeyEvent);
 
+
+
+    // If use the md-calendar directly in the body without datepicker,
+    // handleKeyEvent will disable other inputs on the page.
+    // So only apply the handleKeyEvent on the body when the md-calendar inside datepicker,
+    // otherwise apply on the calendar element only.
+
+    var handleKeyElement;
+    if ($element.parent().hasClass('md-datepicker-calendar')) {
+      handleKeyElement = angular.element(document.body);
+    } else {
+      handleKeyElement = $element;
+    }
+
     // Bind the keydown handler to the body, in order to handle cases where the focused
     // element gets removed from the DOM and stops propagating click events.
-    angular.element(document.body).on('keydown', boundKeyHandler);
+    handleKeyElement.on('keydown', boundKeyHandler);
 
     $scope.$on('$destroy', function() {
-      angular.element(document.body).off('keydown', boundKeyHandler);
+      handleKeyElement.off('keydown', boundKeyHandler);
     });
 
-    if (this.minDate && this.minDate > $mdDateLocale.firstRenderableDate) {
-      this.firstRenderableDate = this.minDate;
-    } else {
-      this.firstRenderableDate = $mdDateLocale.firstRenderableDate;
+    // For Angular 1.4 and older, where there are no lifecycle hooks but bindings are pre-assigned,
+    // manually call the $onInit hook.
+    if (angular.version.major === 1 && angular.version.minor <= 4) {
+      this.$onInit();
     }
 
-    if (this.maxDate && this.maxDate < $mdDateLocale.lastRenderableDate) {
+  }
+
+  /**
+   * Angular Lifecycle hook for newer Angular versions.
+   * Bindings are not guaranteed to have been assigned in the controller, but they are in the $onInit hook.
+   */
+  CalendarCtrl.prototype.$onInit = function() {
+
+    /**
+     * The currently visible calendar view. Note the prefix on the scope value,
+     * which is necessary, because the datepicker seems to reset the real one value if the
+     * calendar is open, but the value on the datepicker's scope is empty.
+     * @type {String}
+     */
+    this.currentView = this._currentView || 'month';
+
+    var dateLocale = this.$mdDateLocale;
+
+    if (this.minDate && this.minDate > dateLocale.firstRenderableDate) {
+      this.firstRenderableDate = this.minDate;
+    } else {
+      this.firstRenderableDate = dateLocale.firstRenderableDate;
+    }
+
+    if (this.maxDate && this.maxDate < dateLocale.lastRenderableDate) {
       this.lastRenderableDate = this.maxDate;
     } else {
-      this.lastRenderableDate = $mdDateLocale.lastRenderableDate;
+      this.lastRenderableDate = dateLocale.lastRenderableDate;
     }
-  }
+  };
 
   /**
    * Sets up the controller's reference to ngModelController.
@@ -67594,7 +70579,13 @@ function MdContactChips($mdTheming, $mdUtil) {
                   'md-month-offset="$index" ' +
                   'class="md-calendar-month" ' +
                   'md-start-index="monthCtrl.getSelectedMonthIndex()" ' +
-                  'md-item-size="' + TBODY_HEIGHT + '"></tbody>' +
+                  'md-item-size="' + TBODY_HEIGHT + '">' +
+
+                // The <tr> ensures that the <tbody> will always have the
+                // proper height, even if it's empty. If it's content is
+                // compiled, the <tr> will be overwritten.
+                '<tr aria-hidden="true" style="height:' + TBODY_HEIGHT + 'px;"></tr>' +
+              '</tbody>' +
             '</table>' +
           '</md-virtual-repeat-container>' +
         '</div>',
@@ -67905,8 +70896,8 @@ function MdContactChips($mdTheming, $mdUtil) {
         // of repeated items that are linked, and then those elements have their bindings updated.
         // Since the months are not generated by bindings, we simply regenerate the entire thing
         // when the binding (offset) changes.
-        scope.$watch(function() { return monthBodyCtrl.offset; }, function(offset, oldOffset) {
-          if (offset !== oldOffset) {
+        scope.$watch(function() { return monthBodyCtrl.offset; }, function(offset) {
+          if (angular.isNumber(offset)) {
             monthBodyCtrl.generateContent();
           }
         });
@@ -68201,7 +71192,11 @@ function MdContactChips($mdTheming, $mdUtil) {
                   'md-virtual-repeat="i in yearCtrl.items" ' +
                   'md-year-offset="$index" class="md-calendar-year" ' +
                   'md-start-index="yearCtrl.getFocusedYearIndex()" ' +
-                  'md-item-size="' + TBODY_HEIGHT + '"></tbody>' +
+                  'md-item-size="' + TBODY_HEIGHT + '">' +
+                // The <tr> ensures that the <tbody> will have the proper
+                // height, even though it may be empty.
+                '<tr aria-hidden="true" style="height:' + TBODY_HEIGHT + 'px;"></tr>' +
+              '</tbody>' +
             '</table>' +
           '</md-virtual-repeat-container>' +
         '</div>',
@@ -68416,8 +71411,8 @@ function MdContactChips($mdTheming, $mdUtil) {
         yearBodyCtrl.calendarCtrl = calendarCtrl;
         yearBodyCtrl.yearCtrl = yearCtrl;
 
-        scope.$watch(function() { return yearBodyCtrl.offset; }, function(offset, oldOffset) {
-          if (offset !== oldOffset) {
+        scope.$watch(function() { return yearBodyCtrl.offset; }, function(offset) {
+          if (angular.isNumber(offset)) {
             yearBodyCtrl.generateContent();
           }
         });
@@ -68600,7 +71595,8 @@ function MdContactChips($mdTheming, $mdUtil) {
    * @property {(Array<string>)=} firstDayOfWeek The first day of the week. Sunday = 0, Monday = 1,
    *    etc.
    * @property {(function(string): Date)=} parseDate Function to parse a date object from a string.
-   * @property {(function(Date): string)=} formatDate Function to format a date object to a string.
+   * @property {(function(Date, string): string)=} formatDate Function to format a date object to a
+   *     string. The datepicker directive also provides the time zone, if it was specified.
    * @property {(function(Date): string)=} monthHeaderFormatter Function that returns the label for
    *     a month given a date.
    * @property {(function(Date): string)=} monthFormatter Function that returns the full name of a month
@@ -68740,9 +71736,10 @@ function MdContactChips($mdTheming, $mdUtil) {
       /**
        * Default date-to-string formatting function.
        * @param {!Date} date
+       * @param {string=} timezone
        * @returns {string}
        */
-      function defaultFormatDate(date) {
+      function defaultFormatDate(date, timezone) {
         if (!date) {
           return '';
         }
@@ -68754,12 +71751,12 @@ function MdContactChips($mdTheming, $mdUtil) {
         // d.toLocaleString(); // == "10/7/1992, 11:00:00 PM"
         var localeTime = date.toLocaleTimeString();
         var formatDate = date;
-        if (date.getHours() == 0 &&
+        if (date.getHours() === 0 &&
             (localeTime.indexOf('11:') !== -1 || localeTime.indexOf('23:') !== -1)) {
           formatDate = new Date(date.getFullYear(), date.getMonth(), date.getDate(), 1, 0, 0);
         }
 
-        return $filter('date')(formatDate, 'M/d/yyyy');
+        return $filter('date')(formatDate, 'M/d/yyyy', timezone);
       }
 
       /**
@@ -69077,7 +72074,7 @@ function MdContactChips($mdTheming, $mdUtil) {
      * @return {boolean} Whether the date is a valid Date.
      */
     function isValidDate(date) {
-      return date != null && date.getTime && !isNaN(date.getTime());
+      return date && date.getTime && !isNaN(date.getTime());
     }
 
     /**
@@ -69211,7 +72208,7 @@ function MdContactChips($mdTheming, $mdUtil) {
   // TODO(jelbourn): input behavior (masking? auto-complete?)
 
 
-  DatePickerCtrl.$inject = ["$scope", "$element", "$attrs", "$window", "$mdConstant", "$mdTheming", "$mdUtil", "$mdDateLocale", "$$mdDateUtil", "$$rAF", "$mdGesture", "$filter"];
+  DatePickerCtrl.$inject = ["$scope", "$element", "$attrs", "$window", "$mdConstant", "$mdTheming", "$mdUtil", "$mdDateLocale", "$$mdDateUtil", "$$rAF", "$filter"];
   datePickerDirective.$inject = ["$$mdSvgRegistry", "$mdUtil", "$mdAria", "inputDirective"];
   angular.module('material.components.datepicker')
       .directive('mdDatepicker', datePickerDirective);
@@ -69227,6 +72224,8 @@ function MdContactChips($mdTheming, $mdUtil) {
    * @param {expression=} ng-change Expression evaluated when the model value changes.
    * @param {expression=} ng-focus Expression evaluated when the input is focused or the calendar is opened.
    * @param {expression=} ng-blur Expression evaluated when focus is removed from the input or the calendar is closed.
+   * @param {boolean=} ng-disabled Whether the datepicker is disabled.
+   * @param {boolean=} ng-required Whether a value is required for the datepicker.
    * @param {Date=} md-min-date Expression representing a min date (inclusive).
    * @param {Date=} md-max-date Expression representing a max date (inclusive).
    * @param {(function(Date): boolean)=} md-date-filter Function expecting a date and returning a boolean whether it can be selected or not.
@@ -69239,8 +72238,9 @@ function MdContactChips($mdTheming, $mdUtil) {
    * * `"all"` - Hides all icons.
    * * `"calendar"` - Only hides the calendar icon.
    * * `"triangle"` - Only hides the triangle icon.
-   * @param {boolean=} ng-disabled Whether the datepicker is disabled.
-   * @param {boolean=} ng-required Whether a value is required for the datepicker.
+   * @param {Object=} md-date-locale Allows for the values from the `$mdDateLocaleProvider` to be
+   * ovewritten on a per-element basis (e.g. `msgOpenCalendar` can be overwritten with
+   * `md-date-locale="{ msgOpenCalendar: 'Open a special calendar' }"`).
    *
    * @description
    * `<md-datepicker>` is a component used to select a single date.
@@ -69278,13 +72278,19 @@ function MdContactChips($mdTheming, $mdUtil) {
                      'md-svg-src="' + $$mdSvgRegistry.mdCalendar + '"></md-icon>' +
           '</md-button>';
 
-        var triangleButton = (hiddenIcons === 'all' || hiddenIcons === 'triangle') ? '' :
-          '<md-button type="button" md-no-ink ' +
+        var triangleButton = '';
+
+        if (hiddenIcons !== 'all' && hiddenIcons !== 'triangle') {
+          triangleButton = '' +
+            '<md-button type="button" md-no-ink ' +
               'class="md-datepicker-triangle-button md-icon-button" ' +
               'ng-click="ctrl.openCalendarPane($event)" ' +
-              'aria-label="{{::ctrl.dateLocale.msgOpenCalendar}}">' +
+              'aria-label="{{::ctrl.locale.msgOpenCalendar}}">' +
             '<div class="md-datepicker-expand-triangle"></div>' +
           '</md-button>';
+
+          tElement.addClass(HAS_TRIANGLE_ICON_CLASS);
+        }
 
         return calendarButton +
         '<div class="md-datepicker-input-container" ng-class="{\'md-datepicker-focused\': ctrl.isFocused}">' +
@@ -69292,18 +72298,19 @@ function MdContactChips($mdTheming, $mdUtil) {
             (ariaLabelValue ? 'aria-label="' + ariaLabelValue + '" ' : '') +
             'class="md-datepicker-input" ' +
             'aria-haspopup="true" ' +
+            'aria-expanded="{{ctrl.isCalendarOpen}}" ' +
             'ng-focus="ctrl.setFocused(true)" ' +
             'ng-blur="ctrl.setFocused(false)"> ' +
             triangleButton +
         '</div>' +
 
         // This pane will be detached from here and re-attached to the document body.
-        '<div class="md-datepicker-calendar-pane md-whiteframe-z1">' +
+        '<div class="md-datepicker-calendar-pane md-whiteframe-z1" id="{{::ctrl.calendarPaneId}}">' +
           '<div class="md-datepicker-input-mask">' +
             '<div class="md-datepicker-input-mask-opaque"></div>' +
           '</div>' +
           '<div class="md-datepicker-calendar">' +
-            '<md-calendar role="dialog" aria-label="{{::ctrl.dateLocale.msgCalendar}}" ' +
+            '<md-calendar role="dialog" aria-label="{{::ctrl.locale.msgCalendar}}" ' +
                 'md-current-view="{{::ctrl.currentView}}"' +
                 'md-min-date="ctrl.minDate"' +
                 'md-max-date="ctrl.maxDate"' +
@@ -69321,7 +72328,8 @@ function MdContactChips($mdTheming, $mdUtil) {
         currentView: '@mdCurrentView',
         dateFilter: '=mdDateFilter',
         isOpen: '=?mdIsOpen',
-        debounceInterval: '=mdDebounceInterval'
+        debounceInterval: '=mdDebounceInterval',
+        dateLocale: '=mdDateLocale'
       },
       controller: DatePickerCtrl,
       controllerAs: 'ctrl',
@@ -69353,7 +72361,7 @@ function MdContactChips($mdTheming, $mdUtil) {
           mdInputContainer.input = element;
           mdInputContainer.element
             .addClass(INPUT_CONTAINER_CLASS)
-            .toggleClass(HAS_ICON_CLASS, attr.mdHideIcons !== 'calendar' && attr.mdHideIcons !== 'all');
+            .toggleClass(HAS_CALENDAR_ICON_CLASS, attr.mdHideIcons !== 'calendar' && attr.mdHideIcons !== 'all');
 
           if (!mdInputContainer.label) {
             $mdAria.expect(element, 'aria-label', attr.mdPlaceholder);
@@ -69394,7 +72402,10 @@ function MdContactChips($mdTheming, $mdUtil) {
   var INPUT_CONTAINER_CLASS = '_md-datepicker-floating-label';
 
   /** Class to be applied when the calendar icon is enabled. */
-  var HAS_ICON_CLASS = '_md-datepicker-has-calendar-icon';
+  var HAS_CALENDAR_ICON_CLASS = '_md-datepicker-has-calendar-icon';
+
+  /** Class to be applied when the triangle icon is enabled. */
+  var HAS_TRIANGLE_ICON_CLASS = '_md-datepicker-has-triangle-icon';
 
   /** Default time in ms to debounce input event by. */
   var DEFAULT_DEBOUNCE_INTERVAL = 500;
@@ -69419,19 +72430,19 @@ function MdContactChips($mdTheming, $mdUtil) {
    */
   var CALENDAR_PANE_WIDTH = 360;
 
+  /** Used for checking whether the current user agent is on iOS or Android. */
+  var IS_MOBILE_REGEX = /ipad|iphone|ipod|android/i;
+
   /**
    * Controller for md-datepicker.
    *
    * @ngInject @constructor
    */
   function DatePickerCtrl($scope, $element, $attrs, $window, $mdConstant,
-    $mdTheming, $mdUtil, $mdDateLocale, $$mdDateUtil, $$rAF, $mdGesture, $filter) {
+    $mdTheming, $mdUtil, $mdDateLocale, $$mdDateUtil, $$rAF, $filter) {
 
     /** @final */
     this.$window = $window;
-
-    /** @final */
-    this.dateLocale = $mdDateLocale;
 
     /** @final */
     this.dateUtil = $$mdDateUtil;
@@ -69444,6 +72455,9 @@ function MdContactChips($mdTheming, $mdUtil) {
 
     /** @final */
     this.$$rAF = $$rAF;
+
+    /** @final */
+    this.$mdDateLocale = $mdDateLocale;
 
     /**
      * The root document element. This is used for attaching a top-level click handler to
@@ -69514,7 +72528,7 @@ function MdContactChips($mdTheming, $mdUtil) {
     this.calendarPaneOpenedFrom = null;
 
     /** @type {String} Unique id for the calendar pane. */
-    this.calendarPane.id = 'md-date-pane' + $mdUtil.nextUid();
+    this.calendarPaneId = 'md-date-pane-' + $mdUtil.nextUid();
 
     /** Pre-bound click handler is saved so that the event listener can be removed. */
     this.bodyClickHandler = angular.bind(this, this.handleBodyClick);
@@ -69524,7 +72538,9 @@ function MdContactChips($mdTheming, $mdUtil) {
      * the resize event doesn't make sense on mobile and can have a negative impact since it
      * triggers whenever the browser zooms in on a focused input.
      */
-    this.windowEventName = ($mdGesture.isIos || $mdGesture.isAndroid) ? 'orientationchange' : 'resize';
+    this.windowEventName = IS_MOBILE_REGEX.test(
+      navigator.userAgent || navigator.vendor || window.opera
+    ) ? 'orientationchange' : 'resize';
 
     /** Pre-bound close handler so that the event listener can be removed. */
     this.windowEventHandler = $mdUtil.debounce(angular.bind(this, this.closeCalendarPane), 100);
@@ -69551,12 +72567,10 @@ function MdContactChips($mdTheming, $mdUtil) {
       $attrs.$set('tabindex', '-1');
     }
 
+    $attrs.$set('aria-owns', this.calendarPaneId);
+
     $mdTheming($element);
     $mdTheming(angular.element(this.calendarPane));
-
-    this.installPropertyInterceptors();
-    this.attachChangeListeners();
-    this.attachInteractionListeners();
 
     var self = this;
 
@@ -69575,7 +72589,32 @@ function MdContactChips($mdTheming, $mdUtil) {
         }
       });
     }
+
+    // For Angular 1.4 and older, where there are no lifecycle hooks but bindings are pre-assigned,
+    // manually call the $onInit hook.
+    if (angular.version.major === 1 && angular.version.minor <= 4) {
+      this.$onInit();
+    }
+
   }
+
+  /**
+   * Angular Lifecycle hook for newer Angular versions.
+   * Bindings are not guaranteed to have been assigned in the controller, but they are in the $onInit hook.
+   */
+  DatePickerCtrl.prototype.$onInit = function() {
+
+    /**
+     * Holds locale-specific formatters, parsers, labels etc. Allows
+     * the user to override specific ones from the $mdDateLocale provider.
+     * @type {!Object}
+     */
+    this.locale = this.dateLocale ? angular.extend({}, this.$mdDateLocale, this.dateLocale) : this.$mdDateLocale;
+
+    this.installPropertyInterceptors();
+    this.attachChangeListeners();
+    this.attachInteractionListeners();
+  };
 
   /**
    * Sets up the controller's reference to ngModelController and
@@ -69610,17 +72649,25 @@ function MdContactChips($mdTheming, $mdUtil) {
             'Currently the model is a: ' + (typeof value));
       }
 
-      self.date = value;
-      self.inputElement.value = self.dateLocale.formatDate(value);
-      self.mdInputContainer && self.mdInputContainer.setHasValue(!!value);
-      self.resizeInputElement();
-      self.updateErrorState();
+      self.onExternalChange(value);
 
       return value;
     });
 
     // Responds to external error state changes (e.g. ng-required based on another input).
     ngModelCtrl.$viewChangeListeners.unshift(angular.bind(this, this.updateErrorState));
+
+    // Forwards any events from the input to the root element. This is necessary to get `updateOn`
+    // working for events that don't bubble (e.g. 'blur') since Angular binds the handlers to
+    // the `<md-datepicker>`.
+    var updateOn = self.$mdUtil.getModelOption(ngModelCtrl, 'updateOn');
+
+    if (updateOn) {
+      this.ngInputElement.on(
+        updateOn,
+        angular.bind(this.$element, this.$element.triggerHandler, updateOn)
+      );
+    }
   };
 
   /**
@@ -69633,12 +72680,8 @@ function MdContactChips($mdTheming, $mdUtil) {
 
     self.$scope.$on('md-calendar-change', function(event, date) {
       self.setModelValue(date);
-      self.date = date;
-      self.inputElement.value = self.dateLocale.formatDate(date);
-      self.mdInputContainer && self.mdInputContainer.setHasValue(!!date);
+      self.onExternalChange(date);
       self.closeCalendarPane();
-      self.resizeInputElement();
-      self.updateErrorState();
     });
 
     self.ngInputElement.on('input', angular.bind(self, self.resizeInputElement));
@@ -69755,12 +72798,7 @@ function MdContactChips($mdTheming, $mdUtil) {
       this.ngModelCtrl.$setValidity('valid', date == null);
     }
 
-    // TODO(jelbourn): Change this to classList.toggle when we stop using PhantomJS in unit tests
-    // because it doesn't conform to the DOMTokenList spec.
-    // See https://github.com/ariya/phantomjs/issues/12782.
-    if (!this.ngModelCtrl.$valid) {
-      this.inputContainer.classList.add(INVALID_CLASS);
-    }
+    angular.element(this.inputContainer).toggleClass(INVALID_CLASS, !this.ngModelCtrl.$valid);
   };
 
   /** Clears any error flags set by `updateErrorState`. */
@@ -69782,14 +72820,14 @@ function MdContactChips($mdTheming, $mdUtil) {
    */
   DatePickerCtrl.prototype.handleInputEvent = function() {
     var inputString = this.inputElement.value;
-    var parsedDate = inputString ? this.dateLocale.parseDate(inputString) : null;
+    var parsedDate = inputString ? this.locale.parseDate(inputString) : null;
     this.dateUtil.setDateTimeToMidnight(parsedDate);
 
     // An input string is valid if it is either empty (representing no date)
     // or if it parses to a valid date that the user is allowed to select.
     var isValidInput = inputString == '' || (
       this.dateUtil.isValidDate(parsedDate) &&
-      this.dateLocale.isDateComplete(inputString) &&
+      this.locale.isDateComplete(inputString) &&
       this.isDateEnabled(parsedDate)
     );
 
@@ -70054,7 +73092,22 @@ function MdContactChips($mdTheming, $mdUtil) {
    * @param {Date=} value Date to be set as the model value.
    */
   DatePickerCtrl.prototype.setModelValue = function(value) {
-    this.ngModelCtrl.$setViewValue(this.ngDateFilter(value, 'yyyy-MM-dd'));
+    var timezone = this.$mdUtil.getModelOption(this.ngModelCtrl, 'timezone');
+    this.ngModelCtrl.$setViewValue(this.ngDateFilter(value, 'yyyy-MM-dd', timezone));
+  };
+
+  /**
+   * Updates the datepicker when a model change occurred externally.
+   * @param {Date=} value Value that was set to the model.
+   */
+  DatePickerCtrl.prototype.onExternalChange = function(value) {
+    var timezone = this.$mdUtil.getModelOption(this.ngModelCtrl, 'timezone');
+
+    this.date = value;
+    this.inputElement.value = this.locale.formatDate(value, timezone);
+    this.mdInputContainer && this.mdInputContainer.setHasValue(!!value);
+    this.resizeInputElement();
+    this.updateErrorState();
   };
 })();
 
@@ -70104,7 +73157,7 @@ angular
  * like `"social:cake"`.
  *
  * When using SVGs, both external SVGs (via URLs) or sets of SVGs [from icon sets] can be
- * easily loaded and used.When use font-icons, developers must following three (3) simple steps:
+ * easily loaded and used. When using font-icons, developers must follow three (3) simple steps:
  *
  * <ol>
  * <li>Load the font library. e.g.<br/>
@@ -70112,13 +73165,18 @@ angular
  *    rel="stylesheet">`
  * </li>
  * <li>
- *   Use either (a) font-icon class names or (b) font ligatures to render the font glyph by using
- *   its textual name
+ *   Use either (a) font-icon class names or (b) a fontset and a font ligature to render the font glyph by
+ *   using its textual name _or_ numerical character reference. Note that `material-icons` is the default fontset when
+ *   none is specified.
  * </li>
- * <li>
- *   Use `<md-icon md-font-icon="classname" />` or <br/>
- *   use `<md-icon md-font-set="font library classname or alias"> textual_name </md-icon>` or <br/>
- *   use `<md-icon md-font-set="font library classname or alias"> numerical_character_reference </md-icon>`
+ * <li> Use any of the following templates: <br/>
+ *   <ul>
+ *     <li>`<md-icon md-font-icon="classname"></md-icon>`</li>
+ *     <li>`<md-icon md-font-set="font library classname or alias">textual_name</md-icon>`</li>
+ *     <li>`<md-icon> numerical_character_reference </md-icon>`</li>
+ *     <li>`<md-icon ng_bind="'textual_name'"></md-icon>`</li>
+ *     <li>`<md-icon ng-bind="scopeVariable"></md-icon>`</li>
+ *   </ul>
  * </li>
  * </ol>
  *
@@ -70135,6 +73193,19 @@ angular
  * <ul>
  * <li>https://design.google.com/icons/</li>
  * <li>https://design.google.com/icons/#ic_accessibility</li>
+ * </ul>
+ *
+ * ### Localization
+ *
+ * Because an `md-icon` element's text content is not intended to translated, it is recommended to declare the text
+ * content for an `md-icon` element in its start tag. Instead of using the HTML text content, consider using `ng-bind`
+ * with a scope variable or literal string.
+ *
+ * Examples:
+ *
+ * <ul>
+ *   <li>`<md-icon ng-bind="myIconVariable"></md-icon>`</li>
+ *   <li>`<md-icon ng-bind="'menu'"></md-icon>`
  * </ul>
  *
  * <h2 id="material_design_icons">Material Design Icons</h2>
@@ -70971,7 +74042,7 @@ function MdIconService(config, $templateRequest, $q, $log, $mdUtil, $sce) {
 
 
 
-MenuController.$inject = ["$mdMenu", "$attrs", "$element", "$scope", "$mdUtil", "$timeout", "$rootScope", "$q"];
+MenuController.$inject = ["$mdMenu", "$attrs", "$element", "$scope", "$mdUtil", "$timeout", "$rootScope", "$q", "$log"];
 angular
     .module('material.components.menu')
     .controller('mdMenuCtrl', MenuController);
@@ -70979,7 +74050,7 @@ angular
 /**
  * @ngInject
  */
-function MenuController($mdMenu, $attrs, $element, $scope, $mdUtil, $timeout, $rootScope, $q) {
+function MenuController($mdMenu, $attrs, $element, $scope, $mdUtil, $timeout, $rootScope, $q, $log) {
 
   var prefixer = $mdUtil.prefixer();
   var menuContainer;
@@ -71113,9 +74184,6 @@ function MenuController($mdMenu, $attrs, $element, $scope, $mdUtil, $timeout, $r
     });
   };
 
-  // Expose a open function to the child scope for html to use
-  $scope.$mdOpenMenu = this.open;
-
   this.onIsOpenChanged = function(isOpen) {
     if (isOpen) {
       menuContainer.attr('aria-hidden', 'false');
@@ -71134,7 +74202,7 @@ function MenuController($mdMenu, $attrs, $element, $scope, $mdUtil, $timeout, $r
     var focusTarget = menuContainer[0]
       .querySelector(prefixer.buildSelector(['md-menu-focus-target', 'md-autofocus']));
 
-    if (!focusTarget) focusTarget = menuContainer[0].querySelector('.md-button');
+    if (!focusTarget) focusTarget = menuContainer[0].querySelector('.md-button:not([disabled])');
     focusTarget.focus();
   };
 
@@ -71206,6 +74274,18 @@ function MenuController($mdMenu, $attrs, $element, $scope, $mdUtil, $timeout, $r
       throw Error('Invalid offsets specified. Please follow format <x, y> or <n>');
     }
   };
+
+  // Functionality that is exposed in the view.
+  $scope.$mdMenu = {
+    open: this.open,
+    close: this.close
+  };
+
+  // Deprecated APIs
+  $scope.$mdOpenMenu = angular.bind(this, function() {
+    $log.warn('mdMenu: The $mdOpenMenu method is deprecated. Please use `$mdMenu.open`.');
+    return this.open.apply(this, arguments);
+  });
 }
 
 })();
@@ -71224,9 +74304,10 @@ function MenuController($mdMenu, $attrs, $element, $scope, $mdUtil, $timeout, $r
  *
  * Every `md-menu` must specify exactly two child elements. The first element is what is
  * left in the DOM and is used to open the menu. This element is called the trigger element.
- * The trigger element's scope has access to `$mdOpenMenu($event)`
+ * The trigger element's scope has access to `$mdMenu.open($event)`
  * which it may call to open the menu. By passing $event as argument, the
- * corresponding event is stopped from propagating up the DOM-tree.
+ * corresponding event is stopped from propagating up the DOM-tree. Similarly, `$mdMenu.close()`
+ * can be used to close the menu.
  *
  * The second element is the `md-menu-content` element which represents the
  * contents of the menu when it is open. Typically this will contain `md-menu-item`s,
@@ -71235,7 +74316,7 @@ function MenuController($mdMenu, $attrs, $element, $scope, $mdUtil, $timeout, $r
  * <hljs lang="html">
  * <md-menu>
  *  <!-- Trigger element is a md-button with an icon -->
- *  <md-button ng-click="$mdOpenMenu($event)" class="md-icon-button" aria-label="Open sample menu">
+ *  <md-button ng-click="$mdMenu.open($event)" class="md-icon-button" aria-label="Open sample menu">
  *    <md-icon md-svg-icon="call:phone"></md-icon>
  *  </md-button>
  *  <md-menu-content>
@@ -71277,7 +74358,7 @@ function MenuController($mdMenu, $attrs, $element, $scope, $mdUtil, $timeout, $r
  *
  * <hljs lang="html">
  * <md-menu>
- *  <md-button ng-click="$mdOpenMenu($event)" class="md-icon-button" aria-label="Open some menu">
+ *  <md-button ng-click="$mdMenu.open($event)" class="md-icon-button" aria-label="Open some menu">
  *    <md-icon md-menu-origin md-svg-icon="call:phone"></md-icon>
  *  </md-button>
  *  <md-menu-content>
@@ -71310,16 +74391,16 @@ function MenuController($mdMenu, $attrs, $element, $scope, $mdUtil, $timeout, $r
  * This offset is provided in the format of `x y` or `n` where `n` will be used
  * in both the `x` and `y` axis.
  *
- * For example, to move a menu by `2px` from the top, we can use:
+ * For example, to move a menu by `2px` down from the top, we can use:
  * <hljs lang="html">
- * <md-menu md-offset="2 0">
+ * <md-menu md-offset="0 2">
  *   <!-- menu-content -->
  * </md-menu>
  * </hljs>
  *
  * ### Auto Focus
  * By default, when a menu opens, `md-menu` focuses the first button in the menu content.
- * 
+ *
  * But sometimes you would like to focus another specific menu item instead of the first.<br/>
  * This can be done by applying the `md-autofocus` directive on the given element.
  *
@@ -71337,22 +74418,24 @@ function MenuController($mdMenu, $attrs, $element, $scope, $mdUtil, $timeout, $r
  * Sometimes you would like to be able to click on a menu item without having the menu
  * close. To do this, ngMaterial exposes the `md-prevent-menu-close` attribute which
  * can be added to a button inside a menu to stop the menu from automatically closing.
- * You can then close the menu programatically by injecting `$mdMenu` and calling 
- * `$mdMenu.hide()`.
+ * You can then close the menu either by using `$mdMenu.close()` in the template,
+ * or programatically by injecting `$mdMenu` and calling `$mdMenu.hide()`.
  *
  * <hljs lang="html">
- * <md-menu-item>
- *   <md-button ng-click="doSomething()" aria-label="Do something" md-prevent-menu-close="md-prevent-menu-close">
- *     <md-icon md-menu-align-target md-svg-icon="call:phone"></md-icon>
- *     Do Something
- *   </md-button>
- * </md-menu-item>
+ * <md-menu-content ng-mouseleave="$mdMenu.close()">
+ *   <md-menu-item>
+ *     <md-button ng-click="doSomething()" aria-label="Do something" md-prevent-menu-close="md-prevent-menu-close">
+ *       <md-icon md-menu-align-target md-svg-icon="call:phone"></md-icon>
+ *       Do Something
+ *     </md-button>
+ *   </md-menu-item>
+ * </md-menu-content>
  * </hljs>
  *
  * @usage
  * <hljs lang="html">
  * <md-menu>
- *  <md-button ng-click="$mdOpenMenu($event)" class="md-icon-button">
+ *  <md-button ng-click="$mdMenu.open($event)" class="md-icon-button">
  *    <md-icon md-svg-icon="call:phone"></md-icon>
  *  </md-button>
  *  <md-menu-content>
@@ -71363,7 +74446,7 @@ function MenuController($mdMenu, $attrs, $element, $scope, $mdUtil, $timeout, $r
  *
  * @param {string} md-position-mode The position mode in the form of
  *           `x`, `y`. Default value is `target`,`target`. Right now the `x` axis
- *           also suppports `target-right`.
+ *           also supports `target-right`.
  * @param {string} md-offset An offset to apply to the dropdown after positioning
  *           `x`, `y`. Default value is `0`,`0`.
  *
@@ -71389,26 +74472,33 @@ function MenuDirective($mdUtil) {
 
   function compile(templateElement) {
     templateElement.addClass('md-menu');
-    var triggerElement = templateElement.children()[0];
+
+    var triggerEl = templateElement.children()[0];
+    var contentEl = templateElement.children()[1];
+
     var prefixer = $mdUtil.prefixer();
 
-    if (!prefixer.hasAttribute(triggerElement, 'ng-click')) {
-      triggerElement = triggerElement
-          .querySelector(prefixer.buildSelector(['ng-click', 'ng-mouseenter'])) || triggerElement;
-    }
-    if (triggerElement && (
-      triggerElement.nodeName == 'MD-BUTTON' ||
-      triggerElement.nodeName == 'BUTTON'
-    ) && !triggerElement.hasAttribute('type')) {
-      triggerElement.setAttribute('type', 'button');
+    if (!prefixer.hasAttribute(triggerEl, 'ng-click')) {
+      triggerEl = triggerEl
+          .querySelector(prefixer.buildSelector(['ng-click', 'ng-mouseenter'])) || triggerEl;
     }
 
-    if (templateElement.children().length != 2) {
-      throw Error(INVALID_PREFIX + 'Expected two children elements.');
+    var isButtonTrigger = triggerEl.nodeName === 'MD-BUTTON' || triggerEl.nodeName === 'BUTTON';
+
+    if (triggerEl && isButtonTrigger && !triggerEl.hasAttribute('type')) {
+      triggerEl.setAttribute('type', 'button');
+    }
+
+    if (!triggerEl) {
+      throw Error(INVALID_PREFIX + 'Expected the menu to have a trigger element.');
+    }
+
+    if (!contentEl || contentEl.nodeName !== 'MD-MENU-CONTENT') {
+      throw Error(INVALID_PREFIX + 'Expected the menu to contain a `md-menu-content` element.');
     }
 
     // Default element for ARIA attributes has the ngClick or ngMouseenter expression
-    triggerElement && triggerElement.setAttribute('aria-haspopup', 'true');
+    triggerEl && triggerEl.setAttribute('aria-haspopup', 'true');
 
     var nestedMenus = templateElement[0].querySelectorAll('md-menu');
     var nestingDepth = parseInt(templateElement[0].getAttribute('md-nest-level'), 10) || 0;
@@ -71426,7 +74516,7 @@ function MenuDirective($mdUtil) {
 
   function link(scope, element, attr, ctrls) {
     var mdMenuCtrl = ctrls[0];
-    var isInMenuBar = ctrls[1] != undefined;
+    var isInMenuBar = !!ctrls[1];
     // Move everything into a md-menu-container and pass it to the controller
     var menuContainer = angular.element( '<div class="_md md-open-menu-container md-whiteframe-z2"></div>');
     var menuContents = element.children()[1];
@@ -71469,7 +74559,7 @@ MenuProvider.$inject = ["$$interimElementProvider"];angular
  */
 
 function MenuProvider($$interimElementProvider) {
-  menuDefaultOptions.$inject = ["$mdUtil", "$mdTheming", "$mdConstant", "$document", "$window", "$q", "$$rAF", "$animateCss", "$animate"];
+  menuDefaultOptions.$inject = ["$mdUtil", "$mdTheming", "$mdConstant", "$document", "$window", "$q", "$$rAF", "$animateCss", "$animate", "$log"];
   var MENU_EDGE_MARGIN = 8;
 
   return $$interimElementProvider('$mdMenu')
@@ -71479,7 +74569,9 @@ function MenuProvider($$interimElementProvider) {
     });
 
   /* @ngInject */
-  function menuDefaultOptions($mdUtil, $mdTheming, $mdConstant, $document, $window, $q, $$rAF, $animateCss, $animate) {
+  function menuDefaultOptions($mdUtil, $mdTheming, $mdConstant, $document, $window, $q, $$rAF,
+                              $animateCss, $animate, $log) {
+
     var prefixer = $mdUtil.prefixer();
     var animator = $mdUtil.dom.animator;
 
@@ -71491,7 +74583,7 @@ function MenuProvider($$interimElementProvider) {
       disableParentScroll: true,
       skipCompile: true,
       preserveScope: true,
-      skipHide: true,
+      multiple: true,
       themable: true
     };
 
@@ -71531,9 +74623,13 @@ function MenuProvider($$interimElementProvider) {
      * and backdrop
      */
     function onRemove(scope, element, opts) {
-      opts.cleanupInteraction && opts.cleanupInteraction();
+      opts.cleanupInteraction();
+      opts.cleanupBackdrop();
       opts.cleanupResizing();
       opts.hideBackdrop();
+
+      // Before the menu is closing remove the clickable class.
+      element.removeClass('md-clickable');
 
       // For navigation $destroy events, do a quick, non-animated removal,
       // but for normal closes (from clicks, etc) animate the removal
@@ -71566,9 +74662,17 @@ function MenuProvider($$interimElementProvider) {
     function onShow(scope, element, opts) {
       sanitizeAndConfigure(opts);
 
-      // Wire up theming on our menu element
-      $mdTheming.inherit(opts.menuContentEl, opts.target);
-
+      if (opts.menuContentEl[0]) {
+        // Inherit the theme from the target element.
+        $mdTheming.inherit(opts.menuContentEl, opts.target);
+      } else {
+        $log.warn(
+          '$mdMenu: Menu elements should always contain a `md-menu-content` element,' +
+          'otherwise interactivity features will not work properly.',
+          element
+        );
+      }
+      
       // Register various listeners to move menu on resize/orientation change
       opts.cleanupResizing = startRepositioningOnResize();
       opts.hideBackdrop = showBackdrop(scope, element, opts);
@@ -71578,6 +74682,11 @@ function MenuProvider($$interimElementProvider) {
         .then(function(response) {
           opts.alreadyOpen = true;
           opts.cleanupInteraction = activateInteraction();
+          opts.cleanupBackdrop = setupBackdrop();
+
+          // Since the menu finished its animation, mark the menu as clickable.
+          element.addClass('md-clickable');
+
           return response;
         });
 
@@ -71647,18 +74756,44 @@ function MenuProvider($$interimElementProvider) {
           $window.removeEventListener('resize', repositionMenu);
           $window.removeEventListener('orientationchange', repositionMenu);
 
+        };
+      }
+
+      /**
+       * Sets up the backdrop and listens for click elements.
+       * Once the backdrop will be clicked, the menu will automatically close.
+       * @returns {!Function} Function to remove the backdrop.
+       */
+      function setupBackdrop() {
+        if (!opts.backdrop) return angular.noop;
+
+        opts.backdrop.on('click', onBackdropClick);
+
+        return function() {
+          opts.backdrop.off('click', onBackdropClick);
         }
       }
 
       /**
-       * Activate interaction on the menu. Wire up keyboard listerns for
-       * clicks, keypresses, backdrop closing, etc.
+       * Function to be called whenever the backdrop is clicked.
+       * @param {!MouseEvent} event
+       */
+      function onBackdropClick(event) {
+        event.preventDefault();
+        event.stopPropagation();
+
+        scope.$apply(function() {
+          opts.mdMenuCtrl.close(true, { closeAll: true });
+        });
+      }
+
+      /**
+       * Activate interaction on the menu. Resolves the focus target and closes the menu on
+       * escape or option click.
+       * @returns {!Function} Function to deactivate the interaction listeners.
        */
       function activateInteraction() {
-        element.addClass('md-clickable');
-
-        // close on backdrop click
-        if (opts.backdrop) opts.backdrop.on('click', onBackdropClick);
+        if (!opts.menuContentEl[0]) return angular.noop;
 
         // Wire up keyboard listeners.
         // - Close on escape,
@@ -71667,21 +74802,28 @@ function MenuProvider($$interimElementProvider) {
         opts.menuContentEl.on('keydown', onMenuKeyDown);
         opts.menuContentEl[0].addEventListener('click', captureClickListener, true);
 
-        // kick off initial focus in the menu on the first element
+        // kick off initial focus in the menu on the first enabled element
         var focusTarget = opts.menuContentEl[0]
           .querySelector(prefixer.buildSelector(['md-menu-focus-target', 'md-autofocus']));
 
         if ( !focusTarget ) {
-          var firstChild = opts.menuContentEl[0].firstElementChild;
-
-          focusTarget = firstChild && (firstChild.querySelector('.md-button:not([disabled])') || firstChild.firstElementChild);
+          var childrenLen = opts.menuContentEl[0].children.length;
+          for(var childIndex = 0; childIndex < childrenLen; childIndex++) {
+            var child = opts.menuContentEl[0].children[childIndex];
+            focusTarget = child.querySelector('.md-button:not([disabled])');
+            if (focusTarget) {
+              break;
+            }
+            if (child.firstElementChild && !child.firstElementChild.disabled) {
+              focusTarget = child.firstElementChild;
+              break;
+            }
+          }
         }
 
         focusTarget && focusTarget.focus();
 
         return function cleanupInteraction() {
-          element.removeClass('md-clickable');
-          if (opts.backdrop) opts.backdrop.off('click', onBackdropClick);
           opts.menuContentEl.off('keydown', onMenuKeyDown);
           opts.menuContentEl[0].removeEventListener('click', captureClickListener, true);
         };
@@ -71756,7 +74898,7 @@ function MenuProvider($$interimElementProvider) {
               }
               break;
             }
-          } while (target = target.parentNode)
+          } while (target = target.parentNode);
 
           function close() {
             scope.$apply(function() {
@@ -72238,15 +75380,11 @@ MenuBarController.prototype.handleParentClick = function(event) {
   var openMenu = this.querySelector('md-menu.md-open');
 
   if (openMenu && !openMenu.contains(event.target)) {
-    angular.element(openMenu).controller('mdMenu').close();
+    angular.element(openMenu).controller('mdMenu').close(true, {
+      closeAll: true
+    });
   }
 };
-
-
-
-
-
-
 
 })();
 (function(){
@@ -72255,7 +75393,7 @@ MenuBarController.prototype.handleParentClick = function(event) {
 /**
  * @ngdoc directive
  * @name mdMenuBar
- * @module material.components.menu-bar
+ * @module material.components.menuBar
  * @restrict E
  * @description
  *
@@ -72266,7 +75404,7 @@ MenuBarController.prototype.handleParentClick = function(event) {
  * <hljs lang="html">
  * <md-menu-bar>
  *   <md-menu>
- *     <button ng-click="$mdOpenMenu()">
+ *     <button ng-click="$mdMenu.open()">
  *       File
  *     </button>
  *     <md-menu-content>
@@ -72279,7 +75417,7 @@ MenuBarController.prototype.handleParentClick = function(event) {
  *       <md-menu-item>
  *       <md-menu-item>
  *         <md-menu>
- *           <md-button ng-click="$mdOpenMenu()">New</md-button>
+ *           <md-button ng-click="$mdMenu.open()">New</md-button>
  *           <md-menu-content>
  *             <md-menu-item><md-button ng-click="ctrl.sampleAction('New Document', $event)">Document</md-button></md-menu-item>
  *             <md-menu-item><md-button ng-click="ctrl.sampleAction('New Spreadsheet', $event)">Spreadsheet</md-button></md-menu-item>
@@ -72306,7 +75444,7 @@ MenuBarController.prototype.handleParentClick = function(event) {
  * <hljs lang="html">
  * <md-menu-bar>
  *  <md-menu>
- *    <button ng-click="$mdOpenMenu()">
+ *    <button ng-click="$mdMenu.open()">
  *      Sample Menu
  *    </button>
  *    <md-menu-content>
@@ -72328,7 +75466,7 @@ MenuBarController.prototype.handleParentClick = function(event) {
  * <hljs lang="html">
  * <md-menu-item>
  *   <md-menu>
- *     <button ng-click="$mdOpenMenu()">New</md-button>
+ *     <button ng-click="$mdMenu.open()">New</md-button>
  *     <md-menu-content>
  *       <md-menu-item><md-button ng-click="ctrl.sampleAction('New Document', $event)">Document</md-button></md-menu-item>
  *       <md-menu-item><md-button ng-click="ctrl.sampleAction('New Spreadsheet', $event)">Spreadsheet</md-button></md-menu-item>
@@ -72531,17 +75669,17 @@ MenuItemController.prototype.handleClick = function(e) {
 "use strict";
 
 
-MenuItemDirective.$inject = ["$mdUtil", "$$mdSvgRegistry"];
+MenuItemDirective.$inject = ["$mdUtil", "$mdConstant", "$$mdSvgRegistry"];
 angular
   .module('material.components.menuBar')
   .directive('mdMenuItem', MenuItemDirective);
 
  /* @ngInject */
-function MenuItemDirective($mdUtil, $$mdSvgRegistry) {
+function MenuItemDirective($mdUtil, $mdConstant, $$mdSvgRegistry) {
   return {
     controller: 'MenuItemController',
     require: ['mdMenuItem', '?ngModel'],
-    priority: 210, // ensure that our post link runs after ngAria
+    priority: $mdConstant.BEFORE_NG_ARIA,
     compile: function(templateEl, templateAttrs) {
       var type = templateAttrs.type;
       var inMenuBarClass = 'md-in-menu-bar';
@@ -72669,7 +75807,6 @@ function MdProgressCircularDirective($window, $mdProgressCircular, $mdTheming,
             $window.webkitCancelRequestAnimationFrame ||
             angular.noop;
 
-  var DEGREE_IN_RADIANS = $window.Math.PI / 180;
   var MODE_DETERMINATE = 'determinate';
   var MODE_INDETERMINATE = 'indeterminate';
   var DISABLED_CLASS = '_md-progress-circular-disabled';
@@ -72694,11 +75831,7 @@ function MdProgressCircularDirective($window, $mdProgressCircular, $mdTheming,
       });
 
       if (angular.isUndefined(attrs.mdMode)) {
-        var hasValue = angular.isDefined(attrs.value);
-        var mode = hasValue ? MODE_DETERMINATE : MODE_INDETERMINATE;
-        var info = "Auto-adding the missing md-mode='{0}' to the ProgressCircular element";
-
-          // $log.debug( $mdUtil.supplant(info, [mode]) );
+        var mode = attrs.hasOwnProperty('value') ? MODE_DETERMINATE : MODE_INDETERMINATE;
         attrs.$set('mdMode', mode);
       } else {
         attrs.$set('mdMode', attrs.mdMode.trim());
@@ -72714,7 +75847,7 @@ function MdProgressCircularDirective($window, $mdProgressCircular, $mdTheming,
     var path = angular.element(node.querySelector('path'));
     var startIndeterminate = $mdProgressCircular.startIndeterminate;
     var endIndeterminate = $mdProgressCircular.endIndeterminate;
-    var rotationIndeterminate = 0;
+    var iterationCount = 0;
     var lastAnimationId = 0;
     var lastDrawFrame;
     var interval;
@@ -72745,8 +75878,8 @@ function MdProgressCircularDirective($window, $mdProgressCircular, $mdTheming,
       if (isDisabled === true || isDisabled === false){
         return isDisabled;
       }
-      return angular.isDefined(element.attr('disabled'));
 
+      return angular.isDefined(element.attr('disabled'));
     }], function(newValues, oldValues) {
       var mode = newValues[1];
       var isDisabled = newValues[2];
@@ -72783,6 +75916,7 @@ function MdProgressCircularDirective($window, $mdProgressCircular, $mdTheming,
     scope.$watch('mdDiameter', function(newValue) {
       var diameter = getSize(newValue);
       var strokeWidth = getStroke(diameter);
+      var value = clamp(scope.value);
       var transformOrigin = (diameter / 2) + 'px';
       var dimensions = {
         width: diameter + 'px',
@@ -72806,37 +75940,52 @@ function MdProgressCircularDirective($window, $mdProgressCircular, $mdTheming,
         .css('transform-origin', transformOrigin + ' ' + transformOrigin + ' ' + transformOrigin);
 
       element.css(dimensions);
-      path.css('stroke-width',  strokeWidth + 'px');
+
+      path.attr('stroke-width', strokeWidth);
+      path.attr('stroke-linecap', 'square');
+      if (scope.mdMode == MODE_INDETERMINATE) {
+        path.attr('d', getSvgArc(diameter, strokeWidth, true));
+        path.attr('stroke-dasharray', (diameter - strokeWidth) * $window.Math.PI * 0.75);
+        path.attr('stroke-dashoffset', getDashLength(diameter, strokeWidth, 1, 75));
+      } else {
+        path.attr('d', getSvgArc(diameter, strokeWidth, false));
+        path.attr('stroke-dasharray', (diameter - strokeWidth) * $window.Math.PI);
+        path.attr('stroke-dashoffset', getDashLength(diameter, strokeWidth, 0, 100));
+        renderCircle(value, value);
+      }
+
     });
 
-    function renderCircle(animateFrom, animateTo, easing, duration, rotation) {
+    function renderCircle(animateFrom, animateTo, easing, duration, iterationCount, maxValue) {
       var id = ++lastAnimationId;
       var startTime = $mdUtil.now();
       var changeInValue = animateTo - animateFrom;
       var diameter = getSize(scope.mdDiameter);
-      var pathDiameter = diameter - getStroke(diameter);
+      var strokeWidth = getStroke(diameter);
       var ease = easing || $mdProgressCircular.easeFn;
       var animationDuration = duration || $mdProgressCircular.duration;
+      var rotation = -90 * (iterationCount || 0);
+      var dashLimit = maxValue || 100;
 
       // No need to animate it if the values are the same
       if (animateTo === animateFrom) {
-        path.attr('d', getSvgArc(animateTo, diameter, pathDiameter, rotation));
+        renderFrame(animateTo);
       } else {
         lastDrawFrame = rAF(function animation() {
           var currentTime = $window.Math.max(0, $window.Math.min($mdUtil.now() - startTime, animationDuration));
 
-          path.attr('d', getSvgArc(
-            ease(currentTime, animateFrom, changeInValue, animationDuration),
-            diameter,
-            pathDiameter,
-            rotation
-          ));
+          renderFrame(ease(currentTime, animateFrom, changeInValue, animationDuration));
 
           // Do not allow overlapping animations
           if (id === lastAnimationId && currentTime < animationDuration) {
             lastDrawFrame = rAF(animation);
           }
         });
+      }
+
+      function renderFrame(value) {
+        path.attr('stroke-dashoffset', getDashLength(diameter, strokeWidth, value, dashLimit));
+        path.attr('transform','rotate(' + (rotation) + ' ' + diameter/2 + ' ' + diameter/2 + ')');
       }
     }
 
@@ -72846,16 +75995,14 @@ function MdProgressCircularDirective($window, $mdProgressCircular, $mdTheming,
         endIndeterminate,
         $mdProgressCircular.easeFnIndeterminate,
         $mdProgressCircular.durationIndeterminate,
-        rotationIndeterminate
+        iterationCount,
+        75
       );
 
-      // The % 100 technically isn't necessary, but it keeps the rotation
-      // under 100, instead of becoming a crazy large number.
-      rotationIndeterminate = (rotationIndeterminate + endIndeterminate) % 100;
+      // The %4 technically isn't necessary, but it keeps the rotation
+      // under 360, instead of becoming a crazy large number.
+      iterationCount = ++iterationCount % 4;
 
-      var temp = startIndeterminate;
-      startIndeterminate = -endIndeterminate;
-      endIndeterminate = -temp;
     }
 
     function startIndeterminateAnimation() {
@@ -72863,7 +76010,7 @@ function MdProgressCircularDirective($window, $mdProgressCircular, $mdTheming,
         // Note that this interval isn't supposed to trigger a digest.
         interval = $interval(
           animateIndeterminate,
-          $mdProgressCircular.durationIndeterminate + 50,
+          $mdProgressCircular.durationIndeterminate,
           0,
           false
         );
@@ -72886,55 +76033,38 @@ function MdProgressCircularDirective($window, $mdProgressCircular, $mdTheming,
   }
 
   /**
-   * Generates an arc following the SVG arc syntax.
+   * Returns SVG path data for progress circle
    * Syntax spec: https://www.w3.org/TR/SVG/paths.html#PathDataEllipticalArcCommands
    *
-   * @param {number} current Current value between 0 and 100.
    * @param {number} diameter Diameter of the container.
-   * @param {number} pathDiameter Diameter of the path element.
-   * @param {number=0} rotation The point at which the semicircle should start rendering.
-   * Used for doing the indeterminate animation.
+   * @param {number} strokeWidth Stroke width to be used when drawing circle
+   * @param {boolean} indeterminate Use if progress circle will be used for indeterminate
    *
    * @returns {string} String representation of an SVG arc.
    */
-  function getSvgArc(current, diameter, pathDiameter, rotation) {
-    // The angle can't be exactly 360, because the arc becomes hidden.
-    var maximumAngle = 359.99 / 100;
-    var startPoint = rotation || 0;
+  function getSvgArc(diameter, strokeWidth, indeterminate) {
     var radius = diameter / 2;
-    var pathRadius = pathDiameter / 2;
-
-    var startAngle = startPoint * maximumAngle;
-    var endAngle = current * maximumAngle;
-    var start = polarToCartesian(radius, pathRadius, startAngle);
-    var end = polarToCartesian(radius, pathRadius, endAngle + startAngle);
-    var arcSweep = endAngle < 0 ? 0 : 1;
-    var largeArcFlag;
-
-    if (endAngle < 0) {
-      largeArcFlag = endAngle >= -180 ? 0 : 1;
-    } else {
-      largeArcFlag = endAngle <= 180 ? 0 : 1;
-    }
-
-    return 'M' + start + 'A' + pathRadius + ',' + pathRadius +
-      ' 0 ' + largeArcFlag + ',' + arcSweep + ' ' + end;
+    var offset = strokeWidth / 2;
+    var start = radius + ',' + offset; // ie: (25, 2.5) or 12 o'clock
+    var end = offset + ',' + radius;   // ie: (2.5, 25) or  9 o'clock
+    var arcRadius = radius - offset;
+    return 'M' + start
+         + 'A' + arcRadius + ',' + arcRadius + ' 0 1 1 ' + end // 75% circle
+         + (indeterminate ? '' : 'A' + arcRadius + ',' + arcRadius + ' 0 0 1 ' + start); // loop to start
   }
 
   /**
-   * Converts Polar coordinates to Cartesian.
+   * Return stroke length for progress circle
    *
-   * @param {number} radius Radius of the container.
-   * @param {number} pathRadius Radius of the path element
-   * @param {number} angleInDegress Angle at which to place the point.
+   * @param {number} diameter Diameter of the container.
+   * @param {number} strokeWidth Stroke width to be used when drawing circle
+   * @param {number} value Percentage of circle (between 0 and 100)
+   * @param {number} limit Max percentage for circle
    *
-   * @returns {string} Cartesian coordinates in the format of `x,y`.
+   * @returns {number} Stroke length for progres circle
    */
-  function polarToCartesian(radius, pathRadius, angleInDegrees) {
-    var angleInRadians = (angleInDegrees - 90) * DEGREE_IN_RADIANS;
-
-    return (radius + (pathRadius * $window.Math.cos(angleInRadians))) +
-      ',' + (radius + (pathRadius * $window.Math.sin(angleInRadians)));
+  function getDashLength(diameter, strokeWidth, value, limit) {
+    return (diameter - strokeWidth) * $window.Math.PI * ( (3 * (limit || 100) / 100) - (value/100) );
   }
 
   /**
@@ -72971,6 +76101,7 @@ function MdProgressCircularDirective($window, $mdProgressCircular, $mdTheming,
   function getStroke(diameter) {
     return $mdProgressCircular.strokeWidth / 100 * diameter;
   }
+
 }
 
 })();
@@ -73025,9 +76156,9 @@ function MdProgressCircularProvider() {
     duration: 100,
     easeFn: linearEase,
 
-    durationIndeterminate: 500,
-    startIndeterminate: 3,
-    endIndeterminate: 80,
+    durationIndeterminate: 1333,
+    startIndeterminate: 1,
+    endIndeterminate: 149,
     easeFnIndeterminate: materialEase,
 
     easingPresets: {
@@ -73124,12 +76255,12 @@ function MdTab () {
       var label = firstChild(element, 'md-tab-label'),
           body  = firstChild(element, 'md-tab-body');
 
-      if (label.length == 0) {
+      if (label.length === 0) {
         label = angular.element('<md-tab-label></md-tab-label>');
         if (attr.label) label.text(attr.label);
         else label.append(element.contents());
 
-        if (body.length == 0) {
+        if (body.length === 0) {
           var contents = element.contents().detach();
           body         = angular.element('<md-tab-body></md-tab-body>');
           body.append(contents);
@@ -73240,7 +76371,7 @@ function MdTabScroll ($parse) {
         });
       };
     }
-  }
+  };
 }
 
 })();
@@ -73248,15 +76379,15 @@ function MdTabScroll ($parse) {
 "use strict";
 
 
-MdTabsController.$inject = ["$scope", "$element", "$window", "$mdConstant", "$mdTabInkRipple", "$mdUtil", "$animateCss", "$attrs", "$compile", "$mdTheming"];angular
+MdTabsController.$inject = ["$scope", "$element", "$window", "$mdConstant", "$mdTabInkRipple", "$mdUtil", "$animateCss", "$attrs", "$compile", "$mdTheming", "$mdInteraction"];angular
     .module('material.components.tabs')
     .controller('MdTabsController', MdTabsController);
 
 /**
  * @ngInject
  */
-function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipple,
-                           $mdUtil, $animateCss, $attrs, $compile, $mdTheming) {
+function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipple, $mdUtil,
+                           $animateCss, $attrs, $compile, $mdTheming, $mdInteraction) {
   // define private properties
   var ctrl      = this,
       locked    = false,
@@ -73265,37 +76396,9 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
       destroyed = false,
       loaded    = false;
 
-  // define one-way bindings
-  defineOneWayBinding('stretchTabs', handleStretchTabs);
 
-  // define public properties with change handlers
-  defineProperty('focusIndex', handleFocusIndexChange, ctrl.selectedIndex || 0);
-  defineProperty('offsetLeft', handleOffsetChange, 0);
-  defineProperty('hasContent', handleHasContent, false);
-  defineProperty('maxTabWidth', handleMaxTabWidth, getMaxTabWidth());
-  defineProperty('shouldPaginate', handleShouldPaginate, false);
-
-  // define boolean attributes
-  defineBooleanAttribute('noInkBar', handleInkBar);
-  defineBooleanAttribute('dynamicHeight', handleDynamicHeight);
-  defineBooleanAttribute('noPagination');
-  defineBooleanAttribute('swipeContent');
-  defineBooleanAttribute('noDisconnect');
-  defineBooleanAttribute('autoselect');
-  defineBooleanAttribute('noSelectClick');
-  defineBooleanAttribute('centerTabs', handleCenterTabs, false);
-  defineBooleanAttribute('enableDisconnect');
-
-  // define public properties
-  ctrl.scope             = $scope;
-  ctrl.parent            = $scope.$parent;
-  ctrl.tabs              = [];
-  ctrl.lastSelectedIndex = null;
-  ctrl.hasFocus          = false;
-  ctrl.lastClick         = true;
-  ctrl.shouldCenterTabs  = shouldCenterTabs();
-
-  // define public methods
+  // Define public methods
+  ctrl.$onInit            = $onInit;
   ctrl.updatePagination   = $mdUtil.debounce(updatePagination, 100);
   ctrl.redirectFocus      = redirectFocus;
   ctrl.attachRipple       = attachRipple;
@@ -73313,13 +76416,58 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
   ctrl.getTabElementIndex = getTabElementIndex;
   ctrl.updateInkBarStyles = $mdUtil.debounce(updateInkBarStyles, 100);
   ctrl.updateTabOrder     = $mdUtil.debounce(updateTabOrder, 100);
+  ctrl.getFocusedTabId    = getFocusedTabId;
 
-  init();
+  // For Angular 1.4 and older, where there are no lifecycle hooks but bindings are pre-assigned,
+  // manually call the $onInit hook.
+  if (angular.version.major === 1 && angular.version.minor <= 4) {
+    this.$onInit();
+  }
 
   /**
-   * Perform initialization for the controller, setup events and watcher(s)
+   * Angular Lifecycle hook for newer Angular versions.
+   * Bindings are not guaranteed to have been assigned in the controller, but they are in the $onInit hook.
    */
-  function init () {
+  function $onInit() {
+    // Define one-way bindings
+    defineOneWayBinding('stretchTabs', handleStretchTabs);
+
+    // Define public properties with change handlers
+    defineProperty('focusIndex', handleFocusIndexChange, ctrl.selectedIndex || 0);
+    defineProperty('offsetLeft', handleOffsetChange, 0);
+    defineProperty('hasContent', handleHasContent, false);
+    defineProperty('maxTabWidth', handleMaxTabWidth, getMaxTabWidth());
+    defineProperty('shouldPaginate', handleShouldPaginate, false);
+
+    // Define boolean attributes
+    defineBooleanAttribute('noInkBar', handleInkBar);
+    defineBooleanAttribute('dynamicHeight', handleDynamicHeight);
+    defineBooleanAttribute('noPagination');
+    defineBooleanAttribute('swipeContent');
+    defineBooleanAttribute('noDisconnect');
+    defineBooleanAttribute('autoselect');
+    defineBooleanAttribute('noSelectClick');
+    defineBooleanAttribute('centerTabs', handleCenterTabs, false);
+    defineBooleanAttribute('enableDisconnect');
+
+    // Define public properties
+    ctrl.scope             = $scope;
+    ctrl.parent            = $scope.$parent;
+    ctrl.tabs              = [];
+    ctrl.lastSelectedIndex = null;
+    ctrl.hasFocus          = false;
+    ctrl.styleTabItemFocus = false;
+    ctrl.shouldCenterTabs  = shouldCenterTabs();
+    ctrl.tabContentPrefix  = 'tab-content-';
+
+    // Setup the tabs controller after all bindings are available.
+    setupTabsController();
+  }
+
+  /**
+   * Perform setup for the controller, setup events and watcher(s)
+   */
+  function setupTabsController () {
     ctrl.selectedIndex = ctrl.selectedIndex || 0;
     compileTemplate();
     configureWatchers();
@@ -73541,7 +76689,6 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
         if (!locked) select(ctrl.focusIndex);
         break;
     }
-    ctrl.lastClick = false;
   }
 
   /**
@@ -73552,7 +76699,6 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
    */
   function select (index, canSkipClick) {
     if (!locked) ctrl.focusIndex = ctrl.selectedIndex = index;
-    ctrl.lastClick = true;
     // skip the click event if noSelectClick is enabled
     if (canSkipClick && ctrl.noSelectClick) return;
     // nextTick is required to prevent errors in user-defined click events
@@ -73583,13 +76729,13 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
       tab = elements.tabs[ i ];
       if (tab.offsetLeft + tab.offsetWidth > totalWidth) break;
     }
-    
+
     if (viewportWidth > tab.offsetWidth) {
       //Canvas width *greater* than tab width: usual positioning
       ctrl.offsetLeft = fixOffset(tab.offsetLeft);
     } else {
       /**
-       * Canvas width *smaller* than tab width: positioning at the *end* of current tab to let 
+       * Canvas width *smaller* than tab width: positioning at the *end* of current tab to let
        * pagination "for loop" to proceed correctly on next tab when nextPage() is called again
        */
       ctrl.offsetLeft = fixOffset(tab.offsetLeft + (tab.offsetWidth - viewportWidth + 1));
@@ -73606,16 +76752,16 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
       tab = elements.tabs[ i ];
       if (tab.offsetLeft + tab.offsetWidth >= ctrl.offsetLeft) break;
     }
-    
+
     if (elements.canvas.clientWidth > tab.offsetWidth) {
       //Canvas width *greater* than tab width: usual positioning
       ctrl.offsetLeft = fixOffset(tab.offsetLeft + tab.offsetWidth - elements.canvas.clientWidth);
     } else {
       /**
-       * Canvas width *smaller* than tab width: positioning at the *beginning* of current tab to let 
+       * Canvas width *smaller* than tab width: positioning at the *beginning* of current tab to let
        * pagination "for loop" to break correctly on previous tab when previousPage() is called again
        */
-      ctrl.offsetLeft = fixOffset(tab.offsetLeft);  
+      ctrl.offsetLeft = fixOffset(tab.offsetLeft);
     }
   }
 
@@ -73679,10 +76825,11 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
           isRight:      function () { return this.getIndex() > ctrl.selectedIndex; },
           shouldRender: function () { return !ctrl.noDisconnect || this.isActive(); },
           hasFocus:     function () {
-            return !ctrl.lastClick
+            return ctrl.styleTabItemFocus
                 && ctrl.hasFocus && this.getIndex() === ctrl.focusIndex;
           },
-          id:           $mdUtil.nextUid()
+          id:           $mdUtil.nextUid(),
+          hasContent: !!(tabData.template && tabData.template.trim())
         },
         tab       = angular.extend(proto, tabData);
     if (angular.isDefined(index)) {
@@ -73690,10 +76837,13 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
     } else {
       ctrl.tabs.push(tab);
     }
+
     processQueue();
     updateHasContent();
     $mdUtil.nextTick(function () {
       updatePagination();
+      setAriaControls(tab);
+
       // if autoselect is enabled, select the newly added tab
       if (hasLoaded && ctrl.autoselect) $mdUtil.nextTick(function () {
         $mdUtil.nextTick(function () { select(ctrl.tabs.indexOf(tab)); });
@@ -73742,6 +76892,17 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
     var lastTab = elements.tabs[ elements.tabs.length - 1 ];
     return lastTab && lastTab.offsetLeft + lastTab.offsetWidth > elements.canvas.clientWidth +
         ctrl.offsetLeft;
+  }
+
+  /**
+   * Returns currently focused tab item's element ID
+   */
+  function getFocusedTabId() {
+    var focusedTab = ctrl.tabs[ctrl.focusIndex];
+    if (!focusedTab || !focusedTab.id) {
+      return null;
+    }
+    return 'tab-item-' + focusedTab.id;
   }
 
   /**
@@ -73826,21 +76987,8 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
    * Updates whether or not pagination should be displayed.
    */
   function updatePagination () {
-    updatePagingWidth();
     ctrl.maxTabWidth = getMaxTabWidth();
     ctrl.shouldPaginate = shouldPaginate();
-  }
-
-  /**
-   * Sets or clears fixed width for md-pagination-wrapper depending on if tabs should stretch.
-   */
-  function updatePagingWidth() {
-    var elements = getElements();
-    if (shouldStretchTabs()) {
-      angular.element(elements.paging).css('width', '');
-    } else {
-      angular.element(elements.paging).css('width', calcPagingWidth() + 'px');
-    }
   }
 
   /**
@@ -73904,6 +77052,7 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
    * issues when attempting to focus an item that is out of view.
    */
   function redirectFocus () {
+    ctrl.styleTabItemFocus = ($mdInteraction.getLastInteractionType() === 'keyboard');
     getElements().dummies[ ctrl.focusIndex ].focus();
   }
 
@@ -73913,7 +77062,7 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
   function adjustOffset (index) {
     var elements = getElements();
 
-    if (index == null) index = ctrl.focusIndex;
+    if (!angular.isNumber(index)) index = ctrl.focusIndex;
     if (!elements.tabs[ index ]) return;
     if (ctrl.shouldCenterTabs) return;
     var tab         = elements.tabs[ index ],
@@ -73937,9 +77086,14 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
    */
   function updateHasContent () {
     var hasContent  = false;
-    angular.forEach(ctrl.tabs, function (tab) {
-      if (tab.template) hasContent = true;
-    });
+
+    for (var i = 0; i < ctrl.tabs.length; i++) {
+      if (ctrl.tabs[i].hasContent) {
+        hasContent = true;
+        break;
+      }
+    }
+
     ctrl.hasContent = hasContent;
   }
 
@@ -74089,6 +77243,18 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
     var options = { colorElement: angular.element(elements.inkBar) };
     $mdTabInkRipple.attach(scope, element, options);
   }
+
+  /**
+   * Sets the `aria-controls` attribute to the elements that
+   * correspond to the passed-in tab.
+   * @param tab
+   */
+  function setAriaControls (tab) {
+    if (tab.hasContent) {
+      var nodes = $element[0].querySelectorAll('[md-tab-id="' + tab.id + '"]');
+      angular.element(nodes).attr('aria-controls', ctrl.tabContentPrefix + tab.id);
+    }
+  }
 }
 
 })();
@@ -74204,7 +77370,7 @@ function MdTabs ($$mdSvgRegistry) {
       selectedIndex: '=?mdSelected'
     },
     template:         function (element, attr) {
-      attr[ "$mdTabsTemplate" ] = element.html();
+      attr.$mdTabsTemplate = element.html();
       return '' +
         '<md-tabs-wrapper> ' +
           '<md-tab-data></md-tab-data> ' +
@@ -74230,7 +77396,7 @@ function MdTabs ($$mdSvgRegistry) {
           '</md-next-button> ' +
           '<md-tabs-canvas ' +
               'tabindex="{{ $mdTabsCtrl.hasFocus ? -1 : 0 }}" ' +
-              'aria-activedescendant="tab-item-{{$mdTabsCtrl.tabs[$mdTabsCtrl.focusIndex].id}}" ' +
+              'aria-activedescendant="{{$mdTabsCtrl.getFocusedTabId()}}" ' +
               'ng-focus="$mdTabsCtrl.redirectFocus()" ' +
               'ng-class="{ ' +
                   '\'md-paginated\': $mdTabsCtrl.shouldPaginate, ' +
@@ -74246,7 +77412,7 @@ function MdTabs ($$mdSvgRegistry) {
                   'class="md-tab" ' +
                   'ng-repeat="tab in $mdTabsCtrl.tabs" ' +
                   'role="tab" ' +
-                  'aria-controls="tab-content-{{::tab.id}}" ' +
+                  'md-tab-id="{{::tab.id}}"' +
                   'aria-selected="{{tab.isActive()}}" ' +
                   'aria-disabled="{{tab.scope.disabled || \'false\'}}" ' +
                   'ng-click="$mdTabsCtrl.select(tab.getIndex())" ' +
@@ -74267,8 +77433,7 @@ function MdTabs ($$mdSvgRegistry) {
                   'class="md-tab" ' +
                   'tabindex="-1" ' +
                   'id="tab-item-{{::tab.id}}" ' +
-                  'role="tab" ' +
-                  'aria-controls="tab-content-{{::tab.id}}" ' +
+                  'md-tab-id="{{::tab.id}}"' +
                   'aria-selected="{{tab.isActive()}}" ' +
                   'aria-disabled="{{tab.scope.disabled || \'false\'}}" ' +
                   'ng-focus="$mdTabsCtrl.hasFocus = true" ' +
@@ -74281,13 +77446,13 @@ function MdTabs ($$mdSvgRegistry) {
         '</md-tabs-wrapper> ' +
         '<md-tabs-content-wrapper ng-show="$mdTabsCtrl.hasContent && $mdTabsCtrl.selectedIndex >= 0" class="_md"> ' +
           '<md-tab-content ' +
-              'id="tab-content-{{::tab.id}}" ' +
+              'id="{{:: $mdTabsCtrl.tabContentPrefix + tab.id}}" ' +
               'class="_md" ' +
               'role="tabpanel" ' +
               'aria-labelledby="tab-item-{{::tab.id}}" ' +
               'md-swipe-left="$mdTabsCtrl.swipeContent && $mdTabsCtrl.incrementIndex(1)" ' +
               'md-swipe-right="$mdTabsCtrl.swipeContent && $mdTabsCtrl.incrementIndex(-1)" ' +
-              'ng-if="$mdTabsCtrl.hasContent" ' +
+              'ng-if="tab.hasContent" ' +
               'ng-repeat="(index, tab) in $mdTabsCtrl.tabs" ' +
               'ng-class="{ ' +
                 '\'md-no-transition\': $mdTabsCtrl.lastSelectedIndex == null, ' +
@@ -74418,8 +77583,8 @@ function MdTabsTemplate ($compile, $mdUtil) {
 
 })();
 (function(){ 
-angular.module("material.core").constant("$MD_THEME_CSS", "md-autocomplete.md-THEME_NAME-theme {  background: '{{background-A100}}'; }  md-autocomplete.md-THEME_NAME-theme[disabled]:not([md-floating-label]) {    background: '{{background-100}}'; }  md-autocomplete.md-THEME_NAME-theme button md-icon path {    fill: '{{background-600}}'; }  md-autocomplete.md-THEME_NAME-theme button:after {    background: '{{background-600-0.3}}'; }.md-autocomplete-suggestions-container.md-THEME_NAME-theme {  background: '{{background-A100}}'; }  .md-autocomplete-suggestions-container.md-THEME_NAME-theme li {    color: '{{background-900}}'; }    .md-autocomplete-suggestions-container.md-THEME_NAME-theme li .highlight {      color: '{{background-600}}'; }    .md-autocomplete-suggestions-container.md-THEME_NAME-theme li:hover, .md-autocomplete-suggestions-container.md-THEME_NAME-theme li.selected {      background: '{{background-200}}'; }md-backdrop {  background-color: '{{background-900-0.0}}'; }  md-backdrop.md-opaque.md-THEME_NAME-theme {    background-color: '{{background-900-1.0}}'; }md-bottom-sheet.md-THEME_NAME-theme {  background-color: '{{background-50}}';  border-top-color: '{{background-300}}'; }  md-bottom-sheet.md-THEME_NAME-theme.md-list md-list-item {    color: '{{foreground-1}}'; }  md-bottom-sheet.md-THEME_NAME-theme .md-subheader {    background-color: '{{background-50}}'; }  md-bottom-sheet.md-THEME_NAME-theme .md-subheader {    color: '{{foreground-1}}'; }.md-button.md-THEME_NAME-theme:not([disabled]):hover {  background-color: '{{background-500-0.2}}'; }.md-button.md-THEME_NAME-theme:not([disabled]).md-focused {  background-color: '{{background-500-0.2}}'; }.md-button.md-THEME_NAME-theme:not([disabled]).md-icon-button:hover {  background-color: transparent; }.md-button.md-THEME_NAME-theme.md-fab {  background-color: '{{accent-color}}';  color: '{{accent-contrast}}'; }  .md-button.md-THEME_NAME-theme.md-fab md-icon {    color: '{{accent-contrast}}'; }  .md-button.md-THEME_NAME-theme.md-fab:not([disabled]):hover {    background-color: '{{accent-A700}}'; }  .md-button.md-THEME_NAME-theme.md-fab:not([disabled]).md-focused {    background-color: '{{accent-A700}}'; }.md-button.md-THEME_NAME-theme.md-primary {  color: '{{primary-color}}'; }  .md-button.md-THEME_NAME-theme.md-primary.md-raised, .md-button.md-THEME_NAME-theme.md-primary.md-fab {    color: '{{primary-contrast}}';    background-color: '{{primary-color}}'; }    .md-button.md-THEME_NAME-theme.md-primary.md-raised:not([disabled]) md-icon, .md-button.md-THEME_NAME-theme.md-primary.md-fab:not([disabled]) md-icon {      color: '{{primary-contrast}}'; }    .md-button.md-THEME_NAME-theme.md-primary.md-raised:not([disabled]):hover, .md-button.md-THEME_NAME-theme.md-primary.md-fab:not([disabled]):hover {      background-color: '{{primary-600}}'; }    .md-button.md-THEME_NAME-theme.md-primary.md-raised:not([disabled]).md-focused, .md-button.md-THEME_NAME-theme.md-primary.md-fab:not([disabled]).md-focused {      background-color: '{{primary-600}}'; }  .md-button.md-THEME_NAME-theme.md-primary:not([disabled]) md-icon {    color: '{{primary-color}}'; }.md-button.md-THEME_NAME-theme.md-fab {  background-color: '{{accent-color}}';  color: '{{accent-contrast}}'; }  .md-button.md-THEME_NAME-theme.md-fab:not([disabled]) .md-icon {    color: '{{accent-contrast}}'; }  .md-button.md-THEME_NAME-theme.md-fab:not([disabled]):hover {    background-color: '{{accent-A700}}'; }  .md-button.md-THEME_NAME-theme.md-fab:not([disabled]).md-focused {    background-color: '{{accent-A700}}'; }.md-button.md-THEME_NAME-theme.md-raised {  color: '{{background-900}}';  background-color: '{{background-50}}'; }  .md-button.md-THEME_NAME-theme.md-raised:not([disabled]) md-icon {    color: '{{background-900}}'; }  .md-button.md-THEME_NAME-theme.md-raised:not([disabled]):hover {    background-color: '{{background-50}}'; }  .md-button.md-THEME_NAME-theme.md-raised:not([disabled]).md-focused {    background-color: '{{background-200}}'; }.md-button.md-THEME_NAME-theme.md-warn {  color: '{{warn-color}}'; }  .md-button.md-THEME_NAME-theme.md-warn.md-raised, .md-button.md-THEME_NAME-theme.md-warn.md-fab {    color: '{{warn-contrast}}';    background-color: '{{warn-color}}'; }    .md-button.md-THEME_NAME-theme.md-warn.md-raised:not([disabled]) md-icon, .md-button.md-THEME_NAME-theme.md-warn.md-fab:not([disabled]) md-icon {      color: '{{warn-contrast}}'; }    .md-button.md-THEME_NAME-theme.md-warn.md-raised:not([disabled]):hover, .md-button.md-THEME_NAME-theme.md-warn.md-fab:not([disabled]):hover {      background-color: '{{warn-600}}'; }    .md-button.md-THEME_NAME-theme.md-warn.md-raised:not([disabled]).md-focused, .md-button.md-THEME_NAME-theme.md-warn.md-fab:not([disabled]).md-focused {      background-color: '{{warn-600}}'; }  .md-button.md-THEME_NAME-theme.md-warn:not([disabled]) md-icon {    color: '{{warn-color}}'; }.md-button.md-THEME_NAME-theme.md-accent {  color: '{{accent-color}}'; }  .md-button.md-THEME_NAME-theme.md-accent.md-raised, .md-button.md-THEME_NAME-theme.md-accent.md-fab {    color: '{{accent-contrast}}';    background-color: '{{accent-color}}'; }    .md-button.md-THEME_NAME-theme.md-accent.md-raised:not([disabled]) md-icon, .md-button.md-THEME_NAME-theme.md-accent.md-fab:not([disabled]) md-icon {      color: '{{accent-contrast}}'; }    .md-button.md-THEME_NAME-theme.md-accent.md-raised:not([disabled]):hover, .md-button.md-THEME_NAME-theme.md-accent.md-fab:not([disabled]):hover {      background-color: '{{accent-A700}}'; }    .md-button.md-THEME_NAME-theme.md-accent.md-raised:not([disabled]).md-focused, .md-button.md-THEME_NAME-theme.md-accent.md-fab:not([disabled]).md-focused {      background-color: '{{accent-A700}}'; }  .md-button.md-THEME_NAME-theme.md-accent:not([disabled]) md-icon {    color: '{{accent-color}}'; }.md-button.md-THEME_NAME-theme[disabled], .md-button.md-THEME_NAME-theme.md-raised[disabled], .md-button.md-THEME_NAME-theme.md-fab[disabled], .md-button.md-THEME_NAME-theme.md-accent[disabled], .md-button.md-THEME_NAME-theme.md-warn[disabled] {  color: '{{foreground-3}}';  cursor: default; }  .md-button.md-THEME_NAME-theme[disabled] md-icon, .md-button.md-THEME_NAME-theme.md-raised[disabled] md-icon, .md-button.md-THEME_NAME-theme.md-fab[disabled] md-icon, .md-button.md-THEME_NAME-theme.md-accent[disabled] md-icon, .md-button.md-THEME_NAME-theme.md-warn[disabled] md-icon {    color: '{{foreground-3}}'; }.md-button.md-THEME_NAME-theme.md-raised[disabled], .md-button.md-THEME_NAME-theme.md-fab[disabled] {  background-color: '{{foreground-4}}'; }.md-button.md-THEME_NAME-theme[disabled] {  background-color: transparent; }._md a.md-THEME_NAME-theme:not(.md-button).md-primary {  color: '{{primary-color}}'; }  ._md a.md-THEME_NAME-theme:not(.md-button).md-primary:hover {    color: '{{primary-700}}'; }._md a.md-THEME_NAME-theme:not(.md-button).md-accent {  color: '{{accent-color}}'; }  ._md a.md-THEME_NAME-theme:not(.md-button).md-accent:hover {    color: '{{accent-700}}'; }._md a.md-THEME_NAME-theme:not(.md-button).md-accent {  color: '{{accent-color}}'; }  ._md a.md-THEME_NAME-theme:not(.md-button).md-accent:hover {    color: '{{accent-A700}}'; }._md a.md-THEME_NAME-theme:not(.md-button).md-warn {  color: '{{warn-color}}'; }  ._md a.md-THEME_NAME-theme:not(.md-button).md-warn:hover {    color: '{{warn-700}}'; }md-card.md-THEME_NAME-theme {  color: '{{foreground-1}}';  background-color: '{{background-hue-1}}';  border-radius: 2px; }  md-card.md-THEME_NAME-theme .md-card-image {    border-radius: 2px 2px 0 0; }  md-card.md-THEME_NAME-theme md-card-header md-card-avatar md-icon {    color: '{{background-color}}';    background-color: '{{foreground-3}}'; }  md-card.md-THEME_NAME-theme md-card-header md-card-header-text .md-subhead {    color: '{{foreground-2}}'; }  md-card.md-THEME_NAME-theme md-card-title md-card-title-text:not(:only-child) .md-subhead {    color: '{{foreground-2}}'; }md-chips.md-THEME_NAME-theme .md-chips {  box-shadow: 0 1px '{{foreground-4}}'; }  md-chips.md-THEME_NAME-theme .md-chips.md-focused {    box-shadow: 0 2px '{{primary-color}}'; }  md-chips.md-THEME_NAME-theme .md-chips .md-chip-input-container input {    color: '{{foreground-1}}'; }    md-chips.md-THEME_NAME-theme .md-chips .md-chip-input-container input::-webkit-input-placeholder {      color: '{{foreground-3}}'; }    md-chips.md-THEME_NAME-theme .md-chips .md-chip-input-container input:-moz-placeholder {      color: '{{foreground-3}}'; }    md-chips.md-THEME_NAME-theme .md-chips .md-chip-input-container input::-moz-placeholder {      color: '{{foreground-3}}'; }    md-chips.md-THEME_NAME-theme .md-chips .md-chip-input-container input:-ms-input-placeholder {      color: '{{foreground-3}}'; }    md-chips.md-THEME_NAME-theme .md-chips .md-chip-input-container input::-webkit-input-placeholder {      color: '{{foreground-3}}'; }md-chips.md-THEME_NAME-theme md-chip {  background: '{{background-300}}';  color: '{{background-800}}'; }  md-chips.md-THEME_NAME-theme md-chip md-icon {    color: '{{background-700}}'; }  md-chips.md-THEME_NAME-theme md-chip.md-focused {    background: '{{primary-color}}';    color: '{{primary-contrast}}'; }    md-chips.md-THEME_NAME-theme md-chip.md-focused md-icon {      color: '{{primary-contrast}}'; }  md-chips.md-THEME_NAME-theme md-chip._md-chip-editing {    background: transparent;    color: '{{background-800}}'; }md-chips.md-THEME_NAME-theme md-chip-remove .md-button md-icon path {  fill: '{{background-500}}'; }.md-contact-suggestion span.md-contact-email {  color: '{{background-400}}'; }md-checkbox.md-THEME_NAME-theme .md-ripple {  color: '{{accent-A700}}'; }md-checkbox.md-THEME_NAME-theme.md-checked .md-ripple {  color: '{{background-600}}'; }md-checkbox.md-THEME_NAME-theme.md-checked.md-focused .md-container:before {  background-color: '{{accent-color-0.26}}'; }md-checkbox.md-THEME_NAME-theme .md-ink-ripple {  color: '{{foreground-2}}'; }md-checkbox.md-THEME_NAME-theme.md-checked .md-ink-ripple {  color: '{{accent-color-0.87}}'; }md-checkbox.md-THEME_NAME-theme:not(.md-checked) .md-icon {  border-color: '{{foreground-2}}'; }md-checkbox.md-THEME_NAME-theme.md-checked .md-icon {  background-color: '{{accent-color-0.87}}'; }md-checkbox.md-THEME_NAME-theme.md-checked .md-icon:after {  border-color: '{{accent-contrast-0.87}}'; }md-checkbox.md-THEME_NAME-theme:not([disabled]).md-primary .md-ripple {  color: '{{primary-600}}'; }md-checkbox.md-THEME_NAME-theme:not([disabled]).md-primary.md-checked .md-ripple {  color: '{{background-600}}'; }md-checkbox.md-THEME_NAME-theme:not([disabled]).md-primary .md-ink-ripple {  color: '{{foreground-2}}'; }md-checkbox.md-THEME_NAME-theme:not([disabled]).md-primary.md-checked .md-ink-ripple {  color: '{{primary-color-0.87}}'; }md-checkbox.md-THEME_NAME-theme:not([disabled]).md-primary:not(.md-checked) .md-icon {  border-color: '{{foreground-2}}'; }md-checkbox.md-THEME_NAME-theme:not([disabled]).md-primary.md-checked .md-icon {  background-color: '{{primary-color-0.87}}'; }md-checkbox.md-THEME_NAME-theme:not([disabled]).md-primary.md-checked.md-focused .md-container:before {  background-color: '{{primary-color-0.26}}'; }md-checkbox.md-THEME_NAME-theme:not([disabled]).md-primary.md-checked .md-icon:after {  border-color: '{{primary-contrast-0.87}}'; }md-checkbox.md-THEME_NAME-theme:not([disabled]).md-primary .md-indeterminate[disabled] .md-container {  color: '{{foreground-3}}'; }md-checkbox.md-THEME_NAME-theme:not([disabled]).md-warn .md-ripple {  color: '{{warn-600}}'; }md-checkbox.md-THEME_NAME-theme:not([disabled]).md-warn .md-ink-ripple {  color: '{{foreground-2}}'; }md-checkbox.md-THEME_NAME-theme:not([disabled]).md-warn.md-checked .md-ink-ripple {  color: '{{warn-color-0.87}}'; }md-checkbox.md-THEME_NAME-theme:not([disabled]).md-warn:not(.md-checked) .md-icon {  border-color: '{{foreground-2}}'; }md-checkbox.md-THEME_NAME-theme:not([disabled]).md-warn.md-checked .md-icon {  background-color: '{{warn-color-0.87}}'; }md-checkbox.md-THEME_NAME-theme:not([disabled]).md-warn.md-checked.md-focused:not([disabled]) .md-container:before {  background-color: '{{warn-color-0.26}}'; }md-checkbox.md-THEME_NAME-theme:not([disabled]).md-warn.md-checked .md-icon:after {  border-color: '{{background-200}}'; }md-checkbox.md-THEME_NAME-theme[disabled]:not(.md-checked) .md-icon {  border-color: '{{foreground-3}}'; }md-checkbox.md-THEME_NAME-theme[disabled].md-checked .md-icon {  background-color: '{{foreground-3}}'; }md-checkbox.md-THEME_NAME-theme[disabled].md-checked .md-icon:after {  border-color: '{{background-200}}'; }md-checkbox.md-THEME_NAME-theme[disabled] .md-icon:after {  border-color: '{{foreground-3}}'; }md-checkbox.md-THEME_NAME-theme[disabled] .md-label {  color: '{{foreground-3}}'; }md-content.md-THEME_NAME-theme {  color: '{{foreground-1}}';  background-color: '{{background-default}}'; }/** Theme styles for mdCalendar. */.md-calendar.md-THEME_NAME-theme {  background: '{{background-A100}}';  color: '{{background-A200-0.87}}'; }  .md-calendar.md-THEME_NAME-theme tr:last-child td {    border-bottom-color: '{{background-200}}'; }.md-THEME_NAME-theme .md-calendar-day-header {  background: '{{background-300}}';  color: '{{background-A200-0.87}}'; }.md-THEME_NAME-theme .md-calendar-date.md-calendar-date-today .md-calendar-date-selection-indicator {  border: 1px solid '{{primary-500}}'; }.md-THEME_NAME-theme .md-calendar-date.md-calendar-date-today.md-calendar-date-disabled {  color: '{{primary-500-0.6}}'; }.md-calendar-date.md-focus .md-THEME_NAME-theme .md-calendar-date-selection-indicator, .md-THEME_NAME-theme .md-calendar-date-selection-indicator:hover {  background: '{{background-300}}'; }.md-THEME_NAME-theme .md-calendar-date.md-calendar-selected-date .md-calendar-date-selection-indicator,.md-THEME_NAME-theme .md-calendar-date.md-focus.md-calendar-selected-date .md-calendar-date-selection-indicator {  background: '{{primary-500}}';  color: '{{primary-500-contrast}}';  border-color: transparent; }.md-THEME_NAME-theme .md-calendar-date-disabled,.md-THEME_NAME-theme .md-calendar-month-label-disabled {  color: '{{background-A200-0.435}}'; }/** Theme styles for mdDatepicker. */.md-THEME_NAME-theme .md-datepicker-input {  color: '{{foreground-1}}'; }  .md-THEME_NAME-theme .md-datepicker-input::-webkit-input-placeholder {    color: '{{foreground-3}}'; }  .md-THEME_NAME-theme .md-datepicker-input:-moz-placeholder {    color: '{{foreground-3}}'; }  .md-THEME_NAME-theme .md-datepicker-input::-moz-placeholder {    color: '{{foreground-3}}'; }  .md-THEME_NAME-theme .md-datepicker-input:-ms-input-placeholder {    color: '{{foreground-3}}'; }  .md-THEME_NAME-theme .md-datepicker-input::-webkit-input-placeholder {    color: '{{foreground-3}}'; }.md-THEME_NAME-theme .md-datepicker-input-container {  border-bottom-color: '{{foreground-4}}'; }  .md-THEME_NAME-theme .md-datepicker-input-container.md-datepicker-focused {    border-bottom-color: '{{primary-color}}'; }    .md-accent .md-THEME_NAME-theme .md-datepicker-input-container.md-datepicker-focused {      border-bottom-color: '{{accent-color}}'; }    .md-warn .md-THEME_NAME-theme .md-datepicker-input-container.md-datepicker-focused {      border-bottom-color: '{{warn-A700}}'; }  .md-THEME_NAME-theme .md-datepicker-input-container.md-datepicker-invalid {    border-bottom-color: '{{warn-A700}}'; }.md-THEME_NAME-theme .md-datepicker-calendar-pane {  border-color: '{{background-hue-1}}'; }.md-THEME_NAME-theme .md-datepicker-triangle-button .md-datepicker-expand-triangle {  border-top-color: '{{foreground-3}}'; }.md-THEME_NAME-theme .md-datepicker-triangle-button:hover .md-datepicker-expand-triangle {  border-top-color: '{{foreground-2}}'; }.md-THEME_NAME-theme .md-datepicker-open .md-datepicker-calendar-icon {  color: '{{primary-color}}'; }.md-THEME_NAME-theme .md-datepicker-open.md-accent .md-datepicker-calendar-icon, .md-accent .md-THEME_NAME-theme .md-datepicker-open .md-datepicker-calendar-icon {  color: '{{accent-color}}'; }.md-THEME_NAME-theme .md-datepicker-open.md-warn .md-datepicker-calendar-icon, .md-warn .md-THEME_NAME-theme .md-datepicker-open .md-datepicker-calendar-icon {  color: '{{warn-A700}}'; }.md-THEME_NAME-theme .md-datepicker-calendar {  background: '{{background-A100}}'; }.md-THEME_NAME-theme .md-datepicker-input-mask-opaque {  box-shadow: 0 0 0 9999px \"{{background-hue-1}}\"; }.md-THEME_NAME-theme .md-datepicker-open .md-datepicker-input-container {  background: \"{{background-hue-1}}\"; }md-dialog.md-THEME_NAME-theme {  border-radius: 4px;  background-color: '{{background-hue-1}}';  color: '{{foreground-1}}'; }  md-dialog.md-THEME_NAME-theme.md-content-overflow .md-actions, md-dialog.md-THEME_NAME-theme.md-content-overflow md-dialog-actions {    border-top-color: '{{foreground-4}}'; }md-divider.md-THEME_NAME-theme {  border-top-color: '{{foreground-4}}'; }.layout-row > md-divider.md-THEME_NAME-theme,.layout-xs-row > md-divider.md-THEME_NAME-theme, .layout-gt-xs-row > md-divider.md-THEME_NAME-theme,.layout-sm-row > md-divider.md-THEME_NAME-theme, .layout-gt-sm-row > md-divider.md-THEME_NAME-theme,.layout-md-row > md-divider.md-THEME_NAME-theme, .layout-gt-md-row > md-divider.md-THEME_NAME-theme,.layout-lg-row > md-divider.md-THEME_NAME-theme, .layout-gt-lg-row > md-divider.md-THEME_NAME-theme,.layout-xl-row > md-divider.md-THEME_NAME-theme {  border-right-color: '{{foreground-4}}'; }md-icon.md-THEME_NAME-theme {  color: '{{foreground-2}}'; }  md-icon.md-THEME_NAME-theme.md-primary {    color: '{{primary-color}}'; }  md-icon.md-THEME_NAME-theme.md-accent {    color: '{{accent-color}}'; }  md-icon.md-THEME_NAME-theme.md-warn {    color: '{{warn-color}}'; }md-input-container.md-THEME_NAME-theme .md-input {  color: '{{foreground-1}}';  border-color: '{{foreground-4}}'; }  md-input-container.md-THEME_NAME-theme .md-input::-webkit-input-placeholder {    color: '{{foreground-3}}'; }  md-input-container.md-THEME_NAME-theme .md-input:-moz-placeholder {    color: '{{foreground-3}}'; }  md-input-container.md-THEME_NAME-theme .md-input::-moz-placeholder {    color: '{{foreground-3}}'; }  md-input-container.md-THEME_NAME-theme .md-input:-ms-input-placeholder {    color: '{{foreground-3}}'; }  md-input-container.md-THEME_NAME-theme .md-input::-webkit-input-placeholder {    color: '{{foreground-3}}'; }md-input-container.md-THEME_NAME-theme > md-icon {  color: '{{foreground-1}}'; }md-input-container.md-THEME_NAME-theme label,md-input-container.md-THEME_NAME-theme .md-placeholder {  color: '{{foreground-3}}'; }md-input-container.md-THEME_NAME-theme label.md-required:after {  color: '{{warn-A700}}'; }md-input-container.md-THEME_NAME-theme:not(.md-input-focused):not(.md-input-invalid) label.md-required:after {  color: '{{foreground-2}}'; }md-input-container.md-THEME_NAME-theme .md-input-messages-animation, md-input-container.md-THEME_NAME-theme .md-input-message-animation {  color: '{{warn-A700}}'; }  md-input-container.md-THEME_NAME-theme .md-input-messages-animation .md-char-counter, md-input-container.md-THEME_NAME-theme .md-input-message-animation .md-char-counter {    color: '{{foreground-1}}'; }md-input-container.md-THEME_NAME-theme:not(.md-input-invalid).md-input-has-value label {  color: '{{foreground-2}}'; }md-input-container.md-THEME_NAME-theme:not(.md-input-invalid).md-input-focused .md-input, md-input-container.md-THEME_NAME-theme:not(.md-input-invalid).md-input-resized .md-input {  border-color: '{{primary-color}}'; }md-input-container.md-THEME_NAME-theme:not(.md-input-invalid).md-input-focused label,md-input-container.md-THEME_NAME-theme:not(.md-input-invalid).md-input-focused md-icon {  color: '{{primary-color}}'; }md-input-container.md-THEME_NAME-theme:not(.md-input-invalid).md-input-focused.md-accent .md-input {  border-color: '{{accent-color}}'; }md-input-container.md-THEME_NAME-theme:not(.md-input-invalid).md-input-focused.md-accent label,md-input-container.md-THEME_NAME-theme:not(.md-input-invalid).md-input-focused.md-accent md-icon {  color: '{{accent-color}}'; }md-input-container.md-THEME_NAME-theme:not(.md-input-invalid).md-input-focused.md-warn .md-input {  border-color: '{{warn-A700}}'; }md-input-container.md-THEME_NAME-theme:not(.md-input-invalid).md-input-focused.md-warn label,md-input-container.md-THEME_NAME-theme:not(.md-input-invalid).md-input-focused.md-warn md-icon {  color: '{{warn-A700}}'; }md-input-container.md-THEME_NAME-theme.md-input-invalid .md-input {  border-color: '{{warn-A700}}'; }md-input-container.md-THEME_NAME-theme.md-input-invalid label,md-input-container.md-THEME_NAME-theme.md-input-invalid .md-input-message-animation,md-input-container.md-THEME_NAME-theme.md-input-invalid .md-char-counter {  color: '{{warn-A700}}'; }md-input-container.md-THEME_NAME-theme .md-input[disabled],[disabled] md-input-container.md-THEME_NAME-theme .md-input {  border-bottom-color: transparent;  color: '{{foreground-3}}';  background-image: linear-gradient(to right, \"{{foreground-3}}\" 0%, \"{{foreground-3}}\" 33%, transparent 0%);  background-image: -ms-linear-gradient(left, transparent 0%, \"{{foreground-3}}\" 100%); }md-list.md-THEME_NAME-theme md-list-item.md-2-line .md-list-item-text h3, md-list.md-THEME_NAME-theme md-list-item.md-2-line .md-list-item-text h4,md-list.md-THEME_NAME-theme md-list-item.md-3-line .md-list-item-text h3,md-list.md-THEME_NAME-theme md-list-item.md-3-line .md-list-item-text h4 {  color: '{{foreground-1}}'; }md-list.md-THEME_NAME-theme md-list-item.md-2-line .md-list-item-text p,md-list.md-THEME_NAME-theme md-list-item.md-3-line .md-list-item-text p {  color: '{{foreground-2}}'; }md-list.md-THEME_NAME-theme .md-proxy-focus.md-focused div.md-no-style {  background-color: '{{background-100}}'; }md-list.md-THEME_NAME-theme md-list-item .md-avatar-icon {  background-color: '{{foreground-3}}';  color: '{{background-color}}'; }md-list.md-THEME_NAME-theme md-list-item > md-icon {  color: '{{foreground-2}}'; }  md-list.md-THEME_NAME-theme md-list-item > md-icon.md-highlight {    color: '{{primary-color}}'; }    md-list.md-THEME_NAME-theme md-list-item > md-icon.md-highlight.md-accent {      color: '{{accent-color}}'; }md-menu-content.md-THEME_NAME-theme {  background-color: '{{background-A100}}'; }  md-menu-content.md-THEME_NAME-theme md-menu-item {    color: '{{background-A200-0.87}}'; }    md-menu-content.md-THEME_NAME-theme md-menu-item md-icon {      color: '{{background-A200-0.54}}'; }    md-menu-content.md-THEME_NAME-theme md-menu-item .md-button[disabled] {      color: '{{background-A200-0.25}}'; }      md-menu-content.md-THEME_NAME-theme md-menu-item .md-button[disabled] md-icon {        color: '{{background-A200-0.25}}'; }  md-menu-content.md-THEME_NAME-theme md-menu-divider {    background-color: '{{background-A200-0.11}}'; }md-menu-bar.md-THEME_NAME-theme > button.md-button {  color: '{{foreground-2}}';  border-radius: 2px; }md-menu-bar.md-THEME_NAME-theme md-menu.md-open > button, md-menu-bar.md-THEME_NAME-theme md-menu > button:focus {  outline: none;  background: '{{background-200}}'; }md-menu-bar.md-THEME_NAME-theme.md-open:not(.md-keyboard-mode) md-menu:hover > button {  background-color: '{{ background-500-0.2}}'; }md-menu-bar.md-THEME_NAME-theme:not(.md-keyboard-mode):not(.md-open) md-menu button:hover,md-menu-bar.md-THEME_NAME-theme:not(.md-keyboard-mode):not(.md-open) md-menu button:focus {  background: transparent; }md-menu-content.md-THEME_NAME-theme .md-menu > .md-button:after {  color: '{{background-A200-0.54}}'; }md-menu-content.md-THEME_NAME-theme .md-menu.md-open > .md-button {  background-color: '{{ background-500-0.2}}'; }md-toolbar.md-THEME_NAME-theme.md-menu-toolbar {  background-color: '{{background-A100}}';  color: '{{background-A200}}'; }  md-toolbar.md-THEME_NAME-theme.md-menu-toolbar md-toolbar-filler {    background-color: '{{primary-color}}';    color: '{{background-A100-0.87}}'; }    md-toolbar.md-THEME_NAME-theme.md-menu-toolbar md-toolbar-filler md-icon {      color: '{{background-A100-0.87}}'; }md-nav-bar.md-THEME_NAME-theme .md-nav-bar {  background-color: transparent;  border-color: '{{foreground-4}}'; }md-nav-bar.md-THEME_NAME-theme .md-button._md-nav-button.md-unselected {  color: '{{foreground-2}}'; }md-nav-bar.md-THEME_NAME-theme md-nav-ink-bar {  color: '{{accent-color}}';  background: '{{accent-color}}'; }.md-panel {  background-color: '{{background-900-0.0}}'; }  .md-panel._md-panel-backdrop.md-THEME_NAME-theme {    background-color: '{{background-900-1.0}}'; }md-progress-circular.md-THEME_NAME-theme path {  stroke: '{{primary-color}}'; }md-progress-circular.md-THEME_NAME-theme.md-warn path {  stroke: '{{warn-color}}'; }md-progress-circular.md-THEME_NAME-theme.md-accent path {  stroke: '{{accent-color}}'; }md-progress-linear.md-THEME_NAME-theme .md-container {  background-color: '{{primary-100}}'; }md-progress-linear.md-THEME_NAME-theme .md-bar {  background-color: '{{primary-color}}'; }md-progress-linear.md-THEME_NAME-theme.md-warn .md-container {  background-color: '{{warn-100}}'; }md-progress-linear.md-THEME_NAME-theme.md-warn .md-bar {  background-color: '{{warn-color}}'; }md-progress-linear.md-THEME_NAME-theme.md-accent .md-container {  background-color: '{{accent-100}}'; }md-progress-linear.md-THEME_NAME-theme.md-accent .md-bar {  background-color: '{{accent-color}}'; }md-progress-linear.md-THEME_NAME-theme[md-mode=buffer].md-warn .md-bar1 {  background-color: '{{warn-100}}'; }md-progress-linear.md-THEME_NAME-theme[md-mode=buffer].md-warn .md-dashed:before {  background: radial-gradient(\"{{warn-100}}\" 0%, \"{{warn-100}}\" 16%, transparent 42%); }md-progress-linear.md-THEME_NAME-theme[md-mode=buffer].md-accent .md-bar1 {  background-color: '{{accent-100}}'; }md-progress-linear.md-THEME_NAME-theme[md-mode=buffer].md-accent .md-dashed:before {  background: radial-gradient(\"{{accent-100}}\" 0%, \"{{accent-100}}\" 16%, transparent 42%); }md-radio-button.md-THEME_NAME-theme .md-off {  border-color: '{{foreground-2}}'; }md-radio-button.md-THEME_NAME-theme .md-on {  background-color: '{{accent-color-0.87}}'; }md-radio-button.md-THEME_NAME-theme.md-checked .md-off {  border-color: '{{accent-color-0.87}}'; }md-radio-button.md-THEME_NAME-theme.md-checked .md-ink-ripple {  color: '{{accent-color-0.87}}'; }md-radio-button.md-THEME_NAME-theme .md-container .md-ripple {  color: '{{accent-A700}}'; }md-radio-group.md-THEME_NAME-theme:not([disabled]) .md-primary .md-on, md-radio-group.md-THEME_NAME-theme:not([disabled]).md-primary .md-on,md-radio-button.md-THEME_NAME-theme:not([disabled]) .md-primary .md-on,md-radio-button.md-THEME_NAME-theme:not([disabled]).md-primary .md-on {  background-color: '{{primary-color-0.87}}'; }md-radio-group.md-THEME_NAME-theme:not([disabled]) .md-primary .md-checked .md-off, md-radio-group.md-THEME_NAME-theme:not([disabled]) .md-primary.md-checked .md-off, md-radio-group.md-THEME_NAME-theme:not([disabled]).md-primary .md-checked .md-off, md-radio-group.md-THEME_NAME-theme:not([disabled]).md-primary.md-checked .md-off,md-radio-button.md-THEME_NAME-theme:not([disabled]) .md-primary .md-checked .md-off,md-radio-button.md-THEME_NAME-theme:not([disabled]) .md-primary.md-checked .md-off,md-radio-button.md-THEME_NAME-theme:not([disabled]).md-primary .md-checked .md-off,md-radio-button.md-THEME_NAME-theme:not([disabled]).md-primary.md-checked .md-off {  border-color: '{{primary-color-0.87}}'; }md-radio-group.md-THEME_NAME-theme:not([disabled]) .md-primary .md-checked .md-ink-ripple, md-radio-group.md-THEME_NAME-theme:not([disabled]) .md-primary.md-checked .md-ink-ripple, md-radio-group.md-THEME_NAME-theme:not([disabled]).md-primary .md-checked .md-ink-ripple, md-radio-group.md-THEME_NAME-theme:not([disabled]).md-primary.md-checked .md-ink-ripple,md-radio-button.md-THEME_NAME-theme:not([disabled]) .md-primary .md-checked .md-ink-ripple,md-radio-button.md-THEME_NAME-theme:not([disabled]) .md-primary.md-checked .md-ink-ripple,md-radio-button.md-THEME_NAME-theme:not([disabled]).md-primary .md-checked .md-ink-ripple,md-radio-button.md-THEME_NAME-theme:not([disabled]).md-primary.md-checked .md-ink-ripple {  color: '{{primary-color-0.87}}'; }md-radio-group.md-THEME_NAME-theme:not([disabled]) .md-primary .md-container .md-ripple, md-radio-group.md-THEME_NAME-theme:not([disabled]).md-primary .md-container .md-ripple,md-radio-button.md-THEME_NAME-theme:not([disabled]) .md-primary .md-container .md-ripple,md-radio-button.md-THEME_NAME-theme:not([disabled]).md-primary .md-container .md-ripple {  color: '{{primary-600}}'; }md-radio-group.md-THEME_NAME-theme:not([disabled]) .md-warn .md-on, md-radio-group.md-THEME_NAME-theme:not([disabled]).md-warn .md-on,md-radio-button.md-THEME_NAME-theme:not([disabled]) .md-warn .md-on,md-radio-button.md-THEME_NAME-theme:not([disabled]).md-warn .md-on {  background-color: '{{warn-color-0.87}}'; }md-radio-group.md-THEME_NAME-theme:not([disabled]) .md-warn .md-checked .md-off, md-radio-group.md-THEME_NAME-theme:not([disabled]) .md-warn.md-checked .md-off, md-radio-group.md-THEME_NAME-theme:not([disabled]).md-warn .md-checked .md-off, md-radio-group.md-THEME_NAME-theme:not([disabled]).md-warn.md-checked .md-off,md-radio-button.md-THEME_NAME-theme:not([disabled]) .md-warn .md-checked .md-off,md-radio-button.md-THEME_NAME-theme:not([disabled]) .md-warn.md-checked .md-off,md-radio-button.md-THEME_NAME-theme:not([disabled]).md-warn .md-checked .md-off,md-radio-button.md-THEME_NAME-theme:not([disabled]).md-warn.md-checked .md-off {  border-color: '{{warn-color-0.87}}'; }md-radio-group.md-THEME_NAME-theme:not([disabled]) .md-warn .md-checked .md-ink-ripple, md-radio-group.md-THEME_NAME-theme:not([disabled]) .md-warn.md-checked .md-ink-ripple, md-radio-group.md-THEME_NAME-theme:not([disabled]).md-warn .md-checked .md-ink-ripple, md-radio-group.md-THEME_NAME-theme:not([disabled]).md-warn.md-checked .md-ink-ripple,md-radio-button.md-THEME_NAME-theme:not([disabled]) .md-warn .md-checked .md-ink-ripple,md-radio-button.md-THEME_NAME-theme:not([disabled]) .md-warn.md-checked .md-ink-ripple,md-radio-button.md-THEME_NAME-theme:not([disabled]).md-warn .md-checked .md-ink-ripple,md-radio-button.md-THEME_NAME-theme:not([disabled]).md-warn.md-checked .md-ink-ripple {  color: '{{warn-color-0.87}}'; }md-radio-group.md-THEME_NAME-theme:not([disabled]) .md-warn .md-container .md-ripple, md-radio-group.md-THEME_NAME-theme:not([disabled]).md-warn .md-container .md-ripple,md-radio-button.md-THEME_NAME-theme:not([disabled]) .md-warn .md-container .md-ripple,md-radio-button.md-THEME_NAME-theme:not([disabled]).md-warn .md-container .md-ripple {  color: '{{warn-600}}'; }md-radio-group.md-THEME_NAME-theme[disabled],md-radio-button.md-THEME_NAME-theme[disabled] {  color: '{{foreground-3}}'; }  md-radio-group.md-THEME_NAME-theme[disabled] .md-container .md-off,  md-radio-button.md-THEME_NAME-theme[disabled] .md-container .md-off {    border-color: '{{foreground-3}}'; }  md-radio-group.md-THEME_NAME-theme[disabled] .md-container .md-on,  md-radio-button.md-THEME_NAME-theme[disabled] .md-container .md-on {    border-color: '{{foreground-3}}'; }md-radio-group.md-THEME_NAME-theme .md-checked .md-ink-ripple {  color: '{{accent-color-0.26}}'; }md-radio-group.md-THEME_NAME-theme.md-primary .md-checked:not([disabled]) .md-ink-ripple, md-radio-group.md-THEME_NAME-theme .md-checked:not([disabled]).md-primary .md-ink-ripple {  color: '{{primary-color-0.26}}'; }md-radio-group.md-THEME_NAME-theme .md-checked.md-primary .md-ink-ripple {  color: '{{warn-color-0.26}}'; }md-radio-group.md-THEME_NAME-theme.md-focused:not(:empty) .md-checked .md-container:before {  background-color: '{{accent-color-0.26}}'; }md-radio-group.md-THEME_NAME-theme.md-focused:not(:empty).md-primary .md-checked .md-container:before,md-radio-group.md-THEME_NAME-theme.md-focused:not(:empty) .md-checked.md-primary .md-container:before {  background-color: '{{primary-color-0.26}}'; }md-radio-group.md-THEME_NAME-theme.md-focused:not(:empty).md-warn .md-checked .md-container:before,md-radio-group.md-THEME_NAME-theme.md-focused:not(:empty) .md-checked.md-warn .md-container:before {  background-color: '{{warn-color-0.26}}'; }md-input-container md-select.md-THEME_NAME-theme .md-select-value span:first-child:after {  color: '{{warn-A700}}'; }md-input-container:not(.md-input-focused):not(.md-input-invalid) md-select.md-THEME_NAME-theme .md-select-value span:first-child:after {  color: '{{foreground-3}}'; }md-input-container.md-input-focused:not(.md-input-has-value) md-select.md-THEME_NAME-theme .md-select-value {  color: '{{primary-color}}'; }  md-input-container.md-input-focused:not(.md-input-has-value) md-select.md-THEME_NAME-theme .md-select-value.md-select-placeholder {    color: '{{primary-color}}'; }md-input-container.md-input-invalid md-select.md-THEME_NAME-theme .md-select-value {  color: '{{warn-A700}}' !important;  border-bottom-color: '{{warn-A700}}' !important; }md-input-container.md-input-invalid md-select.md-THEME_NAME-theme.md-no-underline .md-select-value {  border-bottom-color: transparent !important; }md-select.md-THEME_NAME-theme[disabled] .md-select-value {  border-bottom-color: transparent;  background-image: linear-gradient(to right, \"{{foreground-3}}\" 0%, \"{{foreground-3}}\" 33%, transparent 0%);  background-image: -ms-linear-gradient(left, transparent 0%, \"{{foreground-3}}\" 100%); }md-select.md-THEME_NAME-theme .md-select-value {  border-bottom-color: '{{foreground-4}}'; }  md-select.md-THEME_NAME-theme .md-select-value.md-select-placeholder {    color: '{{foreground-3}}'; }  md-select.md-THEME_NAME-theme .md-select-value span:first-child:after {    color: '{{warn-A700}}'; }md-select.md-THEME_NAME-theme.md-no-underline .md-select-value {  border-bottom-color: transparent !important; }md-select.md-THEME_NAME-theme.ng-invalid.ng-touched .md-select-value {  color: '{{warn-A700}}' !important;  border-bottom-color: '{{warn-A700}}' !important; }md-select.md-THEME_NAME-theme.ng-invalid.ng-touched.md-no-underline .md-select-value {  border-bottom-color: transparent !important; }md-select.md-THEME_NAME-theme:not([disabled]):focus .md-select-value {  border-bottom-color: '{{primary-color}}';  color: '{{ foreground-1 }}'; }  md-select.md-THEME_NAME-theme:not([disabled]):focus .md-select-value.md-select-placeholder {    color: '{{ foreground-1 }}'; }md-select.md-THEME_NAME-theme:not([disabled]):focus.md-no-underline .md-select-value {  border-bottom-color: transparent !important; }md-select.md-THEME_NAME-theme:not([disabled]):focus.md-accent .md-select-value {  border-bottom-color: '{{accent-color}}'; }md-select.md-THEME_NAME-theme:not([disabled]):focus.md-warn .md-select-value {  border-bottom-color: '{{warn-color}}'; }md-select.md-THEME_NAME-theme[disabled] .md-select-value {  color: '{{foreground-3}}'; }  md-select.md-THEME_NAME-theme[disabled] .md-select-value.md-select-placeholder {    color: '{{foreground-3}}'; }md-select-menu.md-THEME_NAME-theme md-content {  background: '{{background-A100}}'; }  md-select-menu.md-THEME_NAME-theme md-content md-optgroup {    color: '{{background-600-0.87}}'; }  md-select-menu.md-THEME_NAME-theme md-content md-option {    color: '{{background-900-0.87}}'; }    md-select-menu.md-THEME_NAME-theme md-content md-option[disabled] .md-text {      color: '{{background-400-0.87}}'; }    md-select-menu.md-THEME_NAME-theme md-content md-option:not([disabled]):focus, md-select-menu.md-THEME_NAME-theme md-content md-option:not([disabled]):hover {      background: '{{background-200}}'; }    md-select-menu.md-THEME_NAME-theme md-content md-option[selected] {      color: '{{primary-500}}'; }      md-select-menu.md-THEME_NAME-theme md-content md-option[selected]:focus {        color: '{{primary-600}}'; }      md-select-menu.md-THEME_NAME-theme md-content md-option[selected].md-accent {        color: '{{accent-color}}'; }        md-select-menu.md-THEME_NAME-theme md-content md-option[selected].md-accent:focus {          color: '{{accent-A700}}'; }.md-checkbox-enabled.md-THEME_NAME-theme .md-ripple {  color: '{{primary-600}}'; }.md-checkbox-enabled.md-THEME_NAME-theme[selected] .md-ripple {  color: '{{background-600}}'; }.md-checkbox-enabled.md-THEME_NAME-theme .md-ink-ripple {  color: '{{foreground-2}}'; }.md-checkbox-enabled.md-THEME_NAME-theme[selected] .md-ink-ripple {  color: '{{primary-color-0.87}}'; }.md-checkbox-enabled.md-THEME_NAME-theme:not(.md-checked) .md-icon {  border-color: '{{foreground-2}}'; }.md-checkbox-enabled.md-THEME_NAME-theme[selected] .md-icon {  background-color: '{{primary-color-0.87}}'; }.md-checkbox-enabled.md-THEME_NAME-theme[selected].md-focused .md-container:before {  background-color: '{{primary-color-0.26}}'; }.md-checkbox-enabled.md-THEME_NAME-theme[selected] .md-icon:after {  border-color: '{{primary-contrast-0.87}}'; }.md-checkbox-enabled.md-THEME_NAME-theme .md-indeterminate[disabled] .md-container {  color: '{{foreground-3}}'; }.md-checkbox-enabled.md-THEME_NAME-theme md-option .md-text {  color: '{{background-900-0.87}}'; }md-sidenav.md-THEME_NAME-theme, md-sidenav.md-THEME_NAME-theme md-content {  background-color: '{{background-hue-1}}'; }md-slider.md-THEME_NAME-theme .md-track {  background-color: '{{foreground-3}}'; }md-slider.md-THEME_NAME-theme .md-track-ticks {  color: '{{background-contrast}}'; }md-slider.md-THEME_NAME-theme .md-focus-ring {  background-color: '{{accent-A200-0.2}}'; }md-slider.md-THEME_NAME-theme .md-disabled-thumb {  border-color: '{{background-color}}';  background-color: '{{background-color}}'; }md-slider.md-THEME_NAME-theme.md-min .md-thumb:after {  background-color: '{{background-color}}';  border-color: '{{foreground-3}}'; }md-slider.md-THEME_NAME-theme.md-min .md-focus-ring {  background-color: '{{foreground-3-0.38}}'; }md-slider.md-THEME_NAME-theme.md-min[md-discrete] .md-thumb:after {  background-color: '{{background-contrast}}';  border-color: transparent; }md-slider.md-THEME_NAME-theme.md-min[md-discrete] .md-sign {  background-color: '{{background-400}}'; }  md-slider.md-THEME_NAME-theme.md-min[md-discrete] .md-sign:after {    border-top-color: '{{background-400}}'; }md-slider.md-THEME_NAME-theme.md-min[md-discrete][md-vertical] .md-sign:after {  border-top-color: transparent;  border-left-color: '{{background-400}}'; }md-slider.md-THEME_NAME-theme .md-track.md-track-fill {  background-color: '{{accent-color}}'; }md-slider.md-THEME_NAME-theme .md-thumb:after {  border-color: '{{accent-color}}';  background-color: '{{accent-color}}'; }md-slider.md-THEME_NAME-theme .md-sign {  background-color: '{{accent-color}}'; }  md-slider.md-THEME_NAME-theme .md-sign:after {    border-top-color: '{{accent-color}}'; }md-slider.md-THEME_NAME-theme[md-vertical] .md-sign:after {  border-top-color: transparent;  border-left-color: '{{accent-color}}'; }md-slider.md-THEME_NAME-theme .md-thumb-text {  color: '{{accent-contrast}}'; }md-slider.md-THEME_NAME-theme.md-warn .md-focus-ring {  background-color: '{{warn-200-0.38}}'; }md-slider.md-THEME_NAME-theme.md-warn .md-track.md-track-fill {  background-color: '{{warn-color}}'; }md-slider.md-THEME_NAME-theme.md-warn .md-thumb:after {  border-color: '{{warn-color}}';  background-color: '{{warn-color}}'; }md-slider.md-THEME_NAME-theme.md-warn .md-sign {  background-color: '{{warn-color}}'; }  md-slider.md-THEME_NAME-theme.md-warn .md-sign:after {    border-top-color: '{{warn-color}}'; }md-slider.md-THEME_NAME-theme.md-warn[md-vertical] .md-sign:after {  border-top-color: transparent;  border-left-color: '{{warn-color}}'; }md-slider.md-THEME_NAME-theme.md-warn .md-thumb-text {  color: '{{warn-contrast}}'; }md-slider.md-THEME_NAME-theme.md-primary .md-focus-ring {  background-color: '{{primary-200-0.38}}'; }md-slider.md-THEME_NAME-theme.md-primary .md-track.md-track-fill {  background-color: '{{primary-color}}'; }md-slider.md-THEME_NAME-theme.md-primary .md-thumb:after {  border-color: '{{primary-color}}';  background-color: '{{primary-color}}'; }md-slider.md-THEME_NAME-theme.md-primary .md-sign {  background-color: '{{primary-color}}'; }  md-slider.md-THEME_NAME-theme.md-primary .md-sign:after {    border-top-color: '{{primary-color}}'; }md-slider.md-THEME_NAME-theme.md-primary[md-vertical] .md-sign:after {  border-top-color: transparent;  border-left-color: '{{primary-color}}'; }md-slider.md-THEME_NAME-theme.md-primary .md-thumb-text {  color: '{{primary-contrast}}'; }md-slider.md-THEME_NAME-theme[disabled] .md-thumb:after {  border-color: transparent; }md-slider.md-THEME_NAME-theme[disabled]:not(.md-min) .md-thumb:after, md-slider.md-THEME_NAME-theme[disabled][md-discrete] .md-thumb:after {  background-color: '{{foreground-3}}';  border-color: transparent; }md-slider.md-THEME_NAME-theme[disabled][readonly] .md-sign {  background-color: '{{background-400}}'; }  md-slider.md-THEME_NAME-theme[disabled][readonly] .md-sign:after {    border-top-color: '{{background-400}}'; }md-slider.md-THEME_NAME-theme[disabled][readonly][md-vertical] .md-sign:after {  border-top-color: transparent;  border-left-color: '{{background-400}}'; }md-slider.md-THEME_NAME-theme[disabled][readonly] .md-disabled-thumb {  border-color: transparent;  background-color: transparent; }md-slider-container[disabled] > *:first-child:not(md-slider),md-slider-container[disabled] > *:last-child:not(md-slider) {  color: '{{foreground-3}}'; }.md-subheader.md-THEME_NAME-theme {  color: '{{ foreground-2-0.23 }}';  background-color: '{{background-default}}'; }  .md-subheader.md-THEME_NAME-theme.md-primary {    color: '{{primary-color}}'; }  .md-subheader.md-THEME_NAME-theme.md-accent {    color: '{{accent-color}}'; }  .md-subheader.md-THEME_NAME-theme.md-warn {    color: '{{warn-color}}'; }md-switch.md-THEME_NAME-theme .md-ink-ripple {  color: '{{background-500}}'; }md-switch.md-THEME_NAME-theme .md-thumb {  background-color: '{{background-50}}'; }md-switch.md-THEME_NAME-theme .md-bar {  background-color: '{{background-500}}'; }md-switch.md-THEME_NAME-theme.md-checked .md-ink-ripple {  color: '{{accent-color}}'; }md-switch.md-THEME_NAME-theme.md-checked .md-thumb {  background-color: '{{accent-color}}'; }md-switch.md-THEME_NAME-theme.md-checked .md-bar {  background-color: '{{accent-color-0.5}}'; }md-switch.md-THEME_NAME-theme.md-checked.md-focused .md-thumb:before {  background-color: '{{accent-color-0.26}}'; }md-switch.md-THEME_NAME-theme.md-checked.md-primary .md-ink-ripple {  color: '{{primary-color}}'; }md-switch.md-THEME_NAME-theme.md-checked.md-primary .md-thumb {  background-color: '{{primary-color}}'; }md-switch.md-THEME_NAME-theme.md-checked.md-primary .md-bar {  background-color: '{{primary-color-0.5}}'; }md-switch.md-THEME_NAME-theme.md-checked.md-primary.md-focused .md-thumb:before {  background-color: '{{primary-color-0.26}}'; }md-switch.md-THEME_NAME-theme.md-checked.md-warn .md-ink-ripple {  color: '{{warn-color}}'; }md-switch.md-THEME_NAME-theme.md-checked.md-warn .md-thumb {  background-color: '{{warn-color}}'; }md-switch.md-THEME_NAME-theme.md-checked.md-warn .md-bar {  background-color: '{{warn-color-0.5}}'; }md-switch.md-THEME_NAME-theme.md-checked.md-warn.md-focused .md-thumb:before {  background-color: '{{warn-color-0.26}}'; }md-switch.md-THEME_NAME-theme[disabled] .md-thumb {  background-color: '{{background-400}}'; }md-switch.md-THEME_NAME-theme[disabled] .md-bar {  background-color: '{{foreground-4}}'; }md-tabs.md-THEME_NAME-theme md-tabs-wrapper {  background-color: transparent;  border-color: '{{foreground-4}}'; }md-tabs.md-THEME_NAME-theme .md-paginator md-icon {  color: '{{primary-color}}'; }md-tabs.md-THEME_NAME-theme md-ink-bar {  color: '{{accent-color}}';  background: '{{accent-color}}'; }md-tabs.md-THEME_NAME-theme .md-tab {  color: '{{foreground-2}}'; }  md-tabs.md-THEME_NAME-theme .md-tab[disabled], md-tabs.md-THEME_NAME-theme .md-tab[disabled] md-icon {    color: '{{foreground-3}}'; }  md-tabs.md-THEME_NAME-theme .md-tab.md-active, md-tabs.md-THEME_NAME-theme .md-tab.md-active md-icon, md-tabs.md-THEME_NAME-theme .md-tab.md-focused, md-tabs.md-THEME_NAME-theme .md-tab.md-focused md-icon {    color: '{{primary-color}}'; }  md-tabs.md-THEME_NAME-theme .md-tab.md-focused {    background: '{{primary-color-0.1}}'; }  md-tabs.md-THEME_NAME-theme .md-tab .md-ripple-container {    color: '{{accent-A100}}'; }md-tabs.md-THEME_NAME-theme.md-accent > md-tabs-wrapper {  background-color: '{{accent-color}}'; }  md-tabs.md-THEME_NAME-theme.md-accent > md-tabs-wrapper > md-tabs-canvas > md-pagination-wrapper > md-tab-item:not([disabled]) {    color: '{{accent-A100}}'; }    md-tabs.md-THEME_NAME-theme.md-accent > md-tabs-wrapper > md-tabs-canvas > md-pagination-wrapper > md-tab-item:not([disabled]).md-active, md-tabs.md-THEME_NAME-theme.md-accent > md-tabs-wrapper > md-tabs-canvas > md-pagination-wrapper > md-tab-item:not([disabled]).md-active md-icon, md-tabs.md-THEME_NAME-theme.md-accent > md-tabs-wrapper > md-tabs-canvas > md-pagination-wrapper > md-tab-item:not([disabled]).md-focused, md-tabs.md-THEME_NAME-theme.md-accent > md-tabs-wrapper > md-tabs-canvas > md-pagination-wrapper > md-tab-item:not([disabled]).md-focused md-icon {      color: '{{accent-contrast}}'; }    md-tabs.md-THEME_NAME-theme.md-accent > md-tabs-wrapper > md-tabs-canvas > md-pagination-wrapper > md-tab-item:not([disabled]).md-focused {      background: '{{accent-contrast-0.1}}'; }  md-tabs.md-THEME_NAME-theme.md-accent > md-tabs-wrapper > md-tabs-canvas > md-pagination-wrapper > md-ink-bar {    color: '{{primary-600-1}}';    background: '{{primary-600-1}}'; }md-tabs.md-THEME_NAME-theme.md-primary > md-tabs-wrapper {  background-color: '{{primary-color}}'; }  md-tabs.md-THEME_NAME-theme.md-primary > md-tabs-wrapper > md-tabs-canvas > md-pagination-wrapper > md-tab-item:not([disabled]) {    color: '{{primary-100}}'; }    md-tabs.md-THEME_NAME-theme.md-primary > md-tabs-wrapper > md-tabs-canvas > md-pagination-wrapper > md-tab-item:not([disabled]).md-active, md-tabs.md-THEME_NAME-theme.md-primary > md-tabs-wrapper > md-tabs-canvas > md-pagination-wrapper > md-tab-item:not([disabled]).md-active md-icon, md-tabs.md-THEME_NAME-theme.md-primary > md-tabs-wrapper > md-tabs-canvas > md-pagination-wrapper > md-tab-item:not([disabled]).md-focused, md-tabs.md-THEME_NAME-theme.md-primary > md-tabs-wrapper > md-tabs-canvas > md-pagination-wrapper > md-tab-item:not([disabled]).md-focused md-icon {      color: '{{primary-contrast}}'; }    md-tabs.md-THEME_NAME-theme.md-primary > md-tabs-wrapper > md-tabs-canvas > md-pagination-wrapper > md-tab-item:not([disabled]).md-focused {      background: '{{primary-contrast-0.1}}'; }md-tabs.md-THEME_NAME-theme.md-warn > md-tabs-wrapper {  background-color: '{{warn-color}}'; }  md-tabs.md-THEME_NAME-theme.md-warn > md-tabs-wrapper > md-tabs-canvas > md-pagination-wrapper > md-tab-item:not([disabled]) {    color: '{{warn-100}}'; }    md-tabs.md-THEME_NAME-theme.md-warn > md-tabs-wrapper > md-tabs-canvas > md-pagination-wrapper > md-tab-item:not([disabled]).md-active, md-tabs.md-THEME_NAME-theme.md-warn > md-tabs-wrapper > md-tabs-canvas > md-pagination-wrapper > md-tab-item:not([disabled]).md-active md-icon, md-tabs.md-THEME_NAME-theme.md-warn > md-tabs-wrapper > md-tabs-canvas > md-pagination-wrapper > md-tab-item:not([disabled]).md-focused, md-tabs.md-THEME_NAME-theme.md-warn > md-tabs-wrapper > md-tabs-canvas > md-pagination-wrapper > md-tab-item:not([disabled]).md-focused md-icon {      color: '{{warn-contrast}}'; }    md-tabs.md-THEME_NAME-theme.md-warn > md-tabs-wrapper > md-tabs-canvas > md-pagination-wrapper > md-tab-item:not([disabled]).md-focused {      background: '{{warn-contrast-0.1}}'; }md-toolbar > md-tabs.md-THEME_NAME-theme > md-tabs-wrapper {  background-color: '{{primary-color}}'; }  md-toolbar > md-tabs.md-THEME_NAME-theme > md-tabs-wrapper > md-tabs-canvas > md-pagination-wrapper > md-tab-item:not([disabled]) {    color: '{{primary-100}}'; }    md-toolbar > md-tabs.md-THEME_NAME-theme > md-tabs-wrapper > md-tabs-canvas > md-pagination-wrapper > md-tab-item:not([disabled]).md-active, md-toolbar > md-tabs.md-THEME_NAME-theme > md-tabs-wrapper > md-tabs-canvas > md-pagination-wrapper > md-tab-item:not([disabled]).md-active md-icon, md-toolbar > md-tabs.md-THEME_NAME-theme > md-tabs-wrapper > md-tabs-canvas > md-pagination-wrapper > md-tab-item:not([disabled]).md-focused, md-toolbar > md-tabs.md-THEME_NAME-theme > md-tabs-wrapper > md-tabs-canvas > md-pagination-wrapper > md-tab-item:not([disabled]).md-focused md-icon {      color: '{{primary-contrast}}'; }    md-toolbar > md-tabs.md-THEME_NAME-theme > md-tabs-wrapper > md-tabs-canvas > md-pagination-wrapper > md-tab-item:not([disabled]).md-focused {      background: '{{primary-contrast-0.1}}'; }md-toolbar.md-accent > md-tabs.md-THEME_NAME-theme > md-tabs-wrapper {  background-color: '{{accent-color}}'; }  md-toolbar.md-accent > md-tabs.md-THEME_NAME-theme > md-tabs-wrapper > md-tabs-canvas > md-pagination-wrapper > md-tab-item:not([disabled]) {    color: '{{accent-A100}}'; }    md-toolbar.md-accent > md-tabs.md-THEME_NAME-theme > md-tabs-wrapper > md-tabs-canvas > md-pagination-wrapper > md-tab-item:not([disabled]).md-active, md-toolbar.md-accent > md-tabs.md-THEME_NAME-theme > md-tabs-wrapper > md-tabs-canvas > md-pagination-wrapper > md-tab-item:not([disabled]).md-active md-icon, md-toolbar.md-accent > md-tabs.md-THEME_NAME-theme > md-tabs-wrapper > md-tabs-canvas > md-pagination-wrapper > md-tab-item:not([disabled]).md-focused, md-toolbar.md-accent > md-tabs.md-THEME_NAME-theme > md-tabs-wrapper > md-tabs-canvas > md-pagination-wrapper > md-tab-item:not([disabled]).md-focused md-icon {      color: '{{accent-contrast}}'; }    md-toolbar.md-accent > md-tabs.md-THEME_NAME-theme > md-tabs-wrapper > md-tabs-canvas > md-pagination-wrapper > md-tab-item:not([disabled]).md-focused {      background: '{{accent-contrast-0.1}}'; }  md-toolbar.md-accent > md-tabs.md-THEME_NAME-theme > md-tabs-wrapper > md-tabs-canvas > md-pagination-wrapper > md-ink-bar {    color: '{{primary-600-1}}';    background: '{{primary-600-1}}'; }md-toolbar.md-warn > md-tabs.md-THEME_NAME-theme > md-tabs-wrapper {  background-color: '{{warn-color}}'; }  md-toolbar.md-warn > md-tabs.md-THEME_NAME-theme > md-tabs-wrapper > md-tabs-canvas > md-pagination-wrapper > md-tab-item:not([disabled]) {    color: '{{warn-100}}'; }    md-toolbar.md-warn > md-tabs.md-THEME_NAME-theme > md-tabs-wrapper > md-tabs-canvas > md-pagination-wrapper > md-tab-item:not([disabled]).md-active, md-toolbar.md-warn > md-tabs.md-THEME_NAME-theme > md-tabs-wrapper > md-tabs-canvas > md-pagination-wrapper > md-tab-item:not([disabled]).md-active md-icon, md-toolbar.md-warn > md-tabs.md-THEME_NAME-theme > md-tabs-wrapper > md-tabs-canvas > md-pagination-wrapper > md-tab-item:not([disabled]).md-focused, md-toolbar.md-warn > md-tabs.md-THEME_NAME-theme > md-tabs-wrapper > md-tabs-canvas > md-pagination-wrapper > md-tab-item:not([disabled]).md-focused md-icon {      color: '{{warn-contrast}}'; }    md-toolbar.md-warn > md-tabs.md-THEME_NAME-theme > md-tabs-wrapper > md-tabs-canvas > md-pagination-wrapper > md-tab-item:not([disabled]).md-focused {      background: '{{warn-contrast-0.1}}'; }md-toast.md-THEME_NAME-theme .md-toast-content {  background-color: #323232;  color: '{{background-50}}'; }  md-toast.md-THEME_NAME-theme .md-toast-content .md-button {    color: '{{background-50}}'; }    md-toast.md-THEME_NAME-theme .md-toast-content .md-button.md-highlight {      color: '{{accent-color}}'; }      md-toast.md-THEME_NAME-theme .md-toast-content .md-button.md-highlight.md-primary {        color: '{{primary-color}}'; }      md-toast.md-THEME_NAME-theme .md-toast-content .md-button.md-highlight.md-warn {        color: '{{warn-color}}'; }md-toolbar.md-THEME_NAME-theme:not(.md-menu-toolbar) {  background-color: '{{primary-color}}';  color: '{{primary-contrast}}'; }  md-toolbar.md-THEME_NAME-theme:not(.md-menu-toolbar) md-icon {    color: '{{primary-contrast}}';    fill: '{{primary-contrast}}'; }  md-toolbar.md-THEME_NAME-theme:not(.md-menu-toolbar) .md-button[disabled] md-icon {    color: '{{primary-contrast-0.26}}';    fill: '{{primary-contrast-0.26}}'; }  md-toolbar.md-THEME_NAME-theme:not(.md-menu-toolbar).md-accent {    background-color: '{{accent-color}}';    color: '{{accent-contrast}}'; }    md-toolbar.md-THEME_NAME-theme:not(.md-menu-toolbar).md-accent .md-ink-ripple {      color: '{{accent-contrast}}'; }    md-toolbar.md-THEME_NAME-theme:not(.md-menu-toolbar).md-accent md-icon {      color: '{{accent-contrast}}';      fill: '{{accent-contrast}}'; }    md-toolbar.md-THEME_NAME-theme:not(.md-menu-toolbar).md-accent .md-button[disabled] md-icon {      color: '{{accent-contrast-0.26}}';      fill: '{{accent-contrast-0.26}}'; }  md-toolbar.md-THEME_NAME-theme:not(.md-menu-toolbar).md-warn {    background-color: '{{warn-color}}';    color: '{{warn-contrast}}'; }md-tooltip.md-THEME_NAME-theme {  color: '{{background-700-contrast}}'; }  md-tooltip.md-THEME_NAME-theme .md-content {    background-color: '{{background-700}}'; }/*  Only used with Theme processes */html.md-THEME_NAME-theme, body.md-THEME_NAME-theme {  color: '{{foreground-1}}';  background-color: '{{background-color}}'; }"); 
+angular.module("material.core").constant("$MD_THEME_CSS", "md-autocomplete.md-THEME_NAME-theme{background:\"{{background-A100}}\"}md-autocomplete.md-THEME_NAME-theme[disabled]:not([md-floating-label]){background:\"{{background-100}}\"}md-autocomplete.md-THEME_NAME-theme button md-icon path{fill:\"{{background-600}}\"}md-autocomplete.md-THEME_NAME-theme button:after{background:\"{{background-600-0.3}}\"}.md-autocomplete-suggestions-container.md-THEME_NAME-theme{background:\"{{background-A100}}\"}.md-autocomplete-suggestions-container.md-THEME_NAME-theme li{color:\"{{background-900}}\"}.md-autocomplete-suggestions-container.md-THEME_NAME-theme li .highlight{color:\"{{background-600}}\"}.md-autocomplete-suggestions-container.md-THEME_NAME-theme li.selected,.md-autocomplete-suggestions-container.md-THEME_NAME-theme li:hover{background:\"{{background-200}}\"}md-backdrop{background-color:\"{{background-900-0.0}}\"}md-backdrop.md-opaque.md-THEME_NAME-theme{background-color:\"{{background-900-1.0}}\"}md-bottom-sheet.md-THEME_NAME-theme{background-color:\"{{background-50}}\";border-top-color:\"{{background-300}}\"}md-bottom-sheet.md-THEME_NAME-theme.md-list md-list-item{color:\"{{foreground-1}}\"}md-bottom-sheet.md-THEME_NAME-theme .md-subheader{background-color:\"{{background-50}}\";color:\"{{foreground-1}}\"}.md-button.md-THEME_NAME-theme:not([disabled]).md-focused,.md-button.md-THEME_NAME-theme:not([disabled]):hover{background-color:\"{{background-500-0.2}}\"}.md-button.md-THEME_NAME-theme:not([disabled]).md-icon-button:hover{background-color:transparent}.md-button.md-THEME_NAME-theme.md-fab md-icon{color:\"{{accent-contrast}}\"}.md-button.md-THEME_NAME-theme.md-primary{color:\"{{primary-color}}\"}.md-button.md-THEME_NAME-theme.md-primary.md-fab,.md-button.md-THEME_NAME-theme.md-primary.md-raised{color:\"{{primary-contrast}}\";background-color:\"{{primary-color}}\"}.md-button.md-THEME_NAME-theme.md-primary.md-fab:not([disabled]) md-icon,.md-button.md-THEME_NAME-theme.md-primary.md-raised:not([disabled]) md-icon{color:\"{{primary-contrast}}\"}.md-button.md-THEME_NAME-theme.md-primary.md-fab:not([disabled]).md-focused,.md-button.md-THEME_NAME-theme.md-primary.md-fab:not([disabled]):hover,.md-button.md-THEME_NAME-theme.md-primary.md-raised:not([disabled]).md-focused,.md-button.md-THEME_NAME-theme.md-primary.md-raised:not([disabled]):hover{background-color:\"{{primary-600}}\"}.md-button.md-THEME_NAME-theme.md-primary:not([disabled]) md-icon{color:\"{{primary-color}}\"}.md-button.md-THEME_NAME-theme.md-fab{background-color:\"{{accent-color}}\";color:\"{{accent-contrast}}\"}.md-button.md-THEME_NAME-theme.md-fab:not([disabled]) .md-icon{color:\"{{accent-contrast}}\"}.md-button.md-THEME_NAME-theme.md-fab:not([disabled]).md-focused,.md-button.md-THEME_NAME-theme.md-fab:not([disabled]):hover{background-color:\"{{accent-A700}}\"}.md-button.md-THEME_NAME-theme.md-raised{color:\"{{background-900}}\";background-color:\"{{background-50}}\"}.md-button.md-THEME_NAME-theme.md-raised:not([disabled]) md-icon{color:\"{{background-900}}\"}.md-button.md-THEME_NAME-theme.md-raised:not([disabled]):hover{background-color:\"{{background-50}}\"}.md-button.md-THEME_NAME-theme.md-raised:not([disabled]).md-focused{background-color:\"{{background-200}}\"}.md-button.md-THEME_NAME-theme.md-warn{color:\"{{warn-color}}\"}.md-button.md-THEME_NAME-theme.md-warn.md-fab,.md-button.md-THEME_NAME-theme.md-warn.md-raised{color:\"{{warn-contrast}}\";background-color:\"{{warn-color}}\"}.md-button.md-THEME_NAME-theme.md-warn.md-fab:not([disabled]) md-icon,.md-button.md-THEME_NAME-theme.md-warn.md-raised:not([disabled]) md-icon{color:\"{{warn-contrast}}\"}.md-button.md-THEME_NAME-theme.md-warn.md-fab:not([disabled]).md-focused,.md-button.md-THEME_NAME-theme.md-warn.md-fab:not([disabled]):hover,.md-button.md-THEME_NAME-theme.md-warn.md-raised:not([disabled]).md-focused,.md-button.md-THEME_NAME-theme.md-warn.md-raised:not([disabled]):hover{background-color:\"{{warn-600}}\"}.md-button.md-THEME_NAME-theme.md-warn:not([disabled]) md-icon{color:\"{{warn-color}}\"}.md-button.md-THEME_NAME-theme.md-accent{color:\"{{accent-color}}\"}.md-button.md-THEME_NAME-theme.md-accent.md-fab,.md-button.md-THEME_NAME-theme.md-accent.md-raised{color:\"{{accent-contrast}}\";background-color:\"{{accent-color}}\"}.md-button.md-THEME_NAME-theme.md-accent.md-fab:not([disabled]) md-icon,.md-button.md-THEME_NAME-theme.md-accent.md-raised:not([disabled]) md-icon{color:\"{{accent-contrast}}\"}.md-button.md-THEME_NAME-theme.md-accent.md-fab:not([disabled]).md-focused,.md-button.md-THEME_NAME-theme.md-accent.md-fab:not([disabled]):hover,.md-button.md-THEME_NAME-theme.md-accent.md-raised:not([disabled]).md-focused,.md-button.md-THEME_NAME-theme.md-accent.md-raised:not([disabled]):hover{background-color:\"{{accent-A700}}\"}.md-button.md-THEME_NAME-theme.md-accent:not([disabled]) md-icon{color:\"{{accent-color}}\"}.md-button.md-THEME_NAME-theme.md-accent[disabled],.md-button.md-THEME_NAME-theme.md-fab[disabled],.md-button.md-THEME_NAME-theme.md-raised[disabled],.md-button.md-THEME_NAME-theme.md-warn[disabled],.md-button.md-THEME_NAME-theme[disabled]{color:\"{{foreground-3}}\";cursor:default}.md-button.md-THEME_NAME-theme.md-accent[disabled] md-icon,.md-button.md-THEME_NAME-theme.md-fab[disabled] md-icon,.md-button.md-THEME_NAME-theme.md-raised[disabled] md-icon,.md-button.md-THEME_NAME-theme.md-warn[disabled] md-icon,.md-button.md-THEME_NAME-theme[disabled] md-icon{color:\"{{foreground-3}}\"}.md-button.md-THEME_NAME-theme.md-fab[disabled],.md-button.md-THEME_NAME-theme.md-raised[disabled]{background-color:\"{{foreground-4}}\"}.md-button.md-THEME_NAME-theme[disabled]{background-color:transparent}._md a.md-THEME_NAME-theme:not(.md-button).md-primary{color:\"{{primary-color}}\"}._md a.md-THEME_NAME-theme:not(.md-button).md-primary:hover{color:\"{{primary-700}}\"}._md a.md-THEME_NAME-theme:not(.md-button).md-accent:hover{color:\"{{accent-700}}\"}._md a.md-THEME_NAME-theme:not(.md-button).md-accent{color:\"{{accent-color}}\"}._md a.md-THEME_NAME-theme:not(.md-button).md-accent:hover{color:\"{{accent-A700}}\"}._md a.md-THEME_NAME-theme:not(.md-button).md-warn{color:\"{{warn-color}}\"}._md a.md-THEME_NAME-theme:not(.md-button).md-warn:hover{color:\"{{warn-700}}\"}md-card.md-THEME_NAME-theme{color:\"{{foreground-1}}\";background-color:\"{{background-hue-1}}\";border-radius:2px}md-card.md-THEME_NAME-theme .md-card-image{border-radius:2px 2px 0 0}md-card.md-THEME_NAME-theme md-card-header md-card-avatar md-icon{color:\"{{background-color}}\";background-color:\"{{foreground-3}}\"}md-card.md-THEME_NAME-theme md-card-header md-card-header-text .md-subhead,md-card.md-THEME_NAME-theme md-card-title md-card-title-text:not(:only-child) .md-subhead{color:\"{{foreground-2}}\"}md-checkbox.md-THEME_NAME-theme .md-ripple{color:\"{{accent-A700}}\"}md-checkbox.md-THEME_NAME-theme.md-checked .md-ripple{color:\"{{background-600}}\"}md-checkbox.md-THEME_NAME-theme.md-checked.md-focused .md-container:before{background-color:\"{{accent-color-0.26}}\"}md-checkbox.md-THEME_NAME-theme .md-ink-ripple{color:\"{{foreground-2}}\"}md-checkbox.md-THEME_NAME-theme.md-checked .md-ink-ripple{color:\"{{accent-color-0.87}}\"}md-checkbox.md-THEME_NAME-theme:not(.md-checked) .md-icon{border-color:\"{{foreground-2}}\"}md-checkbox.md-THEME_NAME-theme.md-checked .md-icon{background-color:\"{{accent-color-0.87}}\"}md-checkbox.md-THEME_NAME-theme.md-checked .md-icon:after{border-color:\"{{accent-contrast-0.87}}\"}md-checkbox.md-THEME_NAME-theme:not([disabled]).md-primary .md-ripple{color:\"{{primary-600}}\"}md-checkbox.md-THEME_NAME-theme:not([disabled]).md-primary.md-checked .md-ripple{color:\"{{background-600}}\"}md-checkbox.md-THEME_NAME-theme:not([disabled]).md-primary .md-ink-ripple{color:\"{{foreground-2}}\"}md-checkbox.md-THEME_NAME-theme:not([disabled]).md-primary.md-checked .md-ink-ripple{color:\"{{primary-color-0.87}}\"}md-checkbox.md-THEME_NAME-theme:not([disabled]).md-primary:not(.md-checked) .md-icon{border-color:\"{{foreground-2}}\"}md-checkbox.md-THEME_NAME-theme:not([disabled]).md-primary.md-checked .md-icon{background-color:\"{{primary-color-0.87}}\"}md-checkbox.md-THEME_NAME-theme:not([disabled]).md-primary.md-checked.md-focused .md-container:before{background-color:\"{{primary-color-0.26}}\"}md-checkbox.md-THEME_NAME-theme:not([disabled]).md-primary.md-checked .md-icon:after{border-color:\"{{primary-contrast-0.87}}\"}md-checkbox.md-THEME_NAME-theme:not([disabled]).md-primary .md-indeterminate[disabled] .md-container{color:\"{{foreground-3}}\"}md-checkbox.md-THEME_NAME-theme:not([disabled]).md-warn .md-ripple{color:\"{{warn-600}}\"}md-checkbox.md-THEME_NAME-theme:not([disabled]).md-warn .md-ink-ripple{color:\"{{foreground-2}}\"}md-checkbox.md-THEME_NAME-theme:not([disabled]).md-warn.md-checked .md-ink-ripple{color:\"{{warn-color-0.87}}\"}md-checkbox.md-THEME_NAME-theme:not([disabled]).md-warn:not(.md-checked) .md-icon{border-color:\"{{foreground-2}}\"}md-checkbox.md-THEME_NAME-theme:not([disabled]).md-warn.md-checked .md-icon{background-color:\"{{warn-color-0.87}}\"}md-checkbox.md-THEME_NAME-theme:not([disabled]).md-warn.md-checked.md-focused:not([disabled]) .md-container:before{background-color:\"{{warn-color-0.26}}\"}md-checkbox.md-THEME_NAME-theme:not([disabled]).md-warn.md-checked .md-icon:after{border-color:\"{{background-200}}\"}md-checkbox.md-THEME_NAME-theme[disabled]:not(.md-checked) .md-icon{border-color:\"{{foreground-3}}\"}md-checkbox.md-THEME_NAME-theme[disabled].md-checked .md-icon{background-color:\"{{foreground-3}}\"}md-checkbox.md-THEME_NAME-theme[disabled].md-checked .md-icon:after{border-color:\"{{background-200}}\"}md-checkbox.md-THEME_NAME-theme[disabled] .md-icon:after{border-color:\"{{foreground-3}}\"}md-checkbox.md-THEME_NAME-theme[disabled] .md-label{color:\"{{foreground-3}}\"}md-chips.md-THEME_NAME-theme .md-chips{box-shadow:0 1px \"{{foreground-4}}\"}md-chips.md-THEME_NAME-theme .md-chips.md-focused{box-shadow:0 2px \"{{primary-color}}\"}md-chips.md-THEME_NAME-theme .md-chips .md-chip-input-container input{color:\"{{foreground-1}}\"}md-chips.md-THEME_NAME-theme .md-chips .md-chip-input-container input:-moz-placeholder,md-chips.md-THEME_NAME-theme .md-chips .md-chip-input-container input::-moz-placeholder{color:\"{{foreground-3}}\"}md-chips.md-THEME_NAME-theme .md-chips .md-chip-input-container input:-ms-input-placeholder{color:\"{{foreground-3}}\"}md-chips.md-THEME_NAME-theme .md-chips .md-chip-input-container input::-webkit-input-placeholder{color:\"{{foreground-3}}\"}md-chips.md-THEME_NAME-theme md-chip{background:\"{{background-300}}\";color:\"{{background-800}}\"}md-chips.md-THEME_NAME-theme md-chip md-icon{color:\"{{background-700}}\"}md-chips.md-THEME_NAME-theme md-chip.md-focused{background:\"{{primary-color}}\";color:\"{{primary-contrast}}\"}md-chips.md-THEME_NAME-theme md-chip.md-focused md-icon{color:\"{{primary-contrast}}\"}md-chips.md-THEME_NAME-theme md-chip._md-chip-editing{background:transparent;color:\"{{background-800}}\"}md-chips.md-THEME_NAME-theme md-chip-remove .md-button md-icon path{fill:\"{{background-500}}\"}.md-contact-suggestion span.md-contact-email{color:\"{{background-400}}\"}md-content.md-THEME_NAME-theme{color:\"{{foreground-1}}\";background-color:\"{{background-default}}\"}.md-calendar.md-THEME_NAME-theme{background:\"{{background-A100}}\";color:\"{{background-A200-0.87}}\"}.md-calendar.md-THEME_NAME-theme tr:last-child td{border-bottom-color:\"{{background-200}}\"}.md-THEME_NAME-theme .md-calendar-day-header{background:\"{{background-300}}\";color:\"{{background-A200-0.87}}\"}.md-THEME_NAME-theme .md-calendar-date.md-calendar-date-today .md-calendar-date-selection-indicator{border:1px solid \"{{primary-500}}\"}.md-THEME_NAME-theme .md-calendar-date.md-calendar-date-today.md-calendar-date-disabled{color:\"{{primary-500-0.6}}\"}.md-calendar-date.md-focus .md-THEME_NAME-theme .md-calendar-date-selection-indicator,.md-THEME_NAME-theme .md-calendar-date-selection-indicator:hover{background:\"{{background-300}}\"}.md-THEME_NAME-theme .md-calendar-date.md-calendar-selected-date .md-calendar-date-selection-indicator,.md-THEME_NAME-theme .md-calendar-date.md-focus.md-calendar-selected-date .md-calendar-date-selection-indicator{background:\"{{primary-500}}\";color:\"{{primary-500-contrast}}\";border-color:transparent}.md-THEME_NAME-theme .md-calendar-date-disabled,.md-THEME_NAME-theme .md-calendar-month-label-disabled{color:\"{{background-A200-0.435}}\"}.md-THEME_NAME-theme .md-datepicker-input{color:\"{{foreground-1}}\"}.md-THEME_NAME-theme .md-datepicker-input:-moz-placeholder,.md-THEME_NAME-theme .md-datepicker-input::-moz-placeholder{color:\"{{foreground-3}}\"}.md-THEME_NAME-theme .md-datepicker-input:-ms-input-placeholder{color:\"{{foreground-3}}\"}.md-THEME_NAME-theme .md-datepicker-input::-webkit-input-placeholder{color:\"{{foreground-3}}\"}.md-THEME_NAME-theme .md-datepicker-input-container{border-bottom-color:\"{{foreground-4}}\"}.md-THEME_NAME-theme .md-datepicker-input-container.md-datepicker-focused{border-bottom-color:\"{{primary-color}}\"}.md-accent .md-THEME_NAME-theme .md-datepicker-input-container.md-datepicker-focused{border-bottom-color:\"{{accent-color}}\"}.md-THEME_NAME-theme .md-datepicker-input-container.md-datepicker-invalid,.md-warn .md-THEME_NAME-theme .md-datepicker-input-container.md-datepicker-focused{border-bottom-color:\"{{warn-A700}}\"}.md-THEME_NAME-theme .md-datepicker-calendar-pane{border-color:\"{{background-hue-1}}\"}.md-THEME_NAME-theme .md-datepicker-triangle-button .md-datepicker-expand-triangle{border-top-color:\"{{foreground-2}}\"}.md-THEME_NAME-theme .md-datepicker-open .md-datepicker-calendar-icon{color:\"{{primary-color}}\"}.md-accent .md-THEME_NAME-theme .md-datepicker-open .md-datepicker-calendar-icon,.md-THEME_NAME-theme .md-datepicker-open.md-accent .md-datepicker-calendar-icon{color:\"{{accent-color}}\"}.md-THEME_NAME-theme .md-datepicker-open.md-warn .md-datepicker-calendar-icon,.md-warn .md-THEME_NAME-theme .md-datepicker-open .md-datepicker-calendar-icon{color:\"{{warn-A700}}\"}.md-THEME_NAME-theme .md-datepicker-calendar{background:\"{{background-A100}}\"}.md-THEME_NAME-theme .md-datepicker-input-mask-opaque{box-shadow:0 0 0 9999px \"{{background-hue-1}}\"}.md-THEME_NAME-theme .md-datepicker-open .md-datepicker-input-container{background:\"{{background-hue-1}}\"}md-dialog.md-THEME_NAME-theme{border-radius:4px;background-color:\"{{background-hue-1}}\";color:\"{{foreground-1}}\"}md-dialog.md-THEME_NAME-theme.md-content-overflow .md-actions,md-dialog.md-THEME_NAME-theme.md-content-overflow md-dialog-actions,md-divider.md-THEME_NAME-theme{border-top-color:\"{{foreground-4}}\"}.layout-gt-lg-row>md-divider.md-THEME_NAME-theme,.layout-gt-md-row>md-divider.md-THEME_NAME-theme,.layout-gt-sm-row>md-divider.md-THEME_NAME-theme,.layout-gt-xs-row>md-divider.md-THEME_NAME-theme,.layout-lg-row>md-divider.md-THEME_NAME-theme,.layout-md-row>md-divider.md-THEME_NAME-theme,.layout-row>md-divider.md-THEME_NAME-theme,.layout-sm-row>md-divider.md-THEME_NAME-theme,.layout-xl-row>md-divider.md-THEME_NAME-theme,.layout-xs-row>md-divider.md-THEME_NAME-theme{border-right-color:\"{{foreground-4}}\"}md-icon.md-THEME_NAME-theme{color:\"{{foreground-2}}\"}md-icon.md-THEME_NAME-theme.md-primary{color:\"{{primary-color}}\"}md-icon.md-THEME_NAME-theme.md-accent{color:\"{{accent-color}}\"}md-icon.md-THEME_NAME-theme.md-warn{color:\"{{warn-color}}\"}md-input-container.md-THEME_NAME-theme .md-input{color:\"{{foreground-1}}\";border-color:\"{{foreground-4}}\"}md-input-container.md-THEME_NAME-theme .md-input:-moz-placeholder,md-input-container.md-THEME_NAME-theme .md-input::-moz-placeholder{color:\"{{foreground-3}}\"}md-input-container.md-THEME_NAME-theme .md-input:-ms-input-placeholder{color:\"{{foreground-3}}\"}md-input-container.md-THEME_NAME-theme .md-input::-webkit-input-placeholder{color:\"{{foreground-3}}\"}md-input-container.md-THEME_NAME-theme>md-icon{color:\"{{foreground-1}}\"}md-input-container.md-THEME_NAME-theme .md-placeholder,md-input-container.md-THEME_NAME-theme label{color:\"{{foreground-3}}\"}md-input-container.md-THEME_NAME-theme label.md-required:after{color:\"{{warn-A700}}\"}md-input-container.md-THEME_NAME-theme:not(.md-input-focused):not(.md-input-invalid) label.md-required:after{color:\"{{foreground-2}}\"}md-input-container.md-THEME_NAME-theme .md-input-message-animation,md-input-container.md-THEME_NAME-theme .md-input-messages-animation{color:\"{{warn-A700}}\"}md-input-container.md-THEME_NAME-theme .md-input-message-animation .md-char-counter,md-input-container.md-THEME_NAME-theme .md-input-messages-animation .md-char-counter{color:\"{{foreground-1}}\"}md-input-container.md-THEME_NAME-theme.md-input-focused .md-input:-moz-placeholder,md-input-container.md-THEME_NAME-theme.md-input-focused .md-input::-moz-placeholder{color:\"{{foreground-2}}\"}md-input-container.md-THEME_NAME-theme.md-input-focused .md-input:-ms-input-placeholder{color:\"{{foreground-2}}\"}md-input-container.md-THEME_NAME-theme.md-input-focused .md-input::-webkit-input-placeholder{color:\"{{foreground-2}}\"}md-input-container.md-THEME_NAME-theme:not(.md-input-invalid).md-input-has-value label{color:\"{{foreground-2}}\"}md-input-container.md-THEME_NAME-theme:not(.md-input-invalid).md-input-focused .md-input,md-input-container.md-THEME_NAME-theme:not(.md-input-invalid).md-input-resized .md-input{border-color:\"{{primary-color}}\"}md-input-container.md-THEME_NAME-theme:not(.md-input-invalid).md-input-focused label,md-input-container.md-THEME_NAME-theme:not(.md-input-invalid).md-input-focused md-icon{color:\"{{primary-color}}\"}md-input-container.md-THEME_NAME-theme:not(.md-input-invalid).md-input-focused.md-accent .md-input{border-color:\"{{accent-color}}\"}md-input-container.md-THEME_NAME-theme:not(.md-input-invalid).md-input-focused.md-accent label,md-input-container.md-THEME_NAME-theme:not(.md-input-invalid).md-input-focused.md-accent md-icon{color:\"{{accent-color}}\"}md-input-container.md-THEME_NAME-theme:not(.md-input-invalid).md-input-focused.md-warn .md-input{border-color:\"{{warn-A700}}\"}md-input-container.md-THEME_NAME-theme:not(.md-input-invalid).md-input-focused.md-warn label,md-input-container.md-THEME_NAME-theme:not(.md-input-invalid).md-input-focused.md-warn md-icon{color:\"{{warn-A700}}\"}md-input-container.md-THEME_NAME-theme.md-input-invalid .md-input{border-color:\"{{warn-A700}}\"}md-input-container.md-THEME_NAME-theme.md-input-invalid .md-char-counter,md-input-container.md-THEME_NAME-theme.md-input-invalid .md-input-message-animation,md-input-container.md-THEME_NAME-theme.md-input-invalid label{color:\"{{warn-A700}}\"}[disabled] md-input-container.md-THEME_NAME-theme .md-input,md-input-container.md-THEME_NAME-theme .md-input[disabled]{border-bottom-color:transparent;color:\"{{foreground-3}}\";background-image:linear-gradient(90deg,\"{{foreground-3}}\" 0,\"{{foreground-3}}\" 33%,transparent 0);background-image:-ms-linear-gradient(left,transparent 0,\"{{foreground-3}}\" 100%)}md-list.md-THEME_NAME-theme md-list-item.md-2-line .md-list-item-text h3,md-list.md-THEME_NAME-theme md-list-item.md-2-line .md-list-item-text h4,md-list.md-THEME_NAME-theme md-list-item.md-3-line .md-list-item-text h3,md-list.md-THEME_NAME-theme md-list-item.md-3-line .md-list-item-text h4{color:\"{{foreground-1}}\"}md-list.md-THEME_NAME-theme md-list-item.md-2-line .md-list-item-text p,md-list.md-THEME_NAME-theme md-list-item.md-3-line .md-list-item-text p{color:\"{{foreground-2}}\"}md-list.md-THEME_NAME-theme .md-proxy-focus.md-focused div.md-no-style{background-color:\"{{background-100}}\"}md-list.md-THEME_NAME-theme md-list-item .md-avatar-icon{background-color:\"{{foreground-3}}\";color:\"{{background-color}}\"}md-list.md-THEME_NAME-theme md-list-item>md-icon{color:\"{{foreground-2}}\"}md-list.md-THEME_NAME-theme md-list-item>md-icon.md-highlight{color:\"{{primary-color}}\"}md-list.md-THEME_NAME-theme md-list-item>md-icon.md-highlight.md-accent{color:\"{{accent-color}}\"}md-menu-content.md-THEME_NAME-theme{background-color:\"{{background-A100}}\"}md-menu-content.md-THEME_NAME-theme md-menu-item{color:\"{{background-A200-0.87}}\"}md-menu-content.md-THEME_NAME-theme md-menu-item md-icon{color:\"{{background-A200-0.54}}\"}md-menu-content.md-THEME_NAME-theme md-menu-item .md-button[disabled],md-menu-content.md-THEME_NAME-theme md-menu-item .md-button[disabled] md-icon{color:\"{{background-A200-0.25}}\"}md-menu-content.md-THEME_NAME-theme md-menu-divider{background-color:\"{{background-A200-0.11}}\"}md-menu-bar.md-THEME_NAME-theme>button.md-button{color:\"{{foreground-2}}\";border-radius:2px}md-menu-bar.md-THEME_NAME-theme md-menu.md-open>button,md-menu-bar.md-THEME_NAME-theme md-menu>button:focus{outline:none;background:\"{{background-200}}\"}md-menu-bar.md-THEME_NAME-theme.md-open:not(.md-keyboard-mode) md-menu:hover>button{background-color:\"{{ background-500-0.2}}\"}md-menu-bar.md-THEME_NAME-theme:not(.md-keyboard-mode):not(.md-open) md-menu button:focus,md-menu-bar.md-THEME_NAME-theme:not(.md-keyboard-mode):not(.md-open) md-menu button:hover{background:transparent}md-menu-content.md-THEME_NAME-theme .md-menu>.md-button:after{color:\"{{background-A200-0.54}}\"}md-menu-content.md-THEME_NAME-theme .md-menu.md-open>.md-button{background-color:\"{{ background-500-0.2}}\"}md-toolbar.md-THEME_NAME-theme.md-menu-toolbar{background-color:\"{{background-A100}}\";color:\"{{background-A200}}\"}md-toolbar.md-THEME_NAME-theme.md-menu-toolbar md-toolbar-filler{background-color:\"{{primary-color}}\";color:\"{{background-A100-0.87}}\"}md-toolbar.md-THEME_NAME-theme.md-menu-toolbar md-toolbar-filler md-icon{color:\"{{background-A100-0.87}}\"}._md-panel-backdrop.md-THEME_NAME-theme{background-color:\"{{background-900-1.0}}\"}md-nav-bar.md-THEME_NAME-theme .md-nav-bar{background-color:transparent;border-color:\"{{foreground-4}}\"}md-nav-bar.md-THEME_NAME-theme .md-button._md-nav-button.md-unselected{color:\"{{foreground-2}}\"}md-nav-bar.md-THEME_NAME-theme md-nav-ink-bar{color:\"{{accent-color}}\";background:\"{{accent-color}}\"}md-progress-circular.md-THEME_NAME-theme path{stroke:\"{{primary-color}}\"}md-progress-circular.md-THEME_NAME-theme.md-warn path{stroke:\"{{warn-color}}\"}md-progress-circular.md-THEME_NAME-theme.md-accent path{stroke:\"{{accent-color}}\"}md-progress-linear.md-THEME_NAME-theme .md-container{background-color:\"{{primary-100}}\"}md-progress-linear.md-THEME_NAME-theme .md-bar{background-color:\"{{primary-color}}\"}md-progress-linear.md-THEME_NAME-theme.md-warn .md-container{background-color:\"{{warn-100}}\"}md-progress-linear.md-THEME_NAME-theme.md-warn .md-bar{background-color:\"{{warn-color}}\"}md-progress-linear.md-THEME_NAME-theme.md-accent .md-container{background-color:\"{{accent-100}}\"}md-progress-linear.md-THEME_NAME-theme.md-accent .md-bar{background-color:\"{{accent-color}}\"}md-progress-linear.md-THEME_NAME-theme[md-mode=buffer].md-warn .md-bar1{background-color:\"{{warn-100}}\"}md-progress-linear.md-THEME_NAME-theme[md-mode=buffer].md-warn .md-dashed:before{background:radial-gradient(\"{{warn-100}}\" 0,\"{{warn-100}}\" 16%,transparent 42%)}md-progress-linear.md-THEME_NAME-theme[md-mode=buffer].md-accent .md-bar1{background-color:\"{{accent-100}}\"}md-progress-linear.md-THEME_NAME-theme[md-mode=buffer].md-accent .md-dashed:before{background:radial-gradient(\"{{accent-100}}\" 0,\"{{accent-100}}\" 16%,transparent 42%)}md-radio-button.md-THEME_NAME-theme .md-off{border-color:\"{{foreground-2}}\"}md-radio-button.md-THEME_NAME-theme .md-on{background-color:\"{{accent-color-0.87}}\"}md-radio-button.md-THEME_NAME-theme.md-checked .md-off{border-color:\"{{accent-color-0.87}}\"}md-radio-button.md-THEME_NAME-theme.md-checked .md-ink-ripple{color:\"{{accent-color-0.87}}\"}md-radio-button.md-THEME_NAME-theme .md-container .md-ripple{color:\"{{accent-A700}}\"}md-radio-button.md-THEME_NAME-theme:not([disabled]).md-primary .md-on,md-radio-button.md-THEME_NAME-theme:not([disabled]) .md-primary .md-on,md-radio-group.md-THEME_NAME-theme:not([disabled]).md-primary .md-on,md-radio-group.md-THEME_NAME-theme:not([disabled]) .md-primary .md-on{background-color:\"{{primary-color-0.87}}\"}md-radio-button.md-THEME_NAME-theme:not([disabled]).md-primary.md-checked .md-off,md-radio-button.md-THEME_NAME-theme:not([disabled]) .md-primary.md-checked .md-off,md-radio-button.md-THEME_NAME-theme:not([disabled]).md-primary .md-checked .md-off,md-radio-button.md-THEME_NAME-theme:not([disabled]) .md-primary .md-checked .md-off,md-radio-group.md-THEME_NAME-theme:not([disabled]).md-primary.md-checked .md-off,md-radio-group.md-THEME_NAME-theme:not([disabled]) .md-primary.md-checked .md-off,md-radio-group.md-THEME_NAME-theme:not([disabled]).md-primary .md-checked .md-off,md-radio-group.md-THEME_NAME-theme:not([disabled]) .md-primary .md-checked .md-off{border-color:\"{{primary-color-0.87}}\"}md-radio-button.md-THEME_NAME-theme:not([disabled]).md-primary.md-checked .md-ink-ripple,md-radio-button.md-THEME_NAME-theme:not([disabled]) .md-primary.md-checked .md-ink-ripple,md-radio-button.md-THEME_NAME-theme:not([disabled]).md-primary .md-checked .md-ink-ripple,md-radio-button.md-THEME_NAME-theme:not([disabled]) .md-primary .md-checked .md-ink-ripple,md-radio-group.md-THEME_NAME-theme:not([disabled]).md-primary.md-checked .md-ink-ripple,md-radio-group.md-THEME_NAME-theme:not([disabled]) .md-primary.md-checked .md-ink-ripple,md-radio-group.md-THEME_NAME-theme:not([disabled]).md-primary .md-checked .md-ink-ripple,md-radio-group.md-THEME_NAME-theme:not([disabled]) .md-primary .md-checked .md-ink-ripple{color:\"{{primary-color-0.87}}\"}md-radio-button.md-THEME_NAME-theme:not([disabled]).md-primary .md-container .md-ripple,md-radio-button.md-THEME_NAME-theme:not([disabled]) .md-primary .md-container .md-ripple,md-radio-group.md-THEME_NAME-theme:not([disabled]).md-primary .md-container .md-ripple,md-radio-group.md-THEME_NAME-theme:not([disabled]) .md-primary .md-container .md-ripple{color:\"{{primary-600}}\"}md-radio-button.md-THEME_NAME-theme:not([disabled]).md-warn .md-on,md-radio-button.md-THEME_NAME-theme:not([disabled]) .md-warn .md-on,md-radio-group.md-THEME_NAME-theme:not([disabled]).md-warn .md-on,md-radio-group.md-THEME_NAME-theme:not([disabled]) .md-warn .md-on{background-color:\"{{warn-color-0.87}}\"}md-radio-button.md-THEME_NAME-theme:not([disabled]).md-warn.md-checked .md-off,md-radio-button.md-THEME_NAME-theme:not([disabled]) .md-warn.md-checked .md-off,md-radio-button.md-THEME_NAME-theme:not([disabled]).md-warn .md-checked .md-off,md-radio-button.md-THEME_NAME-theme:not([disabled]) .md-warn .md-checked .md-off,md-radio-group.md-THEME_NAME-theme:not([disabled]).md-warn.md-checked .md-off,md-radio-group.md-THEME_NAME-theme:not([disabled]) .md-warn.md-checked .md-off,md-radio-group.md-THEME_NAME-theme:not([disabled]).md-warn .md-checked .md-off,md-radio-group.md-THEME_NAME-theme:not([disabled]) .md-warn .md-checked .md-off{border-color:\"{{warn-color-0.87}}\"}md-radio-button.md-THEME_NAME-theme:not([disabled]).md-warn.md-checked .md-ink-ripple,md-radio-button.md-THEME_NAME-theme:not([disabled]) .md-warn.md-checked .md-ink-ripple,md-radio-button.md-THEME_NAME-theme:not([disabled]).md-warn .md-checked .md-ink-ripple,md-radio-button.md-THEME_NAME-theme:not([disabled]) .md-warn .md-checked .md-ink-ripple,md-radio-group.md-THEME_NAME-theme:not([disabled]).md-warn.md-checked .md-ink-ripple,md-radio-group.md-THEME_NAME-theme:not([disabled]) .md-warn.md-checked .md-ink-ripple,md-radio-group.md-THEME_NAME-theme:not([disabled]).md-warn .md-checked .md-ink-ripple,md-radio-group.md-THEME_NAME-theme:not([disabled]) .md-warn .md-checked .md-ink-ripple{color:\"{{warn-color-0.87}}\"}md-radio-button.md-THEME_NAME-theme:not([disabled]).md-warn .md-container .md-ripple,md-radio-button.md-THEME_NAME-theme:not([disabled]) .md-warn .md-container .md-ripple,md-radio-group.md-THEME_NAME-theme:not([disabled]).md-warn .md-container .md-ripple,md-radio-group.md-THEME_NAME-theme:not([disabled]) .md-warn .md-container .md-ripple{color:\"{{warn-600}}\"}md-radio-button.md-THEME_NAME-theme[disabled],md-radio-group.md-THEME_NAME-theme[disabled]{color:\"{{foreground-3}}\"}md-radio-button.md-THEME_NAME-theme[disabled] .md-container .md-off,md-radio-button.md-THEME_NAME-theme[disabled] .md-container .md-on,md-radio-group.md-THEME_NAME-theme[disabled] .md-container .md-off,md-radio-group.md-THEME_NAME-theme[disabled] .md-container .md-on{border-color:\"{{foreground-3}}\"}md-radio-group.md-THEME_NAME-theme .md-checked .md-ink-ripple{color:\"{{accent-color-0.26}}\"}md-radio-group.md-THEME_NAME-theme .md-checked:not([disabled]).md-primary .md-ink-ripple,md-radio-group.md-THEME_NAME-theme.md-primary .md-checked:not([disabled]) .md-ink-ripple{color:\"{{primary-color-0.26}}\"}md-radio-group.md-THEME_NAME-theme .md-checked.md-primary .md-ink-ripple{color:\"{{warn-color-0.26}}\"}md-radio-group.md-THEME_NAME-theme.md-focused:not(:empty) .md-checked .md-container:before{background-color:\"{{accent-color-0.26}}\"}md-radio-group.md-THEME_NAME-theme.md-focused:not(:empty) .md-checked.md-primary .md-container:before,md-radio-group.md-THEME_NAME-theme.md-focused:not(:empty).md-primary .md-checked .md-container:before{background-color:\"{{primary-color-0.26}}\"}md-radio-group.md-THEME_NAME-theme.md-focused:not(:empty) .md-checked.md-warn .md-container:before,md-radio-group.md-THEME_NAME-theme.md-focused:not(:empty).md-warn .md-checked .md-container:before{background-color:\"{{warn-color-0.26}}\"}md-input-container md-select.md-THEME_NAME-theme .md-select-value span:first-child:after{color:\"{{warn-A700}}\"}md-input-container:not(.md-input-focused):not(.md-input-invalid) md-select.md-THEME_NAME-theme .md-select-value span:first-child:after{color:\"{{foreground-3}}\"}md-input-container.md-input-focused:not(.md-input-has-value) md-select.md-THEME_NAME-theme .md-select-value,md-input-container.md-input-focused:not(.md-input-has-value) md-select.md-THEME_NAME-theme .md-select-value.md-select-placeholder{color:\"{{primary-color}}\"}md-input-container.md-input-invalid md-select.md-THEME_NAME-theme .md-select-value{color:\"{{warn-A700}}\"!important;border-bottom-color:\"{{warn-A700}}\"!important}md-input-container.md-input-invalid md-select.md-THEME_NAME-theme.md-no-underline .md-select-value{border-bottom-color:transparent!important}md-select.md-THEME_NAME-theme[disabled] .md-select-value{border-bottom-color:transparent;background-image:linear-gradient(90deg,\"{{foreground-3}}\" 0,\"{{foreground-3}}\" 33%,transparent 0);background-image:-ms-linear-gradient(left,transparent 0,\"{{foreground-3}}\" 100%)}md-select.md-THEME_NAME-theme .md-select-value{border-bottom-color:\"{{foreground-4}}\"}md-select.md-THEME_NAME-theme .md-select-value.md-select-placeholder{color:\"{{foreground-3}}\"}md-select.md-THEME_NAME-theme .md-select-value span:first-child:after{color:\"{{warn-A700}}\"}md-select.md-THEME_NAME-theme.md-no-underline .md-select-value{border-bottom-color:transparent!important}md-select.md-THEME_NAME-theme.ng-invalid.ng-touched .md-select-value{color:\"{{warn-A700}}\"!important;border-bottom-color:\"{{warn-A700}}\"!important}md-select.md-THEME_NAME-theme.ng-invalid.ng-touched.md-no-underline .md-select-value{border-bottom-color:transparent!important}md-select.md-THEME_NAME-theme:not([disabled]):focus .md-select-value{border-bottom-color:\"{{primary-color}}\";color:\"{{ foreground-1 }}\"}md-select.md-THEME_NAME-theme:not([disabled]):focus .md-select-value.md-select-placeholder{color:\"{{ foreground-1 }}\"}md-select.md-THEME_NAME-theme:not([disabled]):focus.md-no-underline .md-select-value{border-bottom-color:transparent!important}md-select.md-THEME_NAME-theme:not([disabled]):focus.md-accent .md-select-value{border-bottom-color:\"{{accent-color}}\"}md-select.md-THEME_NAME-theme:not([disabled]):focus.md-warn .md-select-value{border-bottom-color:\"{{warn-color}}\"}md-select.md-THEME_NAME-theme[disabled] .md-select-icon,md-select.md-THEME_NAME-theme[disabled] .md-select-value,md-select.md-THEME_NAME-theme[disabled] .md-select-value.md-select-placeholder{color:\"{{foreground-3}}\"}md-select.md-THEME_NAME-theme .md-select-icon{color:\"{{foreground-2}}\"}md-select-menu.md-THEME_NAME-theme md-content{background:\"{{background-A100}}\"}md-select-menu.md-THEME_NAME-theme md-content md-optgroup{color:\"{{background-600-0.87}}\"}md-select-menu.md-THEME_NAME-theme md-content md-option{color:\"{{background-900-0.87}}\"}md-select-menu.md-THEME_NAME-theme md-content md-option[disabled] .md-text{color:\"{{background-400-0.87}}\"}md-select-menu.md-THEME_NAME-theme md-content md-option:not([disabled]):focus,md-select-menu.md-THEME_NAME-theme md-content md-option:not([disabled]):hover{background:\"{{background-200}}\"}md-select-menu.md-THEME_NAME-theme md-content md-option[selected]{color:\"{{primary-500}}\"}md-select-menu.md-THEME_NAME-theme md-content md-option[selected]:focus{color:\"{{primary-600}}\"}md-select-menu.md-THEME_NAME-theme md-content md-option[selected].md-accent{color:\"{{accent-color}}\"}md-select-menu.md-THEME_NAME-theme md-content md-option[selected].md-accent:focus{color:\"{{accent-A700}}\"}.md-checkbox-enabled.md-THEME_NAME-theme .md-ripple{color:\"{{primary-600}}\"}.md-checkbox-enabled.md-THEME_NAME-theme[selected] .md-ripple{color:\"{{background-600}}\"}.md-checkbox-enabled.md-THEME_NAME-theme .md-ink-ripple{color:\"{{foreground-2}}\"}.md-checkbox-enabled.md-THEME_NAME-theme[selected] .md-ink-ripple{color:\"{{primary-color-0.87}}\"}.md-checkbox-enabled.md-THEME_NAME-theme:not(.md-checked) .md-icon{border-color:\"{{foreground-2}}\"}.md-checkbox-enabled.md-THEME_NAME-theme[selected] .md-icon{background-color:\"{{primary-color-0.87}}\"}.md-checkbox-enabled.md-THEME_NAME-theme[selected].md-focused .md-container:before{background-color:\"{{primary-color-0.26}}\"}.md-checkbox-enabled.md-THEME_NAME-theme[selected] .md-icon:after{border-color:\"{{primary-contrast-0.87}}\"}.md-checkbox-enabled.md-THEME_NAME-theme .md-indeterminate[disabled] .md-container{color:\"{{foreground-3}}\"}.md-checkbox-enabled.md-THEME_NAME-theme md-option .md-text{color:\"{{background-900-0.87}}\"}md-sidenav.md-THEME_NAME-theme,md-sidenav.md-THEME_NAME-theme md-content{background-color:\"{{background-hue-1}}\"}md-slider.md-THEME_NAME-theme .md-track{background-color:\"{{foreground-3}}\"}md-slider.md-THEME_NAME-theme .md-track-ticks{color:\"{{background-contrast}}\"}md-slider.md-THEME_NAME-theme .md-focus-ring{background-color:\"{{accent-A200-0.2}}\"}md-slider.md-THEME_NAME-theme .md-disabled-thumb{border-color:\"{{background-color}}\";background-color:\"{{background-color}}\"}md-slider.md-THEME_NAME-theme.md-min .md-thumb:after{background-color:\"{{background-color}}\";border-color:\"{{foreground-3}}\"}md-slider.md-THEME_NAME-theme.md-min .md-focus-ring{background-color:\"{{foreground-3-0.38}}\"}md-slider.md-THEME_NAME-theme.md-min[md-discrete] .md-thumb:after{background-color:\"{{background-contrast}}\";border-color:transparent}md-slider.md-THEME_NAME-theme.md-min[md-discrete] .md-sign{background-color:\"{{background-400}}\"}md-slider.md-THEME_NAME-theme.md-min[md-discrete] .md-sign:after{border-top-color:\"{{background-400}}\"}md-slider.md-THEME_NAME-theme.md-min[md-discrete][md-vertical] .md-sign:after{border-top-color:transparent;border-left-color:\"{{background-400}}\"}md-slider.md-THEME_NAME-theme .md-track.md-track-fill{background-color:\"{{accent-color}}\"}md-slider.md-THEME_NAME-theme .md-thumb:after{border-color:\"{{accent-color}}\";background-color:\"{{accent-color}}\"}md-slider.md-THEME_NAME-theme .md-sign{background-color:\"{{accent-color}}\"}md-slider.md-THEME_NAME-theme .md-sign:after{border-top-color:\"{{accent-color}}\"}md-slider.md-THEME_NAME-theme[md-vertical] .md-sign:after{border-top-color:transparent;border-left-color:\"{{accent-color}}\"}md-slider.md-THEME_NAME-theme .md-thumb-text{color:\"{{accent-contrast}}\"}md-slider.md-THEME_NAME-theme.md-warn .md-focus-ring{background-color:\"{{warn-200-0.38}}\"}md-slider.md-THEME_NAME-theme.md-warn .md-track.md-track-fill{background-color:\"{{warn-color}}\"}md-slider.md-THEME_NAME-theme.md-warn .md-thumb:after{border-color:\"{{warn-color}}\";background-color:\"{{warn-color}}\"}md-slider.md-THEME_NAME-theme.md-warn .md-sign{background-color:\"{{warn-color}}\"}md-slider.md-THEME_NAME-theme.md-warn .md-sign:after{border-top-color:\"{{warn-color}}\"}md-slider.md-THEME_NAME-theme.md-warn[md-vertical] .md-sign:after{border-top-color:transparent;border-left-color:\"{{warn-color}}\"}md-slider.md-THEME_NAME-theme.md-warn .md-thumb-text{color:\"{{warn-contrast}}\"}md-slider.md-THEME_NAME-theme.md-primary .md-focus-ring{background-color:\"{{primary-200-0.38}}\"}md-slider.md-THEME_NAME-theme.md-primary .md-track.md-track-fill{background-color:\"{{primary-color}}\"}md-slider.md-THEME_NAME-theme.md-primary .md-thumb:after{border-color:\"{{primary-color}}\";background-color:\"{{primary-color}}\"}md-slider.md-THEME_NAME-theme.md-primary .md-sign{background-color:\"{{primary-color}}\"}md-slider.md-THEME_NAME-theme.md-primary .md-sign:after{border-top-color:\"{{primary-color}}\"}md-slider.md-THEME_NAME-theme.md-primary[md-vertical] .md-sign:after{border-top-color:transparent;border-left-color:\"{{primary-color}}\"}md-slider.md-THEME_NAME-theme.md-primary .md-thumb-text{color:\"{{primary-contrast}}\"}md-slider.md-THEME_NAME-theme[disabled] .md-thumb:after{border-color:transparent}md-slider.md-THEME_NAME-theme[disabled]:not(.md-min) .md-thumb:after,md-slider.md-THEME_NAME-theme[disabled][md-discrete] .md-thumb:after{background-color:\"{{foreground-3}}\";border-color:transparent}md-slider.md-THEME_NAME-theme[disabled][readonly] .md-sign{background-color:\"{{background-400}}\"}md-slider.md-THEME_NAME-theme[disabled][readonly] .md-sign:after{border-top-color:\"{{background-400}}\"}md-slider.md-THEME_NAME-theme[disabled][readonly][md-vertical] .md-sign:after{border-top-color:transparent;border-left-color:\"{{background-400}}\"}md-slider.md-THEME_NAME-theme[disabled][readonly] .md-disabled-thumb{border-color:transparent;background-color:transparent}md-slider-container[disabled]>:first-child:not(md-slider),md-slider-container[disabled]>:last-child:not(md-slider){color:\"{{foreground-3}}\"}.md-subheader.md-THEME_NAME-theme{color:\"{{ foreground-2-0.23 }}\";background-color:\"{{background-default}}\"}.md-subheader.md-THEME_NAME-theme.md-primary{color:\"{{primary-color}}\"}.md-subheader.md-THEME_NAME-theme.md-accent{color:\"{{accent-color}}\"}.md-subheader.md-THEME_NAME-theme.md-warn{color:\"{{warn-color}}\"}md-switch.md-THEME_NAME-theme .md-ink-ripple{color:\"{{background-500}}\"}md-switch.md-THEME_NAME-theme .md-thumb{background-color:\"{{background-50}}\"}md-switch.md-THEME_NAME-theme .md-bar{background-color:\"{{background-500}}\"}md-switch.md-THEME_NAME-theme.md-checked .md-ink-ripple{color:\"{{accent-color}}\"}md-switch.md-THEME_NAME-theme.md-checked .md-thumb{background-color:\"{{accent-color}}\"}md-switch.md-THEME_NAME-theme.md-checked .md-bar{background-color:\"{{accent-color-0.5}}\"}md-switch.md-THEME_NAME-theme.md-checked.md-focused .md-thumb:before{background-color:\"{{accent-color-0.26}}\"}md-switch.md-THEME_NAME-theme.md-checked.md-primary .md-ink-ripple{color:\"{{primary-color}}\"}md-switch.md-THEME_NAME-theme.md-checked.md-primary .md-thumb{background-color:\"{{primary-color}}\"}md-switch.md-THEME_NAME-theme.md-checked.md-primary .md-bar{background-color:\"{{primary-color-0.5}}\"}md-switch.md-THEME_NAME-theme.md-checked.md-primary.md-focused .md-thumb:before{background-color:\"{{primary-color-0.26}}\"}md-switch.md-THEME_NAME-theme.md-checked.md-warn .md-ink-ripple{color:\"{{warn-color}}\"}md-switch.md-THEME_NAME-theme.md-checked.md-warn .md-thumb{background-color:\"{{warn-color}}\"}md-switch.md-THEME_NAME-theme.md-checked.md-warn .md-bar{background-color:\"{{warn-color-0.5}}\"}md-switch.md-THEME_NAME-theme.md-checked.md-warn.md-focused .md-thumb:before{background-color:\"{{warn-color-0.26}}\"}md-switch.md-THEME_NAME-theme[disabled] .md-thumb{background-color:\"{{background-400}}\"}md-switch.md-THEME_NAME-theme[disabled] .md-bar{background-color:\"{{foreground-4}}\"}md-toast.md-THEME_NAME-theme .md-toast-content{background-color:#323232;color:\"{{background-50}}\"}md-toast.md-THEME_NAME-theme .md-toast-content .md-button{color:\"{{background-50}}\"}md-toast.md-THEME_NAME-theme .md-toast-content .md-button.md-highlight{color:\"{{accent-color}}\"}md-toast.md-THEME_NAME-theme .md-toast-content .md-button.md-highlight.md-primary{color:\"{{primary-color}}\"}md-toast.md-THEME_NAME-theme .md-toast-content .md-button.md-highlight.md-warn{color:\"{{warn-color}}\"}md-tabs.md-THEME_NAME-theme md-tabs-wrapper{background-color:transparent;border-color:\"{{foreground-4}}\"}md-tabs.md-THEME_NAME-theme .md-paginator md-icon{color:\"{{primary-color}}\"}md-tabs.md-THEME_NAME-theme md-ink-bar{color:\"{{accent-color}}\";background:\"{{accent-color}}\"}md-tabs.md-THEME_NAME-theme .md-tab{color:\"{{foreground-2}}\"}md-tabs.md-THEME_NAME-theme .md-tab[disabled],md-tabs.md-THEME_NAME-theme .md-tab[disabled] md-icon{color:\"{{foreground-3}}\"}md-tabs.md-THEME_NAME-theme .md-tab.md-active,md-tabs.md-THEME_NAME-theme .md-tab.md-active md-icon,md-tabs.md-THEME_NAME-theme .md-tab.md-focused,md-tabs.md-THEME_NAME-theme .md-tab.md-focused md-icon{color:\"{{primary-color}}\"}md-tabs.md-THEME_NAME-theme .md-tab.md-focused{background:\"{{primary-color-0.1}}\"}md-tabs.md-THEME_NAME-theme .md-tab .md-ripple-container{color:\"{{accent-A100}}\"}md-tabs.md-THEME_NAME-theme.md-accent>md-tabs-wrapper{background-color:\"{{accent-color}}\"}md-tabs.md-THEME_NAME-theme.md-accent>md-tabs-wrapper>md-tabs-canvas>md-pagination-wrapper>md-tab-item:not([disabled]),md-tabs.md-THEME_NAME-theme.md-accent>md-tabs-wrapper>md-tabs-canvas>md-pagination-wrapper>md-tab-item:not([disabled]) md-icon{color:\"{{accent-A100}}\"}md-tabs.md-THEME_NAME-theme.md-accent>md-tabs-wrapper>md-tabs-canvas>md-pagination-wrapper>md-tab-item:not([disabled]).md-active,md-tabs.md-THEME_NAME-theme.md-accent>md-tabs-wrapper>md-tabs-canvas>md-pagination-wrapper>md-tab-item:not([disabled]).md-active md-icon,md-tabs.md-THEME_NAME-theme.md-accent>md-tabs-wrapper>md-tabs-canvas>md-pagination-wrapper>md-tab-item:not([disabled]).md-focused,md-tabs.md-THEME_NAME-theme.md-accent>md-tabs-wrapper>md-tabs-canvas>md-pagination-wrapper>md-tab-item:not([disabled]).md-focused md-icon{color:\"{{accent-contrast}}\"}md-tabs.md-THEME_NAME-theme.md-accent>md-tabs-wrapper>md-tabs-canvas>md-pagination-wrapper>md-tab-item:not([disabled]).md-focused{background:\"{{accent-contrast-0.1}}\"}md-tabs.md-THEME_NAME-theme.md-accent>md-tabs-wrapper>md-tabs-canvas>md-pagination-wrapper>md-ink-bar{color:\"{{primary-600-1}}\";background:\"{{primary-600-1}}\"}md-tabs.md-THEME_NAME-theme.md-primary>md-tabs-wrapper{background-color:\"{{primary-color}}\"}md-tabs.md-THEME_NAME-theme.md-primary>md-tabs-wrapper>md-tabs-canvas>md-pagination-wrapper>md-tab-item:not([disabled]),md-tabs.md-THEME_NAME-theme.md-primary>md-tabs-wrapper>md-tabs-canvas>md-pagination-wrapper>md-tab-item:not([disabled]) md-icon{color:\"{{primary-100}}\"}md-tabs.md-THEME_NAME-theme.md-primary>md-tabs-wrapper>md-tabs-canvas>md-pagination-wrapper>md-tab-item:not([disabled]).md-active,md-tabs.md-THEME_NAME-theme.md-primary>md-tabs-wrapper>md-tabs-canvas>md-pagination-wrapper>md-tab-item:not([disabled]).md-active md-icon,md-tabs.md-THEME_NAME-theme.md-primary>md-tabs-wrapper>md-tabs-canvas>md-pagination-wrapper>md-tab-item:not([disabled]).md-focused,md-tabs.md-THEME_NAME-theme.md-primary>md-tabs-wrapper>md-tabs-canvas>md-pagination-wrapper>md-tab-item:not([disabled]).md-focused md-icon{color:\"{{primary-contrast}}\"}md-tabs.md-THEME_NAME-theme.md-primary>md-tabs-wrapper>md-tabs-canvas>md-pagination-wrapper>md-tab-item:not([disabled]).md-focused{background:\"{{primary-contrast-0.1}}\"}md-tabs.md-THEME_NAME-theme.md-warn>md-tabs-wrapper{background-color:\"{{warn-color}}\"}md-tabs.md-THEME_NAME-theme.md-warn>md-tabs-wrapper>md-tabs-canvas>md-pagination-wrapper>md-tab-item:not([disabled]),md-tabs.md-THEME_NAME-theme.md-warn>md-tabs-wrapper>md-tabs-canvas>md-pagination-wrapper>md-tab-item:not([disabled]) md-icon{color:\"{{warn-100}}\"}md-tabs.md-THEME_NAME-theme.md-warn>md-tabs-wrapper>md-tabs-canvas>md-pagination-wrapper>md-tab-item:not([disabled]).md-active,md-tabs.md-THEME_NAME-theme.md-warn>md-tabs-wrapper>md-tabs-canvas>md-pagination-wrapper>md-tab-item:not([disabled]).md-active md-icon,md-tabs.md-THEME_NAME-theme.md-warn>md-tabs-wrapper>md-tabs-canvas>md-pagination-wrapper>md-tab-item:not([disabled]).md-focused,md-tabs.md-THEME_NAME-theme.md-warn>md-tabs-wrapper>md-tabs-canvas>md-pagination-wrapper>md-tab-item:not([disabled]).md-focused md-icon{color:\"{{warn-contrast}}\"}md-tabs.md-THEME_NAME-theme.md-warn>md-tabs-wrapper>md-tabs-canvas>md-pagination-wrapper>md-tab-item:not([disabled]).md-focused{background:\"{{warn-contrast-0.1}}\"}md-toolbar>md-tabs.md-THEME_NAME-theme>md-tabs-wrapper{background-color:\"{{primary-color}}\"}md-toolbar>md-tabs.md-THEME_NAME-theme>md-tabs-wrapper>md-tabs-canvas>md-pagination-wrapper>md-tab-item:not([disabled]),md-toolbar>md-tabs.md-THEME_NAME-theme>md-tabs-wrapper>md-tabs-canvas>md-pagination-wrapper>md-tab-item:not([disabled]) md-icon{color:\"{{primary-100}}\"}md-toolbar>md-tabs.md-THEME_NAME-theme>md-tabs-wrapper>md-tabs-canvas>md-pagination-wrapper>md-tab-item:not([disabled]).md-active,md-toolbar>md-tabs.md-THEME_NAME-theme>md-tabs-wrapper>md-tabs-canvas>md-pagination-wrapper>md-tab-item:not([disabled]).md-active md-icon,md-toolbar>md-tabs.md-THEME_NAME-theme>md-tabs-wrapper>md-tabs-canvas>md-pagination-wrapper>md-tab-item:not([disabled]).md-focused,md-toolbar>md-tabs.md-THEME_NAME-theme>md-tabs-wrapper>md-tabs-canvas>md-pagination-wrapper>md-tab-item:not([disabled]).md-focused md-icon{color:\"{{primary-contrast}}\"}md-toolbar>md-tabs.md-THEME_NAME-theme>md-tabs-wrapper>md-tabs-canvas>md-pagination-wrapper>md-tab-item:not([disabled]).md-focused{background:\"{{primary-contrast-0.1}}\"}md-toolbar.md-accent>md-tabs.md-THEME_NAME-theme>md-tabs-wrapper{background-color:\"{{accent-color}}\"}md-toolbar.md-accent>md-tabs.md-THEME_NAME-theme>md-tabs-wrapper>md-tabs-canvas>md-pagination-wrapper>md-tab-item:not([disabled]),md-toolbar.md-accent>md-tabs.md-THEME_NAME-theme>md-tabs-wrapper>md-tabs-canvas>md-pagination-wrapper>md-tab-item:not([disabled]) md-icon{color:\"{{accent-A100}}\"}md-toolbar.md-accent>md-tabs.md-THEME_NAME-theme>md-tabs-wrapper>md-tabs-canvas>md-pagination-wrapper>md-tab-item:not([disabled]).md-active,md-toolbar.md-accent>md-tabs.md-THEME_NAME-theme>md-tabs-wrapper>md-tabs-canvas>md-pagination-wrapper>md-tab-item:not([disabled]).md-active md-icon,md-toolbar.md-accent>md-tabs.md-THEME_NAME-theme>md-tabs-wrapper>md-tabs-canvas>md-pagination-wrapper>md-tab-item:not([disabled]).md-focused,md-toolbar.md-accent>md-tabs.md-THEME_NAME-theme>md-tabs-wrapper>md-tabs-canvas>md-pagination-wrapper>md-tab-item:not([disabled]).md-focused md-icon{color:\"{{accent-contrast}}\"}md-toolbar.md-accent>md-tabs.md-THEME_NAME-theme>md-tabs-wrapper>md-tabs-canvas>md-pagination-wrapper>md-tab-item:not([disabled]).md-focused{background:\"{{accent-contrast-0.1}}\"}md-toolbar.md-accent>md-tabs.md-THEME_NAME-theme>md-tabs-wrapper>md-tabs-canvas>md-pagination-wrapper>md-ink-bar{color:\"{{primary-600-1}}\";background:\"{{primary-600-1}}\"}md-toolbar.md-warn>md-tabs.md-THEME_NAME-theme>md-tabs-wrapper{background-color:\"{{warn-color}}\"}md-toolbar.md-warn>md-tabs.md-THEME_NAME-theme>md-tabs-wrapper>md-tabs-canvas>md-pagination-wrapper>md-tab-item:not([disabled]),md-toolbar.md-warn>md-tabs.md-THEME_NAME-theme>md-tabs-wrapper>md-tabs-canvas>md-pagination-wrapper>md-tab-item:not([disabled]) md-icon{color:\"{{warn-100}}\"}md-toolbar.md-warn>md-tabs.md-THEME_NAME-theme>md-tabs-wrapper>md-tabs-canvas>md-pagination-wrapper>md-tab-item:not([disabled]).md-active,md-toolbar.md-warn>md-tabs.md-THEME_NAME-theme>md-tabs-wrapper>md-tabs-canvas>md-pagination-wrapper>md-tab-item:not([disabled]).md-active md-icon,md-toolbar.md-warn>md-tabs.md-THEME_NAME-theme>md-tabs-wrapper>md-tabs-canvas>md-pagination-wrapper>md-tab-item:not([disabled]).md-focused,md-toolbar.md-warn>md-tabs.md-THEME_NAME-theme>md-tabs-wrapper>md-tabs-canvas>md-pagination-wrapper>md-tab-item:not([disabled]).md-focused md-icon{color:\"{{warn-contrast}}\"}md-toolbar.md-warn>md-tabs.md-THEME_NAME-theme>md-tabs-wrapper>md-tabs-canvas>md-pagination-wrapper>md-tab-item:not([disabled]).md-focused{background:\"{{warn-contrast-0.1}}\"}md-toolbar.md-THEME_NAME-theme:not(.md-menu-toolbar){background-color:\"{{primary-color}}\";color:\"{{primary-contrast}}\"}md-toolbar.md-THEME_NAME-theme:not(.md-menu-toolbar) md-icon{color:\"{{primary-contrast}}\";fill:\"{{primary-contrast}}\"}md-toolbar.md-THEME_NAME-theme:not(.md-menu-toolbar) .md-button[disabled] md-icon{color:\"{{primary-contrast-0.26}}\";fill:\"{{primary-contrast-0.26}}\"}md-toolbar.md-THEME_NAME-theme:not(.md-menu-toolbar).md-accent{background-color:\"{{accent-color}}\";color:\"{{accent-contrast}}\"}md-toolbar.md-THEME_NAME-theme:not(.md-menu-toolbar).md-accent .md-ink-ripple{color:\"{{accent-contrast}}\"}md-toolbar.md-THEME_NAME-theme:not(.md-menu-toolbar).md-accent md-icon{color:\"{{accent-contrast}}\";fill:\"{{accent-contrast}}\"}md-toolbar.md-THEME_NAME-theme:not(.md-menu-toolbar).md-accent .md-button[disabled] md-icon{color:\"{{accent-contrast-0.26}}\";fill:\"{{accent-contrast-0.26}}\"}md-toolbar.md-THEME_NAME-theme:not(.md-menu-toolbar).md-warn{background-color:\"{{warn-color}}\";color:\"{{warn-contrast}}\"}.md-panel.md-tooltip.md-THEME_NAME-theme{color:\"{{background-700-contrast}}\";background-color:\"{{background-700}}\"}body.md-THEME_NAME-theme,html.md-THEME_NAME-theme{color:\"{{foreground-1}}\";background-color:\"{{background-color}}\"}"); 
 })();
 
 
-})(window, window.angular);;window.ngMaterial={version:{full: "1.1.1"}};
+})(window, window.angular);;window.ngMaterial={version:{full: "1.1.3"}};

--- a/dist/styles/vendor.min.css
+++ b/dist/styles/vendor.min.css
@@ -2,7 +2,7 @@
  * Angular Material Design
  * https://github.com/angular/material
  * @license MIT
- * v1.1.1
+ * v1.1.3
  */
 html, body {
   height: 100%;
@@ -284,56 +284,57 @@ input {
 *
 *
 */
-@-webkit-keyframes md-autocomplete-list-out {
-  0% {
-    -webkit-animation-timing-function: linear;
-            animation-timing-function: linear; }
-  50% {
-    opacity: 0;
-    height: 40px;
-    -webkit-animation-timing-function: ease-in;
-            animation-timing-function: ease-in; }
-  100% {
-    height: 0;
-    opacity: 0; } }
-@keyframes md-autocomplete-list-out {
-  0% {
-    -webkit-animation-timing-function: linear;
-            animation-timing-function: linear; }
-  50% {
-    opacity: 0;
-    height: 40px;
-    -webkit-animation-timing-function: ease-in;
-            animation-timing-function: ease-in; }
-  100% {
-    height: 0;
-    opacity: 0; } }
+.md-panel-outer-wrapper {
+  height: 100%;
+  left: 0;
+  position: absolute;
+  top: 0;
+  width: 100%; }
 
-@-webkit-keyframes md-autocomplete-list-in {
-  0% {
-    opacity: 0;
-    height: 0;
-    -webkit-animation-timing-function: ease-out;
-            animation-timing-function: ease-out; }
-  50% {
-    opacity: 0;
-    height: 40px; }
-  100% {
-    opacity: 1;
-    height: 40px; } }
+._md-panel-hidden {
+  display: none; }
 
-@keyframes md-autocomplete-list-in {
-  0% {
-    opacity: 0;
-    height: 0;
-    -webkit-animation-timing-function: ease-out;
-            animation-timing-function: ease-out; }
-  50% {
-    opacity: 0;
-    height: 40px; }
-  100% {
+._md-panel-fullscreen {
+  border-radius: 0;
+  left: 0;
+  min-height: 100%;
+  min-width: 100%;
+  position: fixed;
+  top: 0; }
+
+._md-panel-shown .md-panel {
+  opacity: 1;
+  -webkit-transition: none;
+  transition: none; }
+
+.md-panel {
+  opacity: 0;
+  position: fixed; }
+  .md-panel._md-panel-shown {
     opacity: 1;
-    height: 40px; } }
+    -webkit-transition: none;
+    transition: none; }
+  .md-panel._md-panel-animate-enter {
+    opacity: 1;
+    -webkit-transition: all 0.3s cubic-bezier(0, 0, 0.2, 1);
+    transition: all 0.3s cubic-bezier(0, 0, 0.2, 1); }
+  .md-panel._md-panel-animate-leave {
+    opacity: 1;
+    -webkit-transition: all 0.3s cubic-bezier(0.4, 0, 1, 1);
+    transition: all 0.3s cubic-bezier(0.4, 0, 1, 1); }
+  .md-panel._md-panel-animate-scale-out, .md-panel._md-panel-animate-fade-out {
+    opacity: 0; }
+  .md-panel._md-panel-backdrop {
+    height: 100%;
+    position: absolute;
+    width: 100%; }
+  .md-panel._md-opaque-enter {
+    opacity: .48;
+    -webkit-transition: opacity 0.3s cubic-bezier(0, 0, 0.2, 1);
+    transition: opacity 0.3s cubic-bezier(0, 0, 0.2, 1); }
+  .md-panel._md-opaque-leave {
+    -webkit-transition: opacity 0.3s cubic-bezier(0.4, 0, 1, 1);
+    transition: opacity 0.3s cubic-bezier(0.4, 0, 1, 1); }
 
 md-autocomplete {
   border-radius: 2px;
@@ -349,16 +350,21 @@ md-autocomplete {
     background: transparent;
     height: auto; }
     md-autocomplete[md-floating-label] md-input-container {
-      padding-bottom: 0px; }
+      padding-bottom: 0; }
     md-autocomplete[md-floating-label] md-autocomplete-wrap {
       height: auto; }
-    md-autocomplete[md-floating-label] button {
+    md-autocomplete[md-floating-label] .md-show-clear-button button {
+      display: block;
       position: absolute;
-      top: auto;
-      bottom: 0;
       right: 0;
+      top: 20px;
       width: 30px;
       height: 30px; }
+    md-autocomplete[md-floating-label] .md-show-clear-button input {
+      padding-right: 30px; }
+      [dir=rtl] md-autocomplete[md-floating-label] .md-show-clear-button input {
+        padding-right: 0;
+        padding-left: 30px; }
   md-autocomplete md-autocomplete-wrap {
     display: -webkit-box;
     display: -webkit-flex;
@@ -423,7 +429,7 @@ md-autocomplete {
     height: 40px; }
     md-autocomplete input:not(.md-input)::-ms-clear {
       display: none; }
-  md-autocomplete button {
+  md-autocomplete .md-show-clear-button button {
     position: relative;
     line-height: 20px;
     text-align: center;
@@ -436,7 +442,7 @@ md-autocomplete {
     font-size: 12px;
     background: transparent;
     margin: auto 5px; }
-    md-autocomplete button:after {
+    md-autocomplete .md-show-clear-button button:after {
       content: '';
       position: absolute;
       top: -6px;
@@ -449,36 +455,36 @@ md-autocomplete {
       opacity: 0;
       -webkit-transition: all 0.4s cubic-bezier(0.25, 0.8, 0.25, 1);
       transition: all 0.4s cubic-bezier(0.25, 0.8, 0.25, 1); }
-    md-autocomplete button:focus {
+    md-autocomplete .md-show-clear-button button:focus {
       outline: none; }
-      md-autocomplete button:focus:after {
+      md-autocomplete .md-show-clear-button button:focus:after {
         -webkit-transform: scale(1);
                 transform: scale(1);
         opacity: 1; }
-    md-autocomplete button md-icon {
+    md-autocomplete .md-show-clear-button button md-icon {
       position: absolute;
       top: 50%;
       left: 50%;
       -webkit-transform: translate3d(-50%, -50%, 0) scale(0.9);
               transform: translate3d(-50%, -50%, 0) scale(0.9); }
-      md-autocomplete button md-icon path {
+      md-autocomplete .md-show-clear-button button md-icon path {
         stroke-width: 0; }
-    md-autocomplete button.ng-enter {
+    md-autocomplete .md-show-clear-button button.ng-enter {
       -webkit-transform: scale(0);
               transform: scale(0);
       -webkit-transition: -webkit-transform 0.15s ease-out;
       transition: -webkit-transform 0.15s ease-out;
       transition: transform 0.15s ease-out;
       transition: transform 0.15s ease-out, -webkit-transform 0.15s ease-out; }
-      md-autocomplete button.ng-enter.ng-enter-active {
+      md-autocomplete .md-show-clear-button button.ng-enter.ng-enter-active {
         -webkit-transform: scale(1);
                 transform: scale(1); }
-    md-autocomplete button.ng-leave {
+    md-autocomplete .md-show-clear-button button.ng-leave {
       -webkit-transition: -webkit-transform 0.15s ease-out;
       transition: -webkit-transform 0.15s ease-out;
       transition: transform 0.15s ease-out;
       transition: transform 0.15s ease-out, -webkit-transform 0.15s ease-out; }
-      md-autocomplete button.ng-leave.ng-leave-active {
+      md-autocomplete .md-show-clear-button button.ng-leave.ng-leave-active {
         -webkit-transform: scale(0);
                 transform: scale(0); }
   @media screen and (-ms-high-contrast: active) {
@@ -490,9 +496,8 @@ md-autocomplete {
 .md-virtual-repeat-container.md-autocomplete-suggestions-container {
   position: absolute;
   box-shadow: 0 2px 5px rgba(0, 0, 0, 0.25);
-  height: 225.5px;
-  max-height: 225.5px;
-  z-index: 100; }
+  z-index: 100;
+  height: 100%; }
 
 .md-virtual-repeat-container.md-not-found {
   height: 48px; }
@@ -614,7 +619,6 @@ md-bottom-sheet {
     padding: 0;
     -webkit-box-align: center;
     -webkit-align-items: center;
-                -ms-grid-row-align: center;
             align-items: center;
     height: 48px; }
   md-bottom-sheet.md-grid {
@@ -643,7 +647,6 @@ md-bottom-sheet {
               flex-direction: column;
       -webkit-box-align: center;
       -webkit-align-items: center;
-                  -ms-grid-row-align: center;
               align-items: center;
       -webkit-transition: all 0.5s;
       transition: all 0.5s;
@@ -660,12 +663,10 @@ md-bottom-sheet {
           md-bottom-sheet.md-grid md-list-item:nth-of-type(3n + 1) {
             -webkit-box-align: start;
             -webkit-align-items: flex-start;
-                        -ms-grid-row-align: flex-start;
                     align-items: flex-start; }
           md-bottom-sheet.md-grid md-list-item:nth-of-type(3n) {
             -webkit-box-align: end;
             -webkit-align-items: flex-end;
-                        -ms-grid-row-align: flex-end;
                     align-items: flex-end; } }
       @media (min-width: 960px) and (max-width: 1279px) {
         md-bottom-sheet.md-grid md-list-item {
@@ -742,10 +743,9 @@ button.md-button::-moz-focus-inner {
   vertical-align: middle;
   -webkit-box-align: center;
   -webkit-align-items: center;
-              -ms-grid-row-align: center;
           align-items: center;
   text-align: center;
-  border-radius: 3px;
+  border-radius: 2px;
   box-sizing: border-box;
   /* Reset default button appearance */
   -webkit-user-select: none;
@@ -771,6 +771,15 @@ button.md-button::-moz-focus-inner {
   overflow: hidden;
   -webkit-transition: box-shadow 0.4s cubic-bezier(0.25, 0.8, 0.25, 1), background-color 0.4s cubic-bezier(0.25, 0.8, 0.25, 1);
   transition: box-shadow 0.4s cubic-bezier(0.25, 0.8, 0.25, 1), background-color 0.4s cubic-bezier(0.25, 0.8, 0.25, 1); }
+  .md-dense > .md-button:not(.md-dense-disabled),
+  .md-dense :not(.md-dense-disabled) .md-button:not(.md-dense-disabled) {
+    min-height: 32px; }
+  .md-dense > .md-button:not(.md-dense-disabled),
+  .md-dense :not(.md-dense-disabled) .md-button:not(.md-dense-disabled) {
+    line-height: 32px; }
+  .md-dense > .md-button:not(.md-dense-disabled),
+  .md-dense :not(.md-dense-disabled) .md-button:not(.md-dense-disabled) {
+    font-size: 13px; }
   .md-button:focus {
     outline: none; }
   .md-button:hover, .md-button:focus {
@@ -856,7 +865,7 @@ button.md-button::-moz-focus-inner {
   .md-button:not([disabled]).md-raised:active, .md-button:not([disabled]).md-fab:active {
     box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.4); }
   .md-button .md-ripple-container {
-    border-radius: 3px;
+    border-radius: 2px;
     background-clip: padding-box;
     overflow: hidden;
     -webkit-mask-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAA5JREFUeNpiYGBgAAgwAAAEAAGbA+oJAAAAAElFTkSuQmCC"); }
@@ -958,6 +967,9 @@ md-card {
         border-radius: 50%; }
       md-card md-card-header md-card-avatar md-icon {
         padding: 8px; }
+        md-card md-card-header md-card-avatar md-icon > svg {
+          height: inherit;
+          width: inherit; }
       md-card md-card-header md-card-avatar + md-card-header-text {
         max-height: 40px; }
         md-card md-card-header md-card-avatar + md-card-header-text .md-title {
@@ -1113,6 +1125,151 @@ md-card {
 .md-image-no-fill > img {
   width: auto;
   height: auto; }
+
+.md-inline-form md-checkbox {
+  margin: 19px 0 18px; }
+
+md-checkbox {
+  box-sizing: border-box;
+  display: inline-block;
+  margin-bottom: 16px;
+  white-space: nowrap;
+  cursor: pointer;
+  outline: none;
+  -webkit-user-select: none;
+     -moz-user-select: none;
+      -ms-user-select: none;
+          user-select: none;
+  position: relative;
+  min-width: 20px;
+  min-height: 20px;
+  margin-left: 0;
+  margin-right: 16px; }
+  [dir=rtl] md-checkbox {
+    margin-left: 16px; }
+  [dir=rtl] md-checkbox {
+    margin-right: 0; }
+  md-checkbox:last-of-type {
+    margin-left: 0;
+    margin-right: 0; }
+  md-checkbox.md-focused:not([disabled]) .md-container:before {
+    left: -8px;
+    top: -8px;
+    right: -8px;
+    bottom: -8px; }
+  md-checkbox.md-focused:not([disabled]):not(.md-checked) .md-container:before {
+    background-color: rgba(0, 0, 0, 0.12); }
+  md-checkbox.md-align-top-left > div.md-container {
+    top: 12px; }
+  md-checkbox .md-container {
+    position: absolute;
+    top: 50%;
+    -webkit-transform: translateY(-50%);
+            transform: translateY(-50%);
+    box-sizing: border-box;
+    display: inline-block;
+    width: 20px;
+    height: 20px;
+    left: 0;
+    right: auto; }
+    [dir=rtl] md-checkbox .md-container {
+      left: auto; }
+    [dir=rtl] md-checkbox .md-container {
+      right: 0; }
+    md-checkbox .md-container:before {
+      box-sizing: border-box;
+      background-color: transparent;
+      border-radius: 50%;
+      content: '';
+      position: absolute;
+      display: block;
+      height: auto;
+      left: 0;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      -webkit-transition: all 0.5s;
+      transition: all 0.5s;
+      width: auto; }
+    md-checkbox .md-container:after {
+      box-sizing: border-box;
+      content: '';
+      position: absolute;
+      top: -10px;
+      right: -10px;
+      bottom: -10px;
+      left: -10px; }
+    md-checkbox .md-container .md-ripple-container {
+      position: absolute;
+      display: block;
+      width: auto;
+      height: auto;
+      left: -15px;
+      top: -15px;
+      right: -15px;
+      bottom: -15px; }
+  md-checkbox .md-icon {
+    box-sizing: border-box;
+    -webkit-transition: 240ms;
+    transition: 240ms;
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 20px;
+    height: 20px;
+    border-width: 2px;
+    border-style: solid;
+    border-radius: 2px; }
+  md-checkbox.md-checked .md-icon {
+    border-color: transparent; }
+    md-checkbox.md-checked .md-icon:after {
+      box-sizing: border-box;
+      -webkit-transform: rotate(45deg);
+              transform: rotate(45deg);
+      position: absolute;
+      left: 4.66667px;
+      top: 0.22222px;
+      display: table;
+      width: 6.66667px;
+      height: 13.33333px;
+      border-width: 2px;
+      border-style: solid;
+      border-top: 0;
+      border-left: 0;
+      content: ''; }
+  md-checkbox[disabled] {
+    cursor: default; }
+  md-checkbox.md-indeterminate .md-icon:after {
+    box-sizing: border-box;
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    -webkit-transform: translate(-50%, -50%);
+            transform: translate(-50%, -50%);
+    display: table;
+    width: 12px;
+    height: 2px;
+    border-width: 2px;
+    border-style: solid;
+    border-top: 0;
+    border-left: 0;
+    content: ''; }
+  md-checkbox .md-label {
+    box-sizing: border-box;
+    position: relative;
+    display: inline-block;
+    vertical-align: middle;
+    white-space: normal;
+    -webkit-user-select: text;
+       -moz-user-select: text;
+        -ms-user-select: text;
+            user-select: text;
+    margin-left: 30px;
+    margin-right: 0; }
+    [dir=rtl] md-checkbox .md-label {
+      margin-left: 0; }
+    [dir=rtl] md-checkbox .md-label {
+      margin-right: 30px; }
 
 .md-contact-chips .md-chips md-chip {
   padding: 0 25px 0 0; }
@@ -1295,151 +1452,6 @@ md-card {
   .md-chip-input-container md-autocomplete {
     border: none; } }
 
-.md-inline-form md-checkbox {
-  margin: 19px 0 18px; }
-
-md-checkbox {
-  box-sizing: border-box;
-  display: inline-block;
-  margin-bottom: 16px;
-  white-space: nowrap;
-  cursor: pointer;
-  outline: none;
-  -webkit-user-select: none;
-     -moz-user-select: none;
-      -ms-user-select: none;
-          user-select: none;
-  position: relative;
-  min-width: 20px;
-  min-height: 20px;
-  margin-left: 0;
-  margin-right: 16px; }
-  [dir=rtl] md-checkbox {
-    margin-left: 16px; }
-  [dir=rtl] md-checkbox {
-    margin-right: 0; }
-  md-checkbox:last-of-type {
-    margin-left: 0;
-    margin-right: 0; }
-  md-checkbox.md-focused:not([disabled]) .md-container:before {
-    left: -8px;
-    top: -8px;
-    right: -8px;
-    bottom: -8px; }
-  md-checkbox.md-focused:not([disabled]):not(.md-checked) .md-container:before {
-    background-color: rgba(0, 0, 0, 0.12); }
-  md-checkbox.md-align-top-left > div.md-container {
-    top: 12px; }
-  md-checkbox .md-container {
-    position: absolute;
-    top: 50%;
-    -webkit-transform: translateY(-50%);
-            transform: translateY(-50%);
-    box-sizing: border-box;
-    display: inline-block;
-    width: 20px;
-    height: 20px;
-    left: 0;
-    right: auto; }
-    [dir=rtl] md-checkbox .md-container {
-      left: auto; }
-    [dir=rtl] md-checkbox .md-container {
-      right: 0; }
-    md-checkbox .md-container:before {
-      box-sizing: border-box;
-      background-color: transparent;
-      border-radius: 50%;
-      content: '';
-      position: absolute;
-      display: block;
-      height: auto;
-      left: 0;
-      top: 0;
-      right: 0;
-      bottom: 0;
-      -webkit-transition: all 0.5s;
-      transition: all 0.5s;
-      width: auto; }
-    md-checkbox .md-container:after {
-      box-sizing: border-box;
-      content: '';
-      position: absolute;
-      top: -10px;
-      right: -10px;
-      bottom: -10px;
-      left: -10px; }
-    md-checkbox .md-container .md-ripple-container {
-      position: absolute;
-      display: block;
-      width: auto;
-      height: auto;
-      left: -15px;
-      top: -15px;
-      right: -15px;
-      bottom: -15px; }
-  md-checkbox .md-icon {
-    box-sizing: border-box;
-    -webkit-transition: 240ms;
-    transition: 240ms;
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 20px;
-    height: 20px;
-    border-width: 2px;
-    border-style: solid;
-    border-radius: 2px; }
-  md-checkbox.md-checked .md-icon {
-    border-color: transparent; }
-    md-checkbox.md-checked .md-icon:after {
-      box-sizing: border-box;
-      -webkit-transform: rotate(45deg);
-              transform: rotate(45deg);
-      position: absolute;
-      left: 4.66667px;
-      top: 0.22222px;
-      display: table;
-      width: 6.66667px;
-      height: 13.33333px;
-      border-width: 2px;
-      border-style: solid;
-      border-top: 0;
-      border-left: 0;
-      content: ''; }
-  md-checkbox[disabled] {
-    cursor: default; }
-  md-checkbox.md-indeterminate .md-icon:after {
-    box-sizing: border-box;
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    -webkit-transform: translate(-50%, -50%);
-            transform: translate(-50%, -50%);
-    display: table;
-    width: 12px;
-    height: 2px;
-    border-width: 2px;
-    border-style: solid;
-    border-top: 0;
-    border-left: 0;
-    content: ''; }
-  md-checkbox .md-label {
-    box-sizing: border-box;
-    position: relative;
-    display: inline-block;
-    vertical-align: middle;
-    white-space: normal;
-    -webkit-user-select: text;
-       -moz-user-select: text;
-        -ms-user-select: text;
-            user-select: text;
-    margin-left: 30px;
-    margin-right: 0; }
-    [dir=rtl] md-checkbox .md-label {
-      margin-left: 0; }
-    [dir=rtl] md-checkbox .md-label {
-      margin-right: 30px; }
-
 md-content {
   display: block;
   position: relative;
@@ -1570,15 +1582,7 @@ md-calendar {
 md-datepicker {
   white-space: nowrap;
   overflow: hidden;
-  padding-right: 18px;
-  margin-right: -18px;
   vertical-align: middle; }
-  [dir=rtl] md-datepicker {
-    padding-right: 0;
-    padding-left: 18px; }
-  [dir=rtl] md-datepicker {
-    margin-right: auto;
-    margin-left: -18px; }
 
 .md-inline-form md-datepicker {
   margin-top: 12px; }
@@ -1617,9 +1621,13 @@ md-datepicker {
     border: none; }
   ._md-datepicker-floating-label > md-datepicker .md-datepicker-button {
     float: left;
-    margin-top: -2.5px; }
+    margin-top: -12px;
+    top: 9.5px; }
     [dir=rtl] ._md-datepicker-floating-label > md-datepicker .md-datepicker-button {
       float: right; }
+
+._md-datepicker-floating-label .md-input {
+  float: none; }
 
 ._md-datepicker-floating-label._md-datepicker-has-calendar-icon > label:not(.md-no-float):not(.md-container-ignore) {
   right: 18px;
@@ -1635,6 +1643,16 @@ md-datepicker {
   [dir=rtl] ._md-datepicker-floating-label._md-datepicker-has-calendar-icon .md-input-message-animation {
     margin-left: auto;
     margin-right: 64px; }
+
+._md-datepicker-has-triangle-icon {
+  padding-right: 18px;
+  margin-right: -18px; }
+  [dir=rtl] ._md-datepicker-has-triangle-icon {
+    padding-right: 0;
+    padding-left: 18px; }
+  [dir=rtl] ._md-datepicker-has-triangle-icon {
+    margin-right: auto;
+    margin-left: -18px; }
 
 .md-datepicker-input-container {
   position: relative;
@@ -1706,15 +1724,15 @@ md-datepicker {
 .md-datepicker-triangle-button {
   position: absolute;
   right: 0;
-  top: 5px;
-  -webkit-transform: translateY(-25%) translateX(45%);
-          transform: translateY(-25%) translateX(45%); }
+  bottom: -2.5px;
+  -webkit-transform: translateX(45%);
+          transform: translateX(45%); }
   [dir=rtl] .md-datepicker-triangle-button {
     right: auto;
     left: 0; }
   [dir=rtl] .md-datepicker-triangle-button {
-    -webkit-transform: translateY(-25%) translateX(-45%);
-            transform: translateY(-25%) translateX(-45%); }
+    -webkit-transform: translateX(-45%);
+            transform: translateX(-45%); }
 
 .md-datepicker-triangle-button.md-button.md-icon-button {
   height: 36px;
@@ -1952,7 +1970,6 @@ md-fab-speed-dial {
   md-fab-speed-dial.md-is-open .md-fab-action-item {
     -webkit-box-align: center;
     -webkit-align-items: center;
-                -ms-grid-row-align: center;
             align-items: center; }
   md-fab-speed-dial md-fab-actions {
     display: -webkit-box;
@@ -2704,7 +2721,6 @@ md-list-item {
               flex-direction: inherit;
       -webkit-box-align: inherit;
       -webkit-align-items: inherit;
-                  -ms-grid-row-align: inherit;
               align-items: inherit;
       border-radius: 0;
       margin: 0; }
@@ -2774,6 +2790,7 @@ md-list-item {
     md-list-item .md-list-item-inner > md-checkbox,
     md-list-item .md-list-item-inner md-checkbox.md-secondary {
       -webkit-align-self: center;
+                  -ms-grid-row-align: center;
               align-self: center; }
       md-list-item > div.md-primary > md-checkbox .md-label,
       md-list-item > div.md-secondary > md-checkbox .md-label,
@@ -2889,7 +2906,6 @@ md-list-item {
   md-list-item.md-2-line, md-list-item.md-2-line > .md-no-style, md-list-item.md-3-line, md-list-item.md-3-line > .md-no-style {
     -webkit-box-align: start;
     -webkit-align-items: flex-start;
-                -ms-grid-row-align: flex-start;
             align-items: flex-start;
     -webkit-box-pack: center;
     -webkit-justify-content: center;
@@ -3158,21 +3174,16 @@ md-menu-content.md-menu-bar-menu.md-dense {
         padding: 0 64px 0 32px; }
   md-menu-content.md-menu-bar-menu.md-dense .md-button {
     min-height: 0;
-    height: 32px;
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: flex; }
+    height: 32px; }
     md-menu-content.md-menu-bar-menu.md-dense .md-button span {
-      -webkit-box-flex: 1;
-      -webkit-flex-grow: 1;
-              flex-grow: 1; }
+      float: left; }
+      [dir=rtl] md-menu-content.md-menu-bar-menu.md-dense .md-button span {
+        float: right; }
     md-menu-content.md-menu-bar-menu.md-dense .md-button span.md-alt-text {
-      -webkit-box-flex: 0;
-      -webkit-flex-grow: 0;
-              flex-grow: 0;
-      -webkit-align-self: flex-end;
-              align-self: flex-end;
+      float: right;
       margin: 0 8px; }
+      [dir=rtl] md-menu-content.md-menu-bar-menu.md-dense .md-button span.md-alt-text {
+        float: left; }
   md-menu-content.md-menu-bar-menu.md-dense md-menu-divider {
     margin: 8px 0; }
   md-menu-content.md-menu-bar-menu.md-dense md-menu-item > .md-button, md-menu-content.md-menu-bar-menu.md-dense .md-menu > .md-button {
@@ -3256,62 +3267,13 @@ md-nav-ink-bar {
   md-nav-ink-bar._md-right {
     -webkit-transition: left 0.25s cubic-bezier(0.35, 0, 0.25, 1), right 0.125s cubic-bezier(0.35, 0, 0.25, 1);
     transition: left 0.25s cubic-bezier(0.35, 0, 0.25, 1), right 0.125s cubic-bezier(0.35, 0, 0.25, 1); }
+  md-nav-ink-bar.ng-animate {
+    -webkit-transition: none;
+    transition: none; }
 
 md-nav-extra-content {
   min-height: 48px;
   padding-right: 12px; }
-
-.md-panel-outer-wrapper {
-  height: 100%;
-  left: 0;
-  position: absolute;
-  top: 0;
-  width: 100%; }
-
-._md-panel-hidden {
-  display: none; }
-
-._md-panel-fullscreen {
-  border-radius: 0;
-  left: 0;
-  min-height: 100%;
-  min-width: 100%;
-  position: fixed;
-  top: 0; }
-
-._md-panel-shown .md-panel {
-  opacity: 1;
-  -webkit-transition: none;
-  transition: none; }
-
-.md-panel {
-  opacity: 0;
-  position: fixed; }
-  .md-panel._md-panel-shown {
-    opacity: 1;
-    -webkit-transition: none;
-    transition: none; }
-  .md-panel._md-panel-animate-enter {
-    opacity: 1;
-    -webkit-transition: all 0.3s cubic-bezier(0, 0, 0.2, 1);
-    transition: all 0.3s cubic-bezier(0, 0, 0.2, 1); }
-  .md-panel._md-panel-animate-leave {
-    opacity: 1;
-    -webkit-transition: all 0.3s cubic-bezier(0.4, 0, 1, 1);
-    transition: all 0.3s cubic-bezier(0.4, 0, 1, 1); }
-  .md-panel._md-panel-animate-scale-out, .md-panel._md-panel-animate-fade-out {
-    opacity: 0; }
-  .md-panel._md-panel-backdrop {
-    height: 100%;
-    position: absolute;
-    width: 100%; }
-  .md-panel._md-opaque-enter {
-    opacity: .48;
-    -webkit-transition: opacity 0.3s cubic-bezier(0, 0, 0.2, 1);
-    transition: opacity 0.3s cubic-bezier(0, 0, 0.2, 1); }
-  .md-panel._md-opaque-leave {
-    -webkit-transition: opacity 0.3s cubic-bezier(0.4, 0, 1, 1);
-    transition: opacity 0.3s cubic-bezier(0.4, 0, 1, 1); }
 
 @-webkit-keyframes indeterminate-rotate {
   0% {
@@ -3335,8 +3297,8 @@ md-progress-circular {
   md-progress-circular._md-progress-circular-disabled {
     visibility: hidden; }
   md-progress-circular.md-mode-indeterminate svg {
-    -webkit-animation: indeterminate-rotate 2.9s linear infinite;
-            animation: indeterminate-rotate 2.9s linear infinite; }
+    -webkit-animation: indeterminate-rotate 1568.63ms linear infinite;
+            animation: indeterminate-rotate 1568.63ms linear infinite; }
   md-progress-circular svg {
     position: absolute;
     overflow: visible;
@@ -3871,7 +3833,6 @@ md-input-container.md-input-has-value .md-select-value > span:not(.md-select-ico
     display: block;
     -webkit-box-align: end;
     -webkit-align-items: flex-end;
-                -ms-grid-row-align: flex-end;
             align-items: flex-end;
     text-align: end;
     width: 24px;
@@ -4123,30 +4084,40 @@ md-sidenav {
     display: flex;
     -webkit-transform: translate3d(0, 0, 0);
             transform: translate3d(0, 0, 0); }
-  md-sidenav.md-locked-open, md-sidenav.md-locked-open.md-closed, md-sidenav.md-locked-open.md-closed.md-sidenav-left, md-sidenav.md-locked-open.md-closed, md-sidenav.md-locked-open.md-closed.md-sidenav-right, md-sidenav.md-locked-open-remove.md-closed {
+  md-sidenav.md-locked-open, md-sidenav.md-locked-open.md-closed, md-sidenav.md-locked-open.md-closed.md-sidenav-left, md-sidenav.md-locked-open.md-closed, md-sidenav.md-locked-open.md-closed.md-sidenav-right {
     position: static;
     display: -webkit-box;
     display: -webkit-flex;
     display: flex;
     -webkit-transform: translate3d(0, 0, 0);
             transform: translate3d(0, 0, 0); }
+  md-sidenav.md-locked-open-remove.md-closed {
+    position: static;
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: flex;
+    -webkit-transform: translate3d(0, 0, 0);
+            transform: translate3d(0, 0, 0); }
+  md-sidenav.md-closed.md-locked-open-add {
+    position: static;
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: flex;
+    -webkit-transform: translate3d(0%, 0, 0);
+            transform: translate3d(0%, 0, 0); }
+  md-sidenav.md-closed.md-locked-open-add:not(.md-locked-open-add-active) {
+    -webkit-transition: width 0.3s cubic-bezier(0.55, 0, 0.55, 0.2), min-width 0.3s cubic-bezier(0.55, 0, 0.55, 0.2);
+    transition: width 0.3s cubic-bezier(0.55, 0, 0.55, 0.2), min-width 0.3s cubic-bezier(0.55, 0, 0.55, 0.2);
+    width: 0 !important;
+    min-width: 0 !important; }
+  md-sidenav.md-closed.md-locked-open-add-active {
+    -webkit-transition: width 0.3s cubic-bezier(0.55, 0, 0.55, 0.2), min-width 0.3s cubic-bezier(0.55, 0, 0.55, 0.2);
+    transition: width 0.3s cubic-bezier(0.55, 0, 0.55, 0.2), min-width 0.3s cubic-bezier(0.55, 0, 0.55, 0.2); }
   md-sidenav.md-locked-open-remove-active {
     -webkit-transition: width 0.3s cubic-bezier(0.55, 0, 0.55, 0.2), min-width 0.3s cubic-bezier(0.55, 0, 0.55, 0.2);
     transition: width 0.3s cubic-bezier(0.55, 0, 0.55, 0.2), min-width 0.3s cubic-bezier(0.55, 0, 0.55, 0.2);
     width: 0 !important;
     min-width: 0 !important; }
-  md-sidenav.md-closed.md-locked-open-add {
-    width: 0 !important;
-    min-width: 0 !important;
-    -webkit-transform: translate3d(0%, 0, 0);
-            transform: translate3d(0%, 0, 0); }
-  md-sidenav.md-closed.md-locked-open-add-active {
-    -webkit-transition: width 0.3s cubic-bezier(0.55, 0, 0.55, 0.2), min-width 0.3s cubic-bezier(0.55, 0, 0.55, 0.2);
-    transition: width 0.3s cubic-bezier(0.55, 0, 0.55, 0.2), min-width 0.3s cubic-bezier(0.55, 0, 0.55, 0.2);
-    width: 320px;
-    min-width: 320px;
-    -webkit-transform: translate3d(0%, 0, 0);
-            transform: translate3d(0%, 0, 0); }
 
 .md-sidenav-backdrop.md-locked-open {
   display: none; }
@@ -4737,8 +4708,15 @@ md-switch {
     margin-right: 8px;
     float: left; }
     [dir=rtl] md-switch .md-container {
-      margin-right: auto;
+      margin-right: 0px;
       margin-left: 8px; }
+  md-switch.md-inverted .md-container {
+    margin-right: initial;
+    margin-left: 8px; }
+    [dir=rtl] md-switch.md-inverted .md-container {
+      margin-right: 8px; }
+    [dir=rtl] md-switch.md-inverted .md-container {
+      margin-left: initial; }
   md-switch:not([disabled]) .md-dragging,
   md-switch:not([disabled]).md-dragging .md-container {
     cursor: -webkit-grabbing;
@@ -4826,308 +4804,6 @@ md-switch {
     background-color: #9E9E9E; }
   md-switch.md-default-theme .md-thumb {
     background-color: #fff; } }
-
-@-webkit-keyframes md-tab-content-hide {
-  0% {
-    opacity: 1; }
-  50% {
-    opacity: 1; }
-  100% {
-    opacity: 0; } }
-
-@keyframes md-tab-content-hide {
-  0% {
-    opacity: 1; }
-  50% {
-    opacity: 1; }
-  100% {
-    opacity: 0; } }
-
-md-tab-data {
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  z-index: -1;
-  opacity: 0; }
-
-md-tabs {
-  display: block;
-  margin: 0;
-  border-radius: 2px;
-  overflow: hidden;
-  position: relative;
-  -webkit-flex-shrink: 0;
-          flex-shrink: 0; }
-  md-tabs:not(.md-no-tab-content):not(.md-dynamic-height) {
-    min-height: 248px; }
-  md-tabs[md-align-tabs="bottom"] {
-    padding-bottom: 48px; }
-    md-tabs[md-align-tabs="bottom"] md-tabs-wrapper {
-      position: absolute;
-      bottom: 0;
-      left: 0;
-      right: 0;
-      height: 48px;
-      z-index: 2; }
-    md-tabs[md-align-tabs="bottom"] md-tabs-content-wrapper {
-      top: 0;
-      bottom: 48px; }
-  md-tabs.md-dynamic-height md-tabs-content-wrapper {
-    min-height: 0;
-    position: relative;
-    top: auto;
-    left: auto;
-    right: auto;
-    bottom: auto;
-    overflow: visible; }
-  md-tabs.md-dynamic-height md-tab-content.md-active {
-    position: relative; }
-  md-tabs[md-border-bottom] md-tabs-wrapper {
-    border-width: 0 0 1px;
-    border-style: solid; }
-  md-tabs[md-border-bottom]:not(.md-dynamic-height) md-tabs-content-wrapper {
-    top: 49px; }
-
-md-tabs-wrapper {
-  display: block;
-  position: relative;
-  -webkit-transform: translate3d(0, 0, 0);
-          transform: translate3d(0, 0, 0); }
-  md-tabs-wrapper md-prev-button, md-tabs-wrapper md-next-button {
-    height: 100%;
-    width: 32px;
-    position: absolute;
-    top: 50%;
-    -webkit-transform: translateY(-50%);
-            transform: translateY(-50%);
-    line-height: 1em;
-    z-index: 2;
-    cursor: pointer;
-    font-size: 16px;
-    background: transparent no-repeat center center;
-    -webkit-transition: all 0.5s cubic-bezier(0.35, 0, 0.25, 1);
-    transition: all 0.5s cubic-bezier(0.35, 0, 0.25, 1); }
-    md-tabs-wrapper md-prev-button:focus, md-tabs-wrapper md-next-button:focus {
-      outline: none; }
-    md-tabs-wrapper md-prev-button.md-disabled, md-tabs-wrapper md-next-button.md-disabled {
-      opacity: 0.25;
-      cursor: default; }
-    md-tabs-wrapper md-prev-button.ng-leave, md-tabs-wrapper md-next-button.ng-leave {
-      -webkit-transition: none;
-      transition: none; }
-    md-tabs-wrapper md-prev-button md-icon, md-tabs-wrapper md-next-button md-icon {
-      position: absolute;
-      top: 50%;
-      left: 50%;
-      -webkit-transform: translate3d(-50%, -50%, 0);
-              transform: translate3d(-50%, -50%, 0); }
-  md-tabs-wrapper md-prev-button {
-    left: 0;
-    background-image: url("data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDE3LjEuMCwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPiA8IURPQ1RZUEUgc3ZnIFBVQkxJQyAiLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4iICJodHRwOi8vd3d3LnczLm9yZy9HcmFwaGljcy9TVkcvMS4xL0RURC9zdmcxMS5kdGQiPiA8c3ZnIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgeD0iMHB4IiB5PSIwcHgiIHdpZHRoPSIyNHB4IiBoZWlnaHQ9IjI0cHgiIHZpZXdCb3g9IjAgMCAyNCAyNCIgZW5hYmxlLWJhY2tncm91bmQ9Im5ldyAwIDAgMjQgMjQiIHhtbDpzcGFjZT0icHJlc2VydmUiPiA8ZyBpZD0iSGVhZGVyIj4gPGc+IDxyZWN0IHg9Ii02MTgiIHk9Ii0xMjA4IiBmaWxsPSJub25lIiB3aWR0aD0iMTQwMCIgaGVpZ2h0PSIzNjAwIi8+IDwvZz4gPC9nPiA8ZyBpZD0iTGFiZWwiPiA8L2c+IDxnIGlkPSJJY29uIj4gPGc+IDxwb2x5Z29uIHBvaW50cz0iMTUuNCw3LjQgMTQsNiA4LDEyIDE0LDE4IDE1LjQsMTYuNiAxMC44LDEyIAkJIiBzdHlsZT0iZmlsbDp3aGl0ZTsiLz4gPHJlY3QgZmlsbD0ibm9uZSIgd2lkdGg9IjI0IiBoZWlnaHQ9IjI0Ii8+IDwvZz4gPC9nPiA8ZyBpZD0iR3JpZCIgZGlzcGxheT0ibm9uZSI+IDxnIGRpc3BsYXk9ImlubGluZSI+IDwvZz4gPC9nPiA8L3N2Zz4NCg=="); }
-    [dir=rtl] md-tabs-wrapper md-prev-button {
-      left: auto;
-      right: 0; }
-  md-tabs-wrapper md-next-button {
-    right: 0;
-    background-image: url("data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDE3LjEuMCwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPiA8IURPQ1RZUEUgc3ZnIFBVQkxJQyAiLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4iICJodHRwOi8vd3d3LnczLm9yZy9HcmFwaGljcy9TVkcvMS4xL0RURC9zdmcxMS5kdGQiPiA8c3ZnIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgeD0iMHB4IiB5PSIwcHgiIHdpZHRoPSIyNHB4IiBoZWlnaHQ9IjI0cHgiIHZpZXdCb3g9IjAgMCAyNCAyNCIgZW5hYmxlLWJhY2tncm91bmQ9Im5ldyAwIDAgMjQgMjQiIHhtbDpzcGFjZT0icHJlc2VydmUiPiA8ZyBpZD0iSGVhZGVyIj4gPGc+IDxyZWN0IHg9Ii02MTgiIHk9Ii0xMzM2IiBmaWxsPSJub25lIiB3aWR0aD0iMTQwMCIgaGVpZ2h0PSIzNjAwIi8+IDwvZz4gPC9nPiA8ZyBpZD0iTGFiZWwiPiA8L2c+IDxnIGlkPSJJY29uIj4gPGc+IDxwb2x5Z29uIHBvaW50cz0iMTAsNiA4LjYsNy40IDEzLjIsMTIgOC42LDE2LjYgMTAsMTggMTYsMTIgCQkiIHN0eWxlPSJmaWxsOndoaXRlOyIvPiA8cmVjdCBmaWxsPSJub25lIiB3aWR0aD0iMjQiIGhlaWdodD0iMjQiLz4gPC9nPiA8L2c+IDxnIGlkPSJHcmlkIiBkaXNwbGF5PSJub25lIj4gPGcgZGlzcGxheT0iaW5saW5lIj4gPC9nPiA8L2c+IDwvc3ZnPg0K"); }
-    [dir=rtl] md-tabs-wrapper md-next-button {
-      right: auto;
-      left: 0; }
-    md-tabs-wrapper md-next-button md-icon {
-      -webkit-transform: translate3d(-50%, -50%, 0) rotate(180deg);
-              transform: translate3d(-50%, -50%, 0) rotate(180deg); }
-  md-tabs-wrapper.md-stretch-tabs md-pagination-wrapper {
-    width: 100%;
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: flex;
-    -webkit-box-orient: horizontal;
-    -webkit-box-direction: normal;
-    -webkit-flex-direction: row;
-            flex-direction: row; }
-    md-tabs-wrapper.md-stretch-tabs md-pagination-wrapper md-tab-item {
-      -webkit-box-flex: 1;
-      -webkit-flex-grow: 1;
-              flex-grow: 1; }
-
-md-tabs-canvas {
-  position: relative;
-  overflow: hidden;
-  display: block;
-  height: 48px; }
-  md-tabs-canvas:after {
-    content: '';
-    display: table;
-    clear: both; }
-  md-tabs-canvas .md-dummy-wrapper {
-    position: absolute;
-    top: 0;
-    left: 0; }
-    [dir=rtl] md-tabs-canvas .md-dummy-wrapper {
-      left: auto;
-      right: 0; }
-  md-tabs-canvas.md-paginated {
-    margin: 0 32px; }
-  md-tabs-canvas.md-center-tabs {
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: flex;
-    -webkit-box-orient: vertical;
-    -webkit-box-direction: normal;
-    -webkit-flex-direction: column;
-            flex-direction: column;
-    text-align: center; }
-    md-tabs-canvas.md-center-tabs .md-tab {
-      float: none;
-      display: inline-block; }
-
-md-pagination-wrapper {
-  height: 48px;
-  display: block;
-  -webkit-transition: -webkit-transform 0.5s cubic-bezier(0.35, 0, 0.25, 1);
-  transition: -webkit-transform 0.5s cubic-bezier(0.35, 0, 0.25, 1);
-  transition: transform 0.5s cubic-bezier(0.35, 0, 0.25, 1);
-  transition: transform 0.5s cubic-bezier(0.35, 0, 0.25, 1), -webkit-transform 0.5s cubic-bezier(0.35, 0, 0.25, 1);
-  position: absolute;
-  width: 999999px;
-  left: 0;
-  -webkit-transform: translate3d(0, 0, 0);
-          transform: translate3d(0, 0, 0); }
-  md-pagination-wrapper:after {
-    content: '';
-    display: table;
-    clear: both; }
-  [dir=rtl] md-pagination-wrapper {
-    left: auto;
-    right: 0; }
-  md-pagination-wrapper.md-center-tabs {
-    position: relative;
-    width: auto;
-    margin: 0 auto; }
-
-md-tabs-content-wrapper {
-  display: block;
-  position: absolute;
-  top: 48px;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  overflow: hidden; }
-
-md-tab-content {
-  display: block;
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  -webkit-transition: -webkit-transform 0.5s cubic-bezier(0.35, 0, 0.25, 1);
-  transition: -webkit-transform 0.5s cubic-bezier(0.35, 0, 0.25, 1);
-  transition: transform 0.5s cubic-bezier(0.35, 0, 0.25, 1);
-  transition: transform 0.5s cubic-bezier(0.35, 0, 0.25, 1), -webkit-transform 0.5s cubic-bezier(0.35, 0, 0.25, 1);
-  overflow: auto;
-  -webkit-transform: translate3d(0, 0, 0);
-          transform: translate3d(0, 0, 0); }
-  md-tab-content.md-no-scroll {
-    bottom: auto;
-    overflow: hidden; }
-  md-tab-content.ng-leave, md-tab-content.md-no-transition {
-    -webkit-transition: none;
-    transition: none; }
-  md-tab-content.md-left:not(.md-active) {
-    -webkit-transform: translateX(-100%);
-            transform: translateX(-100%);
-    -webkit-animation: 1s md-tab-content-hide;
-            animation: 1s md-tab-content-hide;
-    opacity: 0; }
-    [dir=rtl] md-tab-content.md-left:not(.md-active) {
-      -webkit-transform: translateX(100%);
-              transform: translateX(100%); }
-    md-tab-content.md-left:not(.md-active) * {
-      -webkit-transition: visibility 0s linear;
-      transition: visibility 0s linear;
-      -webkit-transition-delay: 0.5s;
-              transition-delay: 0.5s;
-      visibility: hidden; }
-  md-tab-content.md-right:not(.md-active) {
-    -webkit-transform: translateX(100%);
-            transform: translateX(100%);
-    -webkit-animation: 1s md-tab-content-hide;
-            animation: 1s md-tab-content-hide;
-    opacity: 0; }
-    [dir=rtl] md-tab-content.md-right:not(.md-active) {
-      -webkit-transform: translateX(-100%);
-              transform: translateX(-100%); }
-    md-tab-content.md-right:not(.md-active) * {
-      -webkit-transition: visibility 0s linear;
-      transition: visibility 0s linear;
-      -webkit-transition-delay: 0.5s;
-              transition-delay: 0.5s;
-      visibility: hidden; }
-  md-tab-content > div.ng-leave {
-    -webkit-animation: 1s md-tab-content-hide;
-            animation: 1s md-tab-content-hide; }
-
-md-ink-bar {
-  position: absolute;
-  left: auto;
-  right: auto;
-  bottom: 0;
-  height: 2px; }
-  md-ink-bar.md-left {
-    -webkit-transition: left 0.125s cubic-bezier(0.35, 0, 0.25, 1), right 0.25s cubic-bezier(0.35, 0, 0.25, 1);
-    transition: left 0.125s cubic-bezier(0.35, 0, 0.25, 1), right 0.25s cubic-bezier(0.35, 0, 0.25, 1); }
-  md-ink-bar.md-right {
-    -webkit-transition: left 0.25s cubic-bezier(0.35, 0, 0.25, 1), right 0.125s cubic-bezier(0.35, 0, 0.25, 1);
-    transition: left 0.25s cubic-bezier(0.35, 0, 0.25, 1), right 0.125s cubic-bezier(0.35, 0, 0.25, 1); }
-
-md-tab {
-  position: absolute;
-  z-index: -1;
-  left: -9999px; }
-
-.md-tab {
-  font-size: 14px;
-  text-align: center;
-  line-height: 24px;
-  padding: 12px 24px;
-  -webkit-transition: background-color 0.35s cubic-bezier(0.35, 0, 0.25, 1);
-  transition: background-color 0.35s cubic-bezier(0.35, 0, 0.25, 1);
-  cursor: pointer;
-  white-space: nowrap;
-  position: relative;
-  text-transform: uppercase;
-  float: left;
-  font-weight: 500;
-  box-sizing: border-box;
-  overflow: hidden;
-  text-overflow: ellipsis; }
-  [dir=rtl] .md-tab {
-    float: right; }
-  .md-tab.md-focused {
-    box-shadow: none;
-    outline: none; }
-  .md-tab.md-active {
-    cursor: default; }
-  .md-tab.md-disabled {
-    pointer-events: none;
-    touch-action: pan-y;
-    -webkit-user-select: none;
-       -moz-user-select: none;
-        -ms-user-select: none;
-            user-select: none;
-    -webkit-user-drag: none;
-    opacity: 0.5;
-    cursor: default; }
-  .md-tab.ng-leave {
-    -webkit-transition: none;
-    transition: none; }
-
-md-toolbar + md-tabs {
-  border-top-left-radius: 0;
-  border-top-right-radius: 0; }
 
 .md-toast-text {
   padding: 0 6px; }
@@ -5297,6 +4973,314 @@ md-toast {
 .md-toast-animating {
   overflow: hidden !important; }
 
+@-webkit-keyframes md-tab-content-hide {
+  0% {
+    opacity: 1; }
+  50% {
+    opacity: 1; }
+  100% {
+    opacity: 0; } }
+
+@keyframes md-tab-content-hide {
+  0% {
+    opacity: 1; }
+  50% {
+    opacity: 1; }
+  100% {
+    opacity: 0; } }
+
+md-tab-data {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: -1;
+  opacity: 0; }
+
+md-tabs {
+  display: block;
+  margin: 0;
+  border-radius: 2px;
+  overflow: hidden;
+  position: relative;
+  -webkit-flex-shrink: 0;
+          flex-shrink: 0; }
+  md-tabs:not(.md-no-tab-content):not(.md-dynamic-height) {
+    min-height: 248px; }
+  md-tabs[md-align-tabs="bottom"] {
+    padding-bottom: 48px; }
+    md-tabs[md-align-tabs="bottom"] md-tabs-wrapper {
+      position: absolute;
+      bottom: 0;
+      left: 0;
+      right: 0;
+      height: 48px;
+      z-index: 2; }
+    md-tabs[md-align-tabs="bottom"] md-tabs-content-wrapper {
+      top: 0;
+      bottom: 48px; }
+  md-tabs.md-dynamic-height md-tabs-content-wrapper {
+    min-height: 0;
+    position: relative;
+    top: auto;
+    left: auto;
+    right: auto;
+    bottom: auto;
+    overflow: visible; }
+  md-tabs.md-dynamic-height md-tab-content.md-active {
+    position: relative; }
+  md-tabs[md-border-bottom] md-tabs-wrapper {
+    border-width: 0 0 1px;
+    border-style: solid; }
+  md-tabs[md-border-bottom]:not(.md-dynamic-height) md-tabs-content-wrapper {
+    top: 49px; }
+
+md-tabs-wrapper {
+  display: block;
+  position: relative;
+  -webkit-transform: translate3d(0, 0, 0);
+          transform: translate3d(0, 0, 0); }
+  md-tabs-wrapper md-prev-button, md-tabs-wrapper md-next-button {
+    height: 100%;
+    width: 32px;
+    position: absolute;
+    top: 50%;
+    -webkit-transform: translateY(-50%);
+            transform: translateY(-50%);
+    line-height: 1em;
+    z-index: 2;
+    cursor: pointer;
+    font-size: 16px;
+    background: transparent no-repeat center center;
+    -webkit-transition: all 0.5s cubic-bezier(0.35, 0, 0.25, 1);
+    transition: all 0.5s cubic-bezier(0.35, 0, 0.25, 1); }
+    md-tabs-wrapper md-prev-button:focus, md-tabs-wrapper md-next-button:focus {
+      outline: none; }
+    md-tabs-wrapper md-prev-button.md-disabled, md-tabs-wrapper md-next-button.md-disabled {
+      opacity: 0.25;
+      cursor: default; }
+    md-tabs-wrapper md-prev-button.ng-leave, md-tabs-wrapper md-next-button.ng-leave {
+      -webkit-transition: none;
+      transition: none; }
+    md-tabs-wrapper md-prev-button md-icon, md-tabs-wrapper md-next-button md-icon {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      -webkit-transform: translate3d(-50%, -50%, 0);
+              transform: translate3d(-50%, -50%, 0); }
+  md-tabs-wrapper md-prev-button {
+    left: 0;
+    background-image: url("data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDE3LjEuMCwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPiA8IURPQ1RZUEUgc3ZnIFBVQkxJQyAiLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4iICJodHRwOi8vd3d3LnczLm9yZy9HcmFwaGljcy9TVkcvMS4xL0RURC9zdmcxMS5kdGQiPiA8c3ZnIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgeD0iMHB4IiB5PSIwcHgiIHdpZHRoPSIyNHB4IiBoZWlnaHQ9IjI0cHgiIHZpZXdCb3g9IjAgMCAyNCAyNCIgZW5hYmxlLWJhY2tncm91bmQ9Im5ldyAwIDAgMjQgMjQiIHhtbDpzcGFjZT0icHJlc2VydmUiPiA8ZyBpZD0iSGVhZGVyIj4gPGc+IDxyZWN0IHg9Ii02MTgiIHk9Ii0xMjA4IiBmaWxsPSJub25lIiB3aWR0aD0iMTQwMCIgaGVpZ2h0PSIzNjAwIi8+IDwvZz4gPC9nPiA8ZyBpZD0iTGFiZWwiPiA8L2c+IDxnIGlkPSJJY29uIj4gPGc+IDxwb2x5Z29uIHBvaW50cz0iMTUuNCw3LjQgMTQsNiA4LDEyIDE0LDE4IDE1LjQsMTYuNiAxMC44LDEyIAkJIiBzdHlsZT0iZmlsbDp3aGl0ZTsiLz4gPHJlY3QgZmlsbD0ibm9uZSIgd2lkdGg9IjI0IiBoZWlnaHQ9IjI0Ii8+IDwvZz4gPC9nPiA8ZyBpZD0iR3JpZCIgZGlzcGxheT0ibm9uZSI+IDxnIGRpc3BsYXk9ImlubGluZSI+IDwvZz4gPC9nPiA8L3N2Zz4NCg=="); }
+    [dir=rtl] md-tabs-wrapper md-prev-button {
+      left: auto;
+      right: 0; }
+  md-tabs-wrapper md-next-button {
+    right: 0;
+    background-image: url("data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDE3LjEuMCwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPiA8IURPQ1RZUEUgc3ZnIFBVQkxJQyAiLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4iICJodHRwOi8vd3d3LnczLm9yZy9HcmFwaGljcy9TVkcvMS4xL0RURC9zdmcxMS5kdGQiPiA8c3ZnIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgeD0iMHB4IiB5PSIwcHgiIHdpZHRoPSIyNHB4IiBoZWlnaHQ9IjI0cHgiIHZpZXdCb3g9IjAgMCAyNCAyNCIgZW5hYmxlLWJhY2tncm91bmQ9Im5ldyAwIDAgMjQgMjQiIHhtbDpzcGFjZT0icHJlc2VydmUiPiA8ZyBpZD0iSGVhZGVyIj4gPGc+IDxyZWN0IHg9Ii02MTgiIHk9Ii0xMzM2IiBmaWxsPSJub25lIiB3aWR0aD0iMTQwMCIgaGVpZ2h0PSIzNjAwIi8+IDwvZz4gPC9nPiA8ZyBpZD0iTGFiZWwiPiA8L2c+IDxnIGlkPSJJY29uIj4gPGc+IDxwb2x5Z29uIHBvaW50cz0iMTAsNiA4LjYsNy40IDEzLjIsMTIgOC42LDE2LjYgMTAsMTggMTYsMTIgCQkiIHN0eWxlPSJmaWxsOndoaXRlOyIvPiA8cmVjdCBmaWxsPSJub25lIiB3aWR0aD0iMjQiIGhlaWdodD0iMjQiLz4gPC9nPiA8L2c+IDxnIGlkPSJHcmlkIiBkaXNwbGF5PSJub25lIj4gPGcgZGlzcGxheT0iaW5saW5lIj4gPC9nPiA8L2c+IDwvc3ZnPg0K"); }
+    [dir=rtl] md-tabs-wrapper md-next-button {
+      right: auto;
+      left: 0; }
+    md-tabs-wrapper md-next-button md-icon {
+      -webkit-transform: translate3d(-50%, -50%, 0) rotate(180deg);
+              transform: translate3d(-50%, -50%, 0) rotate(180deg); }
+  md-tabs-wrapper.md-stretch-tabs md-pagination-wrapper {
+    width: 100%;
+    -webkit-box-orient: horizontal;
+    -webkit-box-direction: normal;
+    -webkit-flex-direction: row;
+            flex-direction: row; }
+    md-tabs-wrapper.md-stretch-tabs md-pagination-wrapper md-tab-item {
+      -webkit-box-flex: 1;
+      -webkit-flex-grow: 1;
+              flex-grow: 1; }
+
+md-tabs-canvas {
+  position: relative;
+  overflow: hidden;
+  display: block;
+  height: 48px; }
+  md-tabs-canvas:after {
+    content: '';
+    display: table;
+    clear: both; }
+  md-tabs-canvas .md-dummy-wrapper {
+    position: absolute;
+    top: 0;
+    left: 0; }
+    [dir=rtl] md-tabs-canvas .md-dummy-wrapper {
+      left: auto;
+      right: 0; }
+  md-tabs-canvas.md-paginated {
+    margin: 0 32px; }
+  md-tabs-canvas.md-center-tabs {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: flex;
+    -webkit-box-orient: vertical;
+    -webkit-box-direction: normal;
+    -webkit-flex-direction: column;
+            flex-direction: column;
+    text-align: center; }
+    md-tabs-canvas.md-center-tabs .md-tab {
+      float: none;
+      display: inline-block; }
+
+md-pagination-wrapper {
+  height: 48px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: flex;
+  -webkit-transition: -webkit-transform 0.5s cubic-bezier(0.35, 0, 0.25, 1);
+  transition: -webkit-transform 0.5s cubic-bezier(0.35, 0, 0.25, 1);
+  transition: transform 0.5s cubic-bezier(0.35, 0, 0.25, 1);
+  transition: transform 0.5s cubic-bezier(0.35, 0, 0.25, 1), -webkit-transform 0.5s cubic-bezier(0.35, 0, 0.25, 1);
+  position: absolute;
+  left: 0;
+  -webkit-transform: translate3d(0, 0, 0);
+          transform: translate3d(0, 0, 0); }
+  md-pagination-wrapper:after {
+    content: '';
+    display: table;
+    clear: both; }
+  [dir=rtl] md-pagination-wrapper {
+    left: auto;
+    right: 0; }
+  md-pagination-wrapper.md-center-tabs {
+    position: relative;
+    -webkit-box-pack: center;
+    -webkit-justify-content: center;
+            justify-content: center; }
+
+md-tabs-content-wrapper {
+  display: block;
+  position: absolute;
+  top: 48px;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  overflow: hidden; }
+
+md-tab-content {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: flex;
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  -webkit-transition: -webkit-transform 0.5s cubic-bezier(0.35, 0, 0.25, 1);
+  transition: -webkit-transform 0.5s cubic-bezier(0.35, 0, 0.25, 1);
+  transition: transform 0.5s cubic-bezier(0.35, 0, 0.25, 1);
+  transition: transform 0.5s cubic-bezier(0.35, 0, 0.25, 1), -webkit-transform 0.5s cubic-bezier(0.35, 0, 0.25, 1);
+  overflow: auto;
+  -webkit-transform: translate3d(0, 0, 0);
+          transform: translate3d(0, 0, 0); }
+  md-tab-content.md-no-scroll {
+    bottom: auto;
+    overflow: hidden; }
+  md-tab-content.ng-leave, md-tab-content.md-no-transition {
+    -webkit-transition: none;
+    transition: none; }
+  md-tab-content.md-left:not(.md-active) {
+    -webkit-transform: translateX(-100%);
+            transform: translateX(-100%);
+    -webkit-animation: 1s md-tab-content-hide;
+            animation: 1s md-tab-content-hide;
+    opacity: 0; }
+    [dir=rtl] md-tab-content.md-left:not(.md-active) {
+      -webkit-transform: translateX(100%);
+              transform: translateX(100%); }
+    md-tab-content.md-left:not(.md-active) * {
+      -webkit-transition: visibility 0s linear;
+      transition: visibility 0s linear;
+      -webkit-transition-delay: 0.5s;
+              transition-delay: 0.5s;
+      visibility: hidden; }
+  md-tab-content.md-right:not(.md-active) {
+    -webkit-transform: translateX(100%);
+            transform: translateX(100%);
+    -webkit-animation: 1s md-tab-content-hide;
+            animation: 1s md-tab-content-hide;
+    opacity: 0; }
+    [dir=rtl] md-tab-content.md-right:not(.md-active) {
+      -webkit-transform: translateX(-100%);
+              transform: translateX(-100%); }
+    md-tab-content.md-right:not(.md-active) * {
+      -webkit-transition: visibility 0s linear;
+      transition: visibility 0s linear;
+      -webkit-transition-delay: 0.5s;
+              transition-delay: 0.5s;
+      visibility: hidden; }
+  md-tab-content > div {
+    -webkit-box-flex: 1;
+    -webkit-flex: 1 0 100%;
+            flex: 1 0 100%;
+    min-width: 0; }
+    md-tab-content > div.ng-leave {
+      -webkit-animation: 1s md-tab-content-hide;
+              animation: 1s md-tab-content-hide; }
+
+md-ink-bar {
+  position: absolute;
+  left: auto;
+  right: auto;
+  bottom: 0;
+  height: 2px; }
+  md-ink-bar.md-left {
+    -webkit-transition: left 0.125s cubic-bezier(0.35, 0, 0.25, 1), right 0.25s cubic-bezier(0.35, 0, 0.25, 1);
+    transition: left 0.125s cubic-bezier(0.35, 0, 0.25, 1), right 0.25s cubic-bezier(0.35, 0, 0.25, 1); }
+  md-ink-bar.md-right {
+    -webkit-transition: left 0.25s cubic-bezier(0.35, 0, 0.25, 1), right 0.125s cubic-bezier(0.35, 0, 0.25, 1);
+    transition: left 0.25s cubic-bezier(0.35, 0, 0.25, 1), right 0.125s cubic-bezier(0.35, 0, 0.25, 1); }
+
+md-tab {
+  position: absolute;
+  z-index: -1;
+  left: -9999px; }
+
+.md-tab {
+  font-size: 14px;
+  text-align: center;
+  line-height: 24px;
+  padding: 12px 24px;
+  -webkit-transition: background-color 0.35s cubic-bezier(0.35, 0, 0.25, 1);
+  transition: background-color 0.35s cubic-bezier(0.35, 0, 0.25, 1);
+  cursor: pointer;
+  white-space: nowrap;
+  position: relative;
+  text-transform: uppercase;
+  float: left;
+  font-weight: 500;
+  box-sizing: border-box;
+  overflow: hidden;
+  text-overflow: ellipsis; }
+  [dir=rtl] .md-tab {
+    float: right; }
+  .md-tab.md-focused {
+    box-shadow: none;
+    outline: none; }
+  .md-tab.md-active {
+    cursor: default; }
+  .md-tab.md-disabled {
+    pointer-events: none;
+    touch-action: pan-y;
+    -webkit-user-select: none;
+       -moz-user-select: none;
+        -ms-user-select: none;
+            user-select: none;
+    -webkit-user-drag: none;
+    opacity: 0.5;
+    cursor: default; }
+  .md-tab.ng-leave {
+    -webkit-transition: none;
+    transition: none; }
+
+md-toolbar + md-tabs {
+  border-top-left-radius: 0;
+  border-top-right-radius: 0; }
+
 md-toolbar {
   box-sizing: border-box;
   display: -webkit-box;
@@ -5386,6 +5370,8 @@ md-toolbar {
     -webkit-box-align: center;
     -webkit-align-items: center;
             align-items: center; }
+  .md-toolbar-tools md-checkbox {
+    margin: inherit; }
   .md-toolbar-tools .md-button {
     margin-top: 0;
     margin-bottom: 0; }
@@ -5437,67 +5423,76 @@ md-toolbar {
     height: 48px;
     max-height: 48px; } }
 
-md-tooltip {
-  position: absolute;
-  z-index: 100;
-  overflow: hidden;
+.md-tooltip {
   pointer-events: none;
   border-radius: 4px;
+  overflow: hidden;
+  opacity: 0;
   font-weight: 500;
-  font-size: 14px; }
-  @media (min-width: 960px) {
-    md-tooltip {
-      font-size: 10px; } }
-  md-tooltip .md-content {
-    position: relative;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
+  font-size: 14px;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  height: 32px;
+  line-height: 32px;
+  padding-right: 16px;
+  padding-left: 16px; }
+  .md-tooltip.md-origin-top {
+    -webkit-transform-origin: center bottom;
+            transform-origin: center bottom;
+    margin-top: -24px; }
+  .md-tooltip.md-origin-right {
+    -webkit-transform-origin: left center;
+            transform-origin: left center;
+    margin-left: 24px; }
+  .md-tooltip.md-origin-bottom {
     -webkit-transform-origin: center top;
             transform-origin: center top;
+    margin-top: 24px; }
+  .md-tooltip.md-origin-left {
+    -webkit-transform-origin: right center;
+            transform-origin: right center;
+    margin-left: -24px; }
+  @media (min-width: 960px) {
+    .md-tooltip {
+      font-size: 10px;
+      height: 22px;
+      line-height: 22px;
+      padding-right: 8px;
+      padding-left: 8px; }
+      .md-tooltip.md-origin-top {
+        margin-top: -14px; }
+      .md-tooltip.md-origin-right {
+        margin-left: 14px; }
+      .md-tooltip.md-origin-bottom {
+        margin-top: 14px; }
+      .md-tooltip.md-origin-left {
+        margin-left: -14px; } }
+  .md-tooltip.md-show-add {
     -webkit-transform: scale(0);
-            transform: scale(0);
-    opacity: 0;
-    height: 32px;
-    line-height: 32px;
-    padding-left: 16px;
-    padding-right: 16px; }
-    @media (min-width: 960px) {
-      md-tooltip .md-content {
-        height: 22px;
-        line-height: 22px;
-        padding-left: 8px;
-        padding-right: 8px; } }
-    md-tooltip .md-content.md-show-add {
-      -webkit-transition: all 0.4s cubic-bezier(0.25, 0.8, 0.25, 1);
-      transition: all 0.4s cubic-bezier(0.25, 0.8, 0.25, 1);
-      -webkit-transition-duration: .2s;
-              transition-duration: .2s;
-      -webkit-transform: scale(0);
-              transform: scale(0);
-      opacity: 0; }
-    md-tooltip .md-content.md-show, md-tooltip .md-content.md-show-add-active {
-      -webkit-transform: scale(1);
-              transform: scale(1);
-      opacity: 0.9;
-      -webkit-transform-origin: center top;
-              transform-origin: center top; }
-    md-tooltip .md-content.md-show-remove {
-      -webkit-transition: all 0.4s cubic-bezier(0.25, 0.8, 0.25, 1);
-      transition: all 0.4s cubic-bezier(0.25, 0.8, 0.25, 1);
-      -webkit-transition-duration: .2s;
-              transition-duration: .2s; }
-      md-tooltip .md-content.md-show-remove.md-show-remove-active {
-        -webkit-transform: scale(0);
-                transform: scale(0);
-        opacity: 0; }
-  md-tooltip.md-hide {
-    -webkit-transition: all 0.3s cubic-bezier(0.55, 0, 0.55, 0.2);
-    transition: all 0.3s cubic-bezier(0.55, 0, 0.55, 0.2); }
-  md-tooltip.md-show {
+            transform: scale(0); }
+  .md-tooltip.md-show {
     -webkit-transition: all 0.4s cubic-bezier(0.25, 0.8, 0.25, 1);
     transition: all 0.4s cubic-bezier(0.25, 0.8, 0.25, 1);
-    pointer-events: auto; }
+    -webkit-transform: scale(1);
+            transform: scale(1);
+    opacity: 0.9; }
+  .md-tooltip.md-hide {
+    -webkit-transition: all 0.3s cubic-bezier(0.55, 0, 0.55, 0.2);
+    transition: all 0.3s cubic-bezier(0.55, 0, 0.55, 0.2);
+    -webkit-transition-duration: .1s;
+            transition-duration: .1s;
+    -webkit-transform: scale(0);
+            transform: scale(0);
+    opacity: 0; }
+
+.md-truncate {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis; }
+  .md-truncate.md-clip {
+    text-overflow: clip; }
+  .md-truncate.flex {
+    width: 0; }
 
 .md-virtual-repeat-container {
   box-sizing: border-box;
@@ -6004,7 +5999,6 @@ md-tooltip {
           align-content: stretch;
   -webkit-box-align: stretch;
   -webkit-align-items: stretch;
-              -ms-grid-row-align: stretch;
           align-items: stretch; }
 
 .layout-align-start,
@@ -6058,7 +6052,6 @@ md-tooltip {
 .layout-align-space-around-start {
   -webkit-box-align: start;
   -webkit-align-items: flex-start;
-              -ms-grid-row-align: flex-start;
           align-items: flex-start;
   -webkit-align-content: flex-start;
           align-content: flex-start; }
@@ -6070,7 +6063,6 @@ md-tooltip {
 .layout-align-space-around-center {
   -webkit-box-align: center;
   -webkit-align-items: center;
-              -ms-grid-row-align: center;
           align-items: center;
   -webkit-align-content: center;
           align-content: center;
@@ -6091,7 +6083,6 @@ md-tooltip {
 .layout-align-space-around-end {
   -webkit-box-align: end;
   -webkit-align-items: flex-end;
-              -ms-grid-row-align: flex-end;
           align-items: flex-end;
   -webkit-align-content: flex-end;
           align-content: flex-end; }
@@ -6103,7 +6094,6 @@ md-tooltip {
 .layout-align-space-around-stretch {
   -webkit-box-align: stretch;
   -webkit-align-items: stretch;
-              -ms-grid-row-align: stretch;
           align-items: stretch;
   -webkit-align-content: stretch;
           align-content: stretch; }
@@ -6152,16 +6142,16 @@ md-tooltip {
 
 .flex-0 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 0%;
-          flex: 1 1 0%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 0%;
   max-height: 100%;
   box-sizing: border-box; }
 
 .layout-row > .flex-0 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 0%;
-          flex: 1 1 0%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 0%;
   max-height: 100%;
   box-sizing: border-box;
@@ -6169,8 +6159,8 @@ md-tooltip {
 
 .layout-column > .flex-0 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 0%;
-          flex: 1 1 0%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 100%;
   max-height: 0%;
   box-sizing: border-box; }
@@ -6209,8 +6199,8 @@ md-tooltip {
 
 .layout-row > .flex-0 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 0%;
-          flex: 1 1 0%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 0%;
   max-height: 100%;
   box-sizing: border-box;
@@ -6218,8 +6208,8 @@ md-tooltip {
 
 .layout-column > .flex-0 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 0%;
-          flex: 1 1 0%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 100%;
   max-height: 0%;
   box-sizing: border-box;
@@ -6227,24 +6217,24 @@ md-tooltip {
 
 .flex-5 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 5%;
-          flex: 1 1 5%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 5%;
   max-height: 100%;
   box-sizing: border-box; }
 
 .layout-row > .flex-5 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 5%;
-          flex: 1 1 5%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 5%;
   max-height: 100%;
   box-sizing: border-box; }
 
 .layout-column > .flex-5 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 5%;
-          flex: 1 1 5%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 100%;
   max-height: 5%;
   box-sizing: border-box; }
@@ -6283,40 +6273,40 @@ md-tooltip {
 
 .layout-row > .flex-5 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 5%;
-          flex: 1 1 5%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 5%;
   max-height: 100%;
   box-sizing: border-box; }
 
 .layout-column > .flex-5 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 5%;
-          flex: 1 1 5%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 100%;
   max-height: 5%;
   box-sizing: border-box; }
 
 .flex-10 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 10%;
-          flex: 1 1 10%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 10%;
   max-height: 100%;
   box-sizing: border-box; }
 
 .layout-row > .flex-10 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 10%;
-          flex: 1 1 10%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 10%;
   max-height: 100%;
   box-sizing: border-box; }
 
 .layout-column > .flex-10 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 10%;
-          flex: 1 1 10%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 100%;
   max-height: 10%;
   box-sizing: border-box; }
@@ -6355,40 +6345,40 @@ md-tooltip {
 
 .layout-row > .flex-10 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 10%;
-          flex: 1 1 10%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 10%;
   max-height: 100%;
   box-sizing: border-box; }
 
 .layout-column > .flex-10 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 10%;
-          flex: 1 1 10%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 100%;
   max-height: 10%;
   box-sizing: border-box; }
 
 .flex-15 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 15%;
-          flex: 1 1 15%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 15%;
   max-height: 100%;
   box-sizing: border-box; }
 
 .layout-row > .flex-15 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 15%;
-          flex: 1 1 15%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 15%;
   max-height: 100%;
   box-sizing: border-box; }
 
 .layout-column > .flex-15 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 15%;
-          flex: 1 1 15%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 100%;
   max-height: 15%;
   box-sizing: border-box; }
@@ -6427,40 +6417,40 @@ md-tooltip {
 
 .layout-row > .flex-15 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 15%;
-          flex: 1 1 15%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 15%;
   max-height: 100%;
   box-sizing: border-box; }
 
 .layout-column > .flex-15 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 15%;
-          flex: 1 1 15%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 100%;
   max-height: 15%;
   box-sizing: border-box; }
 
 .flex-20 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 20%;
-          flex: 1 1 20%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 20%;
   max-height: 100%;
   box-sizing: border-box; }
 
 .layout-row > .flex-20 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 20%;
-          flex: 1 1 20%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 20%;
   max-height: 100%;
   box-sizing: border-box; }
 
 .layout-column > .flex-20 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 20%;
-          flex: 1 1 20%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 100%;
   max-height: 20%;
   box-sizing: border-box; }
@@ -6499,40 +6489,40 @@ md-tooltip {
 
 .layout-row > .flex-20 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 20%;
-          flex: 1 1 20%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 20%;
   max-height: 100%;
   box-sizing: border-box; }
 
 .layout-column > .flex-20 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 20%;
-          flex: 1 1 20%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 100%;
   max-height: 20%;
   box-sizing: border-box; }
 
 .flex-25 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 25%;
-          flex: 1 1 25%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 25%;
   max-height: 100%;
   box-sizing: border-box; }
 
 .layout-row > .flex-25 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 25%;
-          flex: 1 1 25%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 25%;
   max-height: 100%;
   box-sizing: border-box; }
 
 .layout-column > .flex-25 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 25%;
-          flex: 1 1 25%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 100%;
   max-height: 25%;
   box-sizing: border-box; }
@@ -6571,40 +6561,40 @@ md-tooltip {
 
 .layout-row > .flex-25 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 25%;
-          flex: 1 1 25%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 25%;
   max-height: 100%;
   box-sizing: border-box; }
 
 .layout-column > .flex-25 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 25%;
-          flex: 1 1 25%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 100%;
   max-height: 25%;
   box-sizing: border-box; }
 
 .flex-30 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 30%;
-          flex: 1 1 30%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 30%;
   max-height: 100%;
   box-sizing: border-box; }
 
 .layout-row > .flex-30 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 30%;
-          flex: 1 1 30%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 30%;
   max-height: 100%;
   box-sizing: border-box; }
 
 .layout-column > .flex-30 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 30%;
-          flex: 1 1 30%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 100%;
   max-height: 30%;
   box-sizing: border-box; }
@@ -6643,40 +6633,40 @@ md-tooltip {
 
 .layout-row > .flex-30 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 30%;
-          flex: 1 1 30%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 30%;
   max-height: 100%;
   box-sizing: border-box; }
 
 .layout-column > .flex-30 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 30%;
-          flex: 1 1 30%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 100%;
   max-height: 30%;
   box-sizing: border-box; }
 
 .flex-35 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 35%;
-          flex: 1 1 35%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 35%;
   max-height: 100%;
   box-sizing: border-box; }
 
 .layout-row > .flex-35 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 35%;
-          flex: 1 1 35%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 35%;
   max-height: 100%;
   box-sizing: border-box; }
 
 .layout-column > .flex-35 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 35%;
-          flex: 1 1 35%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 100%;
   max-height: 35%;
   box-sizing: border-box; }
@@ -6715,40 +6705,40 @@ md-tooltip {
 
 .layout-row > .flex-35 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 35%;
-          flex: 1 1 35%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 35%;
   max-height: 100%;
   box-sizing: border-box; }
 
 .layout-column > .flex-35 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 35%;
-          flex: 1 1 35%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 100%;
   max-height: 35%;
   box-sizing: border-box; }
 
 .flex-40 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 40%;
-          flex: 1 1 40%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 40%;
   max-height: 100%;
   box-sizing: border-box; }
 
 .layout-row > .flex-40 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 40%;
-          flex: 1 1 40%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 40%;
   max-height: 100%;
   box-sizing: border-box; }
 
 .layout-column > .flex-40 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 40%;
-          flex: 1 1 40%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 100%;
   max-height: 40%;
   box-sizing: border-box; }
@@ -6787,40 +6777,40 @@ md-tooltip {
 
 .layout-row > .flex-40 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 40%;
-          flex: 1 1 40%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 40%;
   max-height: 100%;
   box-sizing: border-box; }
 
 .layout-column > .flex-40 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 40%;
-          flex: 1 1 40%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 100%;
   max-height: 40%;
   box-sizing: border-box; }
 
 .flex-45 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 45%;
-          flex: 1 1 45%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 45%;
   max-height: 100%;
   box-sizing: border-box; }
 
 .layout-row > .flex-45 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 45%;
-          flex: 1 1 45%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 45%;
   max-height: 100%;
   box-sizing: border-box; }
 
 .layout-column > .flex-45 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 45%;
-          flex: 1 1 45%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 100%;
   max-height: 45%;
   box-sizing: border-box; }
@@ -6859,40 +6849,40 @@ md-tooltip {
 
 .layout-row > .flex-45 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 45%;
-          flex: 1 1 45%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 45%;
   max-height: 100%;
   box-sizing: border-box; }
 
 .layout-column > .flex-45 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 45%;
-          flex: 1 1 45%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 100%;
   max-height: 45%;
   box-sizing: border-box; }
 
 .flex-50 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 50%;
-          flex: 1 1 50%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 50%;
   max-height: 100%;
   box-sizing: border-box; }
 
 .layout-row > .flex-50 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 50%;
-          flex: 1 1 50%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 50%;
   max-height: 100%;
   box-sizing: border-box; }
 
 .layout-column > .flex-50 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 50%;
-          flex: 1 1 50%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 100%;
   max-height: 50%;
   box-sizing: border-box; }
@@ -6931,40 +6921,40 @@ md-tooltip {
 
 .layout-row > .flex-50 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 50%;
-          flex: 1 1 50%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 50%;
   max-height: 100%;
   box-sizing: border-box; }
 
 .layout-column > .flex-50 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 50%;
-          flex: 1 1 50%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 100%;
   max-height: 50%;
   box-sizing: border-box; }
 
 .flex-55 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 55%;
-          flex: 1 1 55%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 55%;
   max-height: 100%;
   box-sizing: border-box; }
 
 .layout-row > .flex-55 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 55%;
-          flex: 1 1 55%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 55%;
   max-height: 100%;
   box-sizing: border-box; }
 
 .layout-column > .flex-55 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 55%;
-          flex: 1 1 55%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 100%;
   max-height: 55%;
   box-sizing: border-box; }
@@ -7003,40 +6993,40 @@ md-tooltip {
 
 .layout-row > .flex-55 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 55%;
-          flex: 1 1 55%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 55%;
   max-height: 100%;
   box-sizing: border-box; }
 
 .layout-column > .flex-55 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 55%;
-          flex: 1 1 55%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 100%;
   max-height: 55%;
   box-sizing: border-box; }
 
 .flex-60 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 60%;
-          flex: 1 1 60%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 60%;
   max-height: 100%;
   box-sizing: border-box; }
 
 .layout-row > .flex-60 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 60%;
-          flex: 1 1 60%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 60%;
   max-height: 100%;
   box-sizing: border-box; }
 
 .layout-column > .flex-60 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 60%;
-          flex: 1 1 60%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 100%;
   max-height: 60%;
   box-sizing: border-box; }
@@ -7075,40 +7065,40 @@ md-tooltip {
 
 .layout-row > .flex-60 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 60%;
-          flex: 1 1 60%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 60%;
   max-height: 100%;
   box-sizing: border-box; }
 
 .layout-column > .flex-60 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 60%;
-          flex: 1 1 60%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 100%;
   max-height: 60%;
   box-sizing: border-box; }
 
 .flex-65 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 65%;
-          flex: 1 1 65%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 65%;
   max-height: 100%;
   box-sizing: border-box; }
 
 .layout-row > .flex-65 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 65%;
-          flex: 1 1 65%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 65%;
   max-height: 100%;
   box-sizing: border-box; }
 
 .layout-column > .flex-65 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 65%;
-          flex: 1 1 65%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 100%;
   max-height: 65%;
   box-sizing: border-box; }
@@ -7147,40 +7137,40 @@ md-tooltip {
 
 .layout-row > .flex-65 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 65%;
-          flex: 1 1 65%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 65%;
   max-height: 100%;
   box-sizing: border-box; }
 
 .layout-column > .flex-65 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 65%;
-          flex: 1 1 65%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 100%;
   max-height: 65%;
   box-sizing: border-box; }
 
 .flex-70 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 70%;
-          flex: 1 1 70%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 70%;
   max-height: 100%;
   box-sizing: border-box; }
 
 .layout-row > .flex-70 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 70%;
-          flex: 1 1 70%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 70%;
   max-height: 100%;
   box-sizing: border-box; }
 
 .layout-column > .flex-70 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 70%;
-          flex: 1 1 70%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 100%;
   max-height: 70%;
   box-sizing: border-box; }
@@ -7219,40 +7209,40 @@ md-tooltip {
 
 .layout-row > .flex-70 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 70%;
-          flex: 1 1 70%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 70%;
   max-height: 100%;
   box-sizing: border-box; }
 
 .layout-column > .flex-70 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 70%;
-          flex: 1 1 70%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 100%;
   max-height: 70%;
   box-sizing: border-box; }
 
 .flex-75 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 75%;
-          flex: 1 1 75%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 75%;
   max-height: 100%;
   box-sizing: border-box; }
 
 .layout-row > .flex-75 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 75%;
-          flex: 1 1 75%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 75%;
   max-height: 100%;
   box-sizing: border-box; }
 
 .layout-column > .flex-75 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 75%;
-          flex: 1 1 75%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 100%;
   max-height: 75%;
   box-sizing: border-box; }
@@ -7291,40 +7281,40 @@ md-tooltip {
 
 .layout-row > .flex-75 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 75%;
-          flex: 1 1 75%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 75%;
   max-height: 100%;
   box-sizing: border-box; }
 
 .layout-column > .flex-75 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 75%;
-          flex: 1 1 75%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 100%;
   max-height: 75%;
   box-sizing: border-box; }
 
 .flex-80 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 80%;
-          flex: 1 1 80%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 80%;
   max-height: 100%;
   box-sizing: border-box; }
 
 .layout-row > .flex-80 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 80%;
-          flex: 1 1 80%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 80%;
   max-height: 100%;
   box-sizing: border-box; }
 
 .layout-column > .flex-80 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 80%;
-          flex: 1 1 80%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 100%;
   max-height: 80%;
   box-sizing: border-box; }
@@ -7363,40 +7353,40 @@ md-tooltip {
 
 .layout-row > .flex-80 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 80%;
-          flex: 1 1 80%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 80%;
   max-height: 100%;
   box-sizing: border-box; }
 
 .layout-column > .flex-80 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 80%;
-          flex: 1 1 80%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 100%;
   max-height: 80%;
   box-sizing: border-box; }
 
 .flex-85 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 85%;
-          flex: 1 1 85%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 85%;
   max-height: 100%;
   box-sizing: border-box; }
 
 .layout-row > .flex-85 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 85%;
-          flex: 1 1 85%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 85%;
   max-height: 100%;
   box-sizing: border-box; }
 
 .layout-column > .flex-85 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 85%;
-          flex: 1 1 85%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 100%;
   max-height: 85%;
   box-sizing: border-box; }
@@ -7435,40 +7425,40 @@ md-tooltip {
 
 .layout-row > .flex-85 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 85%;
-          flex: 1 1 85%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 85%;
   max-height: 100%;
   box-sizing: border-box; }
 
 .layout-column > .flex-85 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 85%;
-          flex: 1 1 85%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 100%;
   max-height: 85%;
   box-sizing: border-box; }
 
 .flex-90 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 90%;
-          flex: 1 1 90%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 90%;
   max-height: 100%;
   box-sizing: border-box; }
 
 .layout-row > .flex-90 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 90%;
-          flex: 1 1 90%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 90%;
   max-height: 100%;
   box-sizing: border-box; }
 
 .layout-column > .flex-90 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 90%;
-          flex: 1 1 90%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 100%;
   max-height: 90%;
   box-sizing: border-box; }
@@ -7507,40 +7497,40 @@ md-tooltip {
 
 .layout-row > .flex-90 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 90%;
-          flex: 1 1 90%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 90%;
   max-height: 100%;
   box-sizing: border-box; }
 
 .layout-column > .flex-90 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 90%;
-          flex: 1 1 90%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 100%;
   max-height: 90%;
   box-sizing: border-box; }
 
 .flex-95 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 95%;
-          flex: 1 1 95%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 95%;
   max-height: 100%;
   box-sizing: border-box; }
 
 .layout-row > .flex-95 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 95%;
-          flex: 1 1 95%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 95%;
   max-height: 100%;
   box-sizing: border-box; }
 
 .layout-column > .flex-95 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 95%;
-          flex: 1 1 95%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 100%;
   max-height: 95%;
   box-sizing: border-box; }
@@ -7579,16 +7569,16 @@ md-tooltip {
 
 .layout-row > .flex-95 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 95%;
-          flex: 1 1 95%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 95%;
   max-height: 100%;
   box-sizing: border-box; }
 
 .layout-column > .flex-95 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 95%;
-          flex: 1 1 95%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 100%;
   max-height: 95%;
   box-sizing: border-box; }
@@ -7667,16 +7657,16 @@ md-tooltip {
 
 .layout-row > .flex-33, .layout-row > .flex-33 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 33.33%;
-          flex: 1 1 33.33%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 33.33%;
   max-height: 100%;
   box-sizing: border-box; }
 
 .layout-row > .flex-66, .layout-row > .flex-66 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 66.66%;
-          flex: 1 1 66.66%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 66.66%;
   max-height: 100%;
   box-sizing: border-box; }
@@ -7686,16 +7676,16 @@ md-tooltip {
 
 .layout-column > .flex-33, .layout-column > .flex-33 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 33.33%;
-          flex: 1 1 33.33%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 100%;
   max-height: 33.33%;
   box-sizing: border-box; }
 
 .layout-column > .flex-66, .layout-column > .flex-66 {
   -webkit-box-flex: 1;
-  -webkit-flex: 1 1 66.66%;
-          flex: 1 1 66.66%;
+  -webkit-flex: 1 1 100%;
+          flex: 1 1 100%;
   max-width: 100%;
   max-height: 66.66%;
   box-sizing: border-box; }
@@ -8077,7 +8067,6 @@ md-tooltip {
             align-content: stretch;
     -webkit-box-align: stretch;
     -webkit-align-items: stretch;
-                -ms-grid-row-align: stretch;
             align-items: stretch; }
   .layout-align-xs-start,
   .layout-align-xs-start-start,
@@ -8125,7 +8114,6 @@ md-tooltip {
   .layout-align-xs-space-around-start {
     -webkit-box-align: start;
     -webkit-align-items: flex-start;
-                -ms-grid-row-align: flex-start;
             align-items: flex-start;
     -webkit-align-content: flex-start;
             align-content: flex-start; }
@@ -8136,7 +8124,6 @@ md-tooltip {
   .layout-align-xs-space-around-center {
     -webkit-box-align: center;
     -webkit-align-items: center;
-                -ms-grid-row-align: center;
             align-items: center;
     -webkit-align-content: center;
             align-content: center;
@@ -8155,7 +8142,6 @@ md-tooltip {
   .layout-align-xs-space-around-end {
     -webkit-box-align: end;
     -webkit-align-items: flex-end;
-                -ms-grid-row-align: flex-end;
             align-items: flex-end;
     -webkit-align-content: flex-end;
             align-content: flex-end; }
@@ -8166,7 +8152,6 @@ md-tooltip {
   .layout-align-xs-space-around-stretch {
     -webkit-box-align: stretch;
     -webkit-align-items: stretch;
-                -ms-grid-row-align: stretch;
             align-items: stretch;
     -webkit-align-content: stretch;
             align-content: stretch; }
@@ -8207,23 +8192,23 @@ md-tooltip {
     box-sizing: border-box; }
   .flex-xs-0 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 0%;
-            flex: 1 1 0%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 0%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-xs-0 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 0%;
-            flex: 1 1 0%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 0%;
     max-height: 100%;
     box-sizing: border-box;
     min-width: 0; }
   .layout-column > .flex-xs-0 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 0%;
-            flex: 1 1 0%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 0%;
     box-sizing: border-box; }
@@ -8257,38 +8242,38 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-xs-row > .flex-xs-0 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 0%;
-            flex: 1 1 0%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 0%;
     max-height: 100%;
     box-sizing: border-box;
     min-width: 0; }
   .layout-xs-column > .flex-xs-0 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 0%;
-            flex: 1 1 0%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 0%;
     box-sizing: border-box;
     min-height: 0; }
   .flex-xs-5 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 5%;
-            flex: 1 1 5%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 5%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-xs-5 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 5%;
-            flex: 1 1 5%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 5%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-xs-5 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 5%;
-            flex: 1 1 5%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 5%;
     box-sizing: border-box; }
@@ -8322,36 +8307,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-xs-row > .flex-xs-5 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 5%;
-            flex: 1 1 5%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 5%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-xs-column > .flex-xs-5 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 5%;
-            flex: 1 1 5%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 5%;
     box-sizing: border-box; }
   .flex-xs-10 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 10%;
-            flex: 1 1 10%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 10%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-xs-10 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 10%;
-            flex: 1 1 10%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 10%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-xs-10 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 10%;
-            flex: 1 1 10%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 10%;
     box-sizing: border-box; }
@@ -8385,36 +8370,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-xs-row > .flex-xs-10 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 10%;
-            flex: 1 1 10%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 10%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-xs-column > .flex-xs-10 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 10%;
-            flex: 1 1 10%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 10%;
     box-sizing: border-box; }
   .flex-xs-15 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 15%;
-            flex: 1 1 15%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 15%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-xs-15 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 15%;
-            flex: 1 1 15%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 15%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-xs-15 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 15%;
-            flex: 1 1 15%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 15%;
     box-sizing: border-box; }
@@ -8448,36 +8433,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-xs-row > .flex-xs-15 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 15%;
-            flex: 1 1 15%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 15%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-xs-column > .flex-xs-15 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 15%;
-            flex: 1 1 15%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 15%;
     box-sizing: border-box; }
   .flex-xs-20 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 20%;
-            flex: 1 1 20%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 20%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-xs-20 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 20%;
-            flex: 1 1 20%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 20%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-xs-20 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 20%;
-            flex: 1 1 20%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 20%;
     box-sizing: border-box; }
@@ -8511,36 +8496,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-xs-row > .flex-xs-20 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 20%;
-            flex: 1 1 20%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 20%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-xs-column > .flex-xs-20 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 20%;
-            flex: 1 1 20%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 20%;
     box-sizing: border-box; }
   .flex-xs-25 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 25%;
-            flex: 1 1 25%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 25%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-xs-25 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 25%;
-            flex: 1 1 25%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 25%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-xs-25 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 25%;
-            flex: 1 1 25%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 25%;
     box-sizing: border-box; }
@@ -8574,36 +8559,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-xs-row > .flex-xs-25 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 25%;
-            flex: 1 1 25%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 25%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-xs-column > .flex-xs-25 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 25%;
-            flex: 1 1 25%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 25%;
     box-sizing: border-box; }
   .flex-xs-30 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 30%;
-            flex: 1 1 30%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 30%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-xs-30 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 30%;
-            flex: 1 1 30%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 30%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-xs-30 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 30%;
-            flex: 1 1 30%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 30%;
     box-sizing: border-box; }
@@ -8637,36 +8622,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-xs-row > .flex-xs-30 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 30%;
-            flex: 1 1 30%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 30%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-xs-column > .flex-xs-30 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 30%;
-            flex: 1 1 30%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 30%;
     box-sizing: border-box; }
   .flex-xs-35 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 35%;
-            flex: 1 1 35%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 35%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-xs-35 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 35%;
-            flex: 1 1 35%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 35%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-xs-35 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 35%;
-            flex: 1 1 35%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 35%;
     box-sizing: border-box; }
@@ -8700,36 +8685,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-xs-row > .flex-xs-35 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 35%;
-            flex: 1 1 35%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 35%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-xs-column > .flex-xs-35 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 35%;
-            flex: 1 1 35%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 35%;
     box-sizing: border-box; }
   .flex-xs-40 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 40%;
-            flex: 1 1 40%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 40%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-xs-40 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 40%;
-            flex: 1 1 40%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 40%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-xs-40 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 40%;
-            flex: 1 1 40%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 40%;
     box-sizing: border-box; }
@@ -8763,36 +8748,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-xs-row > .flex-xs-40 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 40%;
-            flex: 1 1 40%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 40%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-xs-column > .flex-xs-40 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 40%;
-            flex: 1 1 40%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 40%;
     box-sizing: border-box; }
   .flex-xs-45 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 45%;
-            flex: 1 1 45%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 45%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-xs-45 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 45%;
-            flex: 1 1 45%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 45%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-xs-45 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 45%;
-            flex: 1 1 45%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 45%;
     box-sizing: border-box; }
@@ -8826,36 +8811,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-xs-row > .flex-xs-45 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 45%;
-            flex: 1 1 45%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 45%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-xs-column > .flex-xs-45 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 45%;
-            flex: 1 1 45%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 45%;
     box-sizing: border-box; }
   .flex-xs-50 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 50%;
-            flex: 1 1 50%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 50%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-xs-50 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 50%;
-            flex: 1 1 50%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 50%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-xs-50 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 50%;
-            flex: 1 1 50%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 50%;
     box-sizing: border-box; }
@@ -8889,36 +8874,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-xs-row > .flex-xs-50 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 50%;
-            flex: 1 1 50%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 50%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-xs-column > .flex-xs-50 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 50%;
-            flex: 1 1 50%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 50%;
     box-sizing: border-box; }
   .flex-xs-55 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 55%;
-            flex: 1 1 55%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 55%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-xs-55 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 55%;
-            flex: 1 1 55%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 55%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-xs-55 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 55%;
-            flex: 1 1 55%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 55%;
     box-sizing: border-box; }
@@ -8952,36 +8937,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-xs-row > .flex-xs-55 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 55%;
-            flex: 1 1 55%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 55%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-xs-column > .flex-xs-55 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 55%;
-            flex: 1 1 55%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 55%;
     box-sizing: border-box; }
   .flex-xs-60 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 60%;
-            flex: 1 1 60%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 60%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-xs-60 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 60%;
-            flex: 1 1 60%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 60%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-xs-60 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 60%;
-            flex: 1 1 60%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 60%;
     box-sizing: border-box; }
@@ -9015,36 +9000,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-xs-row > .flex-xs-60 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 60%;
-            flex: 1 1 60%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 60%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-xs-column > .flex-xs-60 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 60%;
-            flex: 1 1 60%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 60%;
     box-sizing: border-box; }
   .flex-xs-65 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 65%;
-            flex: 1 1 65%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 65%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-xs-65 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 65%;
-            flex: 1 1 65%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 65%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-xs-65 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 65%;
-            flex: 1 1 65%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 65%;
     box-sizing: border-box; }
@@ -9078,36 +9063,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-xs-row > .flex-xs-65 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 65%;
-            flex: 1 1 65%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 65%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-xs-column > .flex-xs-65 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 65%;
-            flex: 1 1 65%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 65%;
     box-sizing: border-box; }
   .flex-xs-70 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 70%;
-            flex: 1 1 70%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 70%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-xs-70 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 70%;
-            flex: 1 1 70%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 70%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-xs-70 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 70%;
-            flex: 1 1 70%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 70%;
     box-sizing: border-box; }
@@ -9141,36 +9126,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-xs-row > .flex-xs-70 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 70%;
-            flex: 1 1 70%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 70%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-xs-column > .flex-xs-70 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 70%;
-            flex: 1 1 70%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 70%;
     box-sizing: border-box; }
   .flex-xs-75 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 75%;
-            flex: 1 1 75%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 75%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-xs-75 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 75%;
-            flex: 1 1 75%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 75%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-xs-75 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 75%;
-            flex: 1 1 75%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 75%;
     box-sizing: border-box; }
@@ -9204,36 +9189,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-xs-row > .flex-xs-75 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 75%;
-            flex: 1 1 75%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 75%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-xs-column > .flex-xs-75 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 75%;
-            flex: 1 1 75%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 75%;
     box-sizing: border-box; }
   .flex-xs-80 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 80%;
-            flex: 1 1 80%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 80%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-xs-80 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 80%;
-            flex: 1 1 80%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 80%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-xs-80 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 80%;
-            flex: 1 1 80%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 80%;
     box-sizing: border-box; }
@@ -9267,36 +9252,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-xs-row > .flex-xs-80 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 80%;
-            flex: 1 1 80%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 80%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-xs-column > .flex-xs-80 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 80%;
-            flex: 1 1 80%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 80%;
     box-sizing: border-box; }
   .flex-xs-85 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 85%;
-            flex: 1 1 85%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 85%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-xs-85 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 85%;
-            flex: 1 1 85%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 85%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-xs-85 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 85%;
-            flex: 1 1 85%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 85%;
     box-sizing: border-box; }
@@ -9330,36 +9315,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-xs-row > .flex-xs-85 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 85%;
-            flex: 1 1 85%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 85%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-xs-column > .flex-xs-85 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 85%;
-            flex: 1 1 85%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 85%;
     box-sizing: border-box; }
   .flex-xs-90 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 90%;
-            flex: 1 1 90%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 90%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-xs-90 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 90%;
-            flex: 1 1 90%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 90%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-xs-90 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 90%;
-            flex: 1 1 90%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 90%;
     box-sizing: border-box; }
@@ -9393,36 +9378,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-xs-row > .flex-xs-90 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 90%;
-            flex: 1 1 90%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 90%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-xs-column > .flex-xs-90 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 90%;
-            flex: 1 1 90%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 90%;
     box-sizing: border-box; }
   .flex-xs-95 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 95%;
-            flex: 1 1 95%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 95%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-xs-95 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 95%;
-            flex: 1 1 95%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 95%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-xs-95 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 95%;
-            flex: 1 1 95%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 95%;
     box-sizing: border-box; }
@@ -9456,15 +9441,15 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-xs-row > .flex-xs-95 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 95%;
-            flex: 1 1 95%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 95%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-xs-column > .flex-xs-95 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 95%;
-            flex: 1 1 95%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 95%;
     box-sizing: border-box; }
@@ -9533,15 +9518,15 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-xs-row > .flex-xs-33, .layout-xs-row > .flex-xs-33 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 33.33%;
-            flex: 1 1 33.33%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 33.33%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-xs-row > .flex-xs-66, .layout-xs-row > .flex-xs-66 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 66.66%;
-            flex: 1 1 66.66%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 66.66%;
     max-height: 100%;
     box-sizing: border-box; }
@@ -9549,15 +9534,15 @@ md-tooltip {
     min-width: 0; }
   .layout-xs-column > .flex-xs-33, .layout-xs-column > .flex-xs-33 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 33.33%;
-            flex: 1 1 33.33%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 33.33%;
     box-sizing: border-box; }
   .layout-xs-column > .flex-xs-66, .layout-xs-column > .flex-xs-66 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 66.66%;
-            flex: 1 1 66.66%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 66.66%;
     box-sizing: border-box; }
@@ -9860,7 +9845,6 @@ md-tooltip {
             align-content: stretch;
     -webkit-box-align: stretch;
     -webkit-align-items: stretch;
-                -ms-grid-row-align: stretch;
             align-items: stretch; }
   .layout-align-gt-xs-start,
   .layout-align-gt-xs-start-start,
@@ -9908,7 +9892,6 @@ md-tooltip {
   .layout-align-gt-xs-space-around-start {
     -webkit-box-align: start;
     -webkit-align-items: flex-start;
-                -ms-grid-row-align: flex-start;
             align-items: flex-start;
     -webkit-align-content: flex-start;
             align-content: flex-start; }
@@ -9919,7 +9902,6 @@ md-tooltip {
   .layout-align-gt-xs-space-around-center {
     -webkit-box-align: center;
     -webkit-align-items: center;
-                -ms-grid-row-align: center;
             align-items: center;
     -webkit-align-content: center;
             align-content: center;
@@ -9938,7 +9920,6 @@ md-tooltip {
   .layout-align-gt-xs-space-around-end {
     -webkit-box-align: end;
     -webkit-align-items: flex-end;
-                -ms-grid-row-align: flex-end;
             align-items: flex-end;
     -webkit-align-content: flex-end;
             align-content: flex-end; }
@@ -9949,7 +9930,6 @@ md-tooltip {
   .layout-align-gt-xs-space-around-stretch {
     -webkit-box-align: stretch;
     -webkit-align-items: stretch;
-                -ms-grid-row-align: stretch;
             align-items: stretch;
     -webkit-align-content: stretch;
             align-content: stretch; }
@@ -9990,23 +9970,23 @@ md-tooltip {
     box-sizing: border-box; }
   .flex-gt-xs-0 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 0%;
-            flex: 1 1 0%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 0%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-gt-xs-0 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 0%;
-            flex: 1 1 0%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 0%;
     max-height: 100%;
     box-sizing: border-box;
     min-width: 0; }
   .layout-column > .flex-gt-xs-0 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 0%;
-            flex: 1 1 0%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 0%;
     box-sizing: border-box; }
@@ -10040,38 +10020,38 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-gt-xs-row > .flex-gt-xs-0 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 0%;
-            flex: 1 1 0%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 0%;
     max-height: 100%;
     box-sizing: border-box;
     min-width: 0; }
   .layout-gt-xs-column > .flex-gt-xs-0 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 0%;
-            flex: 1 1 0%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 0%;
     box-sizing: border-box;
     min-height: 0; }
   .flex-gt-xs-5 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 5%;
-            flex: 1 1 5%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 5%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-gt-xs-5 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 5%;
-            flex: 1 1 5%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 5%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-gt-xs-5 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 5%;
-            flex: 1 1 5%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 5%;
     box-sizing: border-box; }
@@ -10105,36 +10085,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-gt-xs-row > .flex-gt-xs-5 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 5%;
-            flex: 1 1 5%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 5%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-gt-xs-column > .flex-gt-xs-5 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 5%;
-            flex: 1 1 5%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 5%;
     box-sizing: border-box; }
   .flex-gt-xs-10 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 10%;
-            flex: 1 1 10%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 10%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-gt-xs-10 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 10%;
-            flex: 1 1 10%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 10%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-gt-xs-10 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 10%;
-            flex: 1 1 10%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 10%;
     box-sizing: border-box; }
@@ -10168,36 +10148,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-gt-xs-row > .flex-gt-xs-10 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 10%;
-            flex: 1 1 10%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 10%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-gt-xs-column > .flex-gt-xs-10 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 10%;
-            flex: 1 1 10%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 10%;
     box-sizing: border-box; }
   .flex-gt-xs-15 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 15%;
-            flex: 1 1 15%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 15%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-gt-xs-15 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 15%;
-            flex: 1 1 15%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 15%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-gt-xs-15 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 15%;
-            flex: 1 1 15%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 15%;
     box-sizing: border-box; }
@@ -10231,36 +10211,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-gt-xs-row > .flex-gt-xs-15 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 15%;
-            flex: 1 1 15%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 15%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-gt-xs-column > .flex-gt-xs-15 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 15%;
-            flex: 1 1 15%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 15%;
     box-sizing: border-box; }
   .flex-gt-xs-20 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 20%;
-            flex: 1 1 20%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 20%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-gt-xs-20 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 20%;
-            flex: 1 1 20%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 20%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-gt-xs-20 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 20%;
-            flex: 1 1 20%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 20%;
     box-sizing: border-box; }
@@ -10294,36 +10274,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-gt-xs-row > .flex-gt-xs-20 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 20%;
-            flex: 1 1 20%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 20%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-gt-xs-column > .flex-gt-xs-20 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 20%;
-            flex: 1 1 20%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 20%;
     box-sizing: border-box; }
   .flex-gt-xs-25 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 25%;
-            flex: 1 1 25%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 25%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-gt-xs-25 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 25%;
-            flex: 1 1 25%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 25%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-gt-xs-25 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 25%;
-            flex: 1 1 25%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 25%;
     box-sizing: border-box; }
@@ -10357,36 +10337,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-gt-xs-row > .flex-gt-xs-25 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 25%;
-            flex: 1 1 25%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 25%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-gt-xs-column > .flex-gt-xs-25 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 25%;
-            flex: 1 1 25%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 25%;
     box-sizing: border-box; }
   .flex-gt-xs-30 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 30%;
-            flex: 1 1 30%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 30%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-gt-xs-30 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 30%;
-            flex: 1 1 30%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 30%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-gt-xs-30 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 30%;
-            flex: 1 1 30%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 30%;
     box-sizing: border-box; }
@@ -10420,36 +10400,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-gt-xs-row > .flex-gt-xs-30 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 30%;
-            flex: 1 1 30%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 30%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-gt-xs-column > .flex-gt-xs-30 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 30%;
-            flex: 1 1 30%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 30%;
     box-sizing: border-box; }
   .flex-gt-xs-35 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 35%;
-            flex: 1 1 35%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 35%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-gt-xs-35 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 35%;
-            flex: 1 1 35%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 35%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-gt-xs-35 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 35%;
-            flex: 1 1 35%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 35%;
     box-sizing: border-box; }
@@ -10483,36 +10463,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-gt-xs-row > .flex-gt-xs-35 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 35%;
-            flex: 1 1 35%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 35%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-gt-xs-column > .flex-gt-xs-35 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 35%;
-            flex: 1 1 35%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 35%;
     box-sizing: border-box; }
   .flex-gt-xs-40 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 40%;
-            flex: 1 1 40%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 40%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-gt-xs-40 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 40%;
-            flex: 1 1 40%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 40%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-gt-xs-40 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 40%;
-            flex: 1 1 40%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 40%;
     box-sizing: border-box; }
@@ -10546,36 +10526,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-gt-xs-row > .flex-gt-xs-40 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 40%;
-            flex: 1 1 40%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 40%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-gt-xs-column > .flex-gt-xs-40 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 40%;
-            flex: 1 1 40%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 40%;
     box-sizing: border-box; }
   .flex-gt-xs-45 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 45%;
-            flex: 1 1 45%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 45%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-gt-xs-45 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 45%;
-            flex: 1 1 45%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 45%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-gt-xs-45 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 45%;
-            flex: 1 1 45%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 45%;
     box-sizing: border-box; }
@@ -10609,36 +10589,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-gt-xs-row > .flex-gt-xs-45 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 45%;
-            flex: 1 1 45%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 45%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-gt-xs-column > .flex-gt-xs-45 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 45%;
-            flex: 1 1 45%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 45%;
     box-sizing: border-box; }
   .flex-gt-xs-50 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 50%;
-            flex: 1 1 50%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 50%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-gt-xs-50 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 50%;
-            flex: 1 1 50%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 50%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-gt-xs-50 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 50%;
-            flex: 1 1 50%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 50%;
     box-sizing: border-box; }
@@ -10672,36 +10652,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-gt-xs-row > .flex-gt-xs-50 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 50%;
-            flex: 1 1 50%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 50%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-gt-xs-column > .flex-gt-xs-50 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 50%;
-            flex: 1 1 50%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 50%;
     box-sizing: border-box; }
   .flex-gt-xs-55 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 55%;
-            flex: 1 1 55%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 55%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-gt-xs-55 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 55%;
-            flex: 1 1 55%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 55%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-gt-xs-55 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 55%;
-            flex: 1 1 55%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 55%;
     box-sizing: border-box; }
@@ -10735,36 +10715,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-gt-xs-row > .flex-gt-xs-55 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 55%;
-            flex: 1 1 55%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 55%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-gt-xs-column > .flex-gt-xs-55 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 55%;
-            flex: 1 1 55%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 55%;
     box-sizing: border-box; }
   .flex-gt-xs-60 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 60%;
-            flex: 1 1 60%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 60%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-gt-xs-60 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 60%;
-            flex: 1 1 60%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 60%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-gt-xs-60 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 60%;
-            flex: 1 1 60%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 60%;
     box-sizing: border-box; }
@@ -10798,36 +10778,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-gt-xs-row > .flex-gt-xs-60 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 60%;
-            flex: 1 1 60%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 60%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-gt-xs-column > .flex-gt-xs-60 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 60%;
-            flex: 1 1 60%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 60%;
     box-sizing: border-box; }
   .flex-gt-xs-65 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 65%;
-            flex: 1 1 65%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 65%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-gt-xs-65 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 65%;
-            flex: 1 1 65%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 65%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-gt-xs-65 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 65%;
-            flex: 1 1 65%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 65%;
     box-sizing: border-box; }
@@ -10861,36 +10841,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-gt-xs-row > .flex-gt-xs-65 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 65%;
-            flex: 1 1 65%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 65%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-gt-xs-column > .flex-gt-xs-65 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 65%;
-            flex: 1 1 65%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 65%;
     box-sizing: border-box; }
   .flex-gt-xs-70 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 70%;
-            flex: 1 1 70%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 70%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-gt-xs-70 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 70%;
-            flex: 1 1 70%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 70%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-gt-xs-70 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 70%;
-            flex: 1 1 70%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 70%;
     box-sizing: border-box; }
@@ -10924,36 +10904,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-gt-xs-row > .flex-gt-xs-70 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 70%;
-            flex: 1 1 70%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 70%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-gt-xs-column > .flex-gt-xs-70 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 70%;
-            flex: 1 1 70%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 70%;
     box-sizing: border-box; }
   .flex-gt-xs-75 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 75%;
-            flex: 1 1 75%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 75%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-gt-xs-75 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 75%;
-            flex: 1 1 75%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 75%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-gt-xs-75 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 75%;
-            flex: 1 1 75%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 75%;
     box-sizing: border-box; }
@@ -10987,36 +10967,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-gt-xs-row > .flex-gt-xs-75 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 75%;
-            flex: 1 1 75%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 75%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-gt-xs-column > .flex-gt-xs-75 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 75%;
-            flex: 1 1 75%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 75%;
     box-sizing: border-box; }
   .flex-gt-xs-80 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 80%;
-            flex: 1 1 80%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 80%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-gt-xs-80 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 80%;
-            flex: 1 1 80%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 80%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-gt-xs-80 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 80%;
-            flex: 1 1 80%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 80%;
     box-sizing: border-box; }
@@ -11050,36 +11030,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-gt-xs-row > .flex-gt-xs-80 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 80%;
-            flex: 1 1 80%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 80%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-gt-xs-column > .flex-gt-xs-80 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 80%;
-            flex: 1 1 80%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 80%;
     box-sizing: border-box; }
   .flex-gt-xs-85 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 85%;
-            flex: 1 1 85%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 85%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-gt-xs-85 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 85%;
-            flex: 1 1 85%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 85%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-gt-xs-85 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 85%;
-            flex: 1 1 85%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 85%;
     box-sizing: border-box; }
@@ -11113,36 +11093,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-gt-xs-row > .flex-gt-xs-85 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 85%;
-            flex: 1 1 85%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 85%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-gt-xs-column > .flex-gt-xs-85 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 85%;
-            flex: 1 1 85%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 85%;
     box-sizing: border-box; }
   .flex-gt-xs-90 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 90%;
-            flex: 1 1 90%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 90%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-gt-xs-90 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 90%;
-            flex: 1 1 90%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 90%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-gt-xs-90 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 90%;
-            flex: 1 1 90%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 90%;
     box-sizing: border-box; }
@@ -11176,36 +11156,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-gt-xs-row > .flex-gt-xs-90 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 90%;
-            flex: 1 1 90%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 90%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-gt-xs-column > .flex-gt-xs-90 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 90%;
-            flex: 1 1 90%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 90%;
     box-sizing: border-box; }
   .flex-gt-xs-95 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 95%;
-            flex: 1 1 95%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 95%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-gt-xs-95 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 95%;
-            flex: 1 1 95%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 95%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-gt-xs-95 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 95%;
-            flex: 1 1 95%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 95%;
     box-sizing: border-box; }
@@ -11239,15 +11219,15 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-gt-xs-row > .flex-gt-xs-95 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 95%;
-            flex: 1 1 95%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 95%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-gt-xs-column > .flex-gt-xs-95 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 95%;
-            flex: 1 1 95%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 95%;
     box-sizing: border-box; }
@@ -11316,15 +11296,15 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-gt-xs-row > .flex-gt-xs-33, .layout-gt-xs-row > .flex-gt-xs-33 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 33.33%;
-            flex: 1 1 33.33%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 33.33%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-gt-xs-row > .flex-gt-xs-66, .layout-gt-xs-row > .flex-gt-xs-66 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 66.66%;
-            flex: 1 1 66.66%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 66.66%;
     max-height: 100%;
     box-sizing: border-box; }
@@ -11332,15 +11312,15 @@ md-tooltip {
     min-width: 0; }
   .layout-gt-xs-column > .flex-gt-xs-33, .layout-gt-xs-column > .flex-gt-xs-33 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 33.33%;
-            flex: 1 1 33.33%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 33.33%;
     box-sizing: border-box; }
   .layout-gt-xs-column > .flex-gt-xs-66, .layout-gt-xs-column > .flex-gt-xs-66 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 66.66%;
-            flex: 1 1 66.66%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 66.66%;
     box-sizing: border-box; }
@@ -11647,7 +11627,6 @@ md-tooltip {
             align-content: stretch;
     -webkit-box-align: stretch;
     -webkit-align-items: stretch;
-                -ms-grid-row-align: stretch;
             align-items: stretch; }
   .layout-align-sm-start,
   .layout-align-sm-start-start,
@@ -11695,7 +11674,6 @@ md-tooltip {
   .layout-align-sm-space-around-start {
     -webkit-box-align: start;
     -webkit-align-items: flex-start;
-                -ms-grid-row-align: flex-start;
             align-items: flex-start;
     -webkit-align-content: flex-start;
             align-content: flex-start; }
@@ -11706,7 +11684,6 @@ md-tooltip {
   .layout-align-sm-space-around-center {
     -webkit-box-align: center;
     -webkit-align-items: center;
-                -ms-grid-row-align: center;
             align-items: center;
     -webkit-align-content: center;
             align-content: center;
@@ -11725,7 +11702,6 @@ md-tooltip {
   .layout-align-sm-space-around-end {
     -webkit-box-align: end;
     -webkit-align-items: flex-end;
-                -ms-grid-row-align: flex-end;
             align-items: flex-end;
     -webkit-align-content: flex-end;
             align-content: flex-end; }
@@ -11736,7 +11712,6 @@ md-tooltip {
   .layout-align-sm-space-around-stretch {
     -webkit-box-align: stretch;
     -webkit-align-items: stretch;
-                -ms-grid-row-align: stretch;
             align-items: stretch;
     -webkit-align-content: stretch;
             align-content: stretch; }
@@ -11777,23 +11752,23 @@ md-tooltip {
     box-sizing: border-box; }
   .flex-sm-0 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 0%;
-            flex: 1 1 0%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 0%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-sm-0 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 0%;
-            flex: 1 1 0%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 0%;
     max-height: 100%;
     box-sizing: border-box;
     min-width: 0; }
   .layout-column > .flex-sm-0 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 0%;
-            flex: 1 1 0%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 0%;
     box-sizing: border-box; }
@@ -11827,38 +11802,38 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-sm-row > .flex-sm-0 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 0%;
-            flex: 1 1 0%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 0%;
     max-height: 100%;
     box-sizing: border-box;
     min-width: 0; }
   .layout-sm-column > .flex-sm-0 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 0%;
-            flex: 1 1 0%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 0%;
     box-sizing: border-box;
     min-height: 0; }
   .flex-sm-5 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 5%;
-            flex: 1 1 5%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 5%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-sm-5 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 5%;
-            flex: 1 1 5%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 5%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-sm-5 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 5%;
-            flex: 1 1 5%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 5%;
     box-sizing: border-box; }
@@ -11892,36 +11867,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-sm-row > .flex-sm-5 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 5%;
-            flex: 1 1 5%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 5%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-sm-column > .flex-sm-5 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 5%;
-            flex: 1 1 5%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 5%;
     box-sizing: border-box; }
   .flex-sm-10 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 10%;
-            flex: 1 1 10%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 10%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-sm-10 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 10%;
-            flex: 1 1 10%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 10%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-sm-10 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 10%;
-            flex: 1 1 10%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 10%;
     box-sizing: border-box; }
@@ -11955,36 +11930,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-sm-row > .flex-sm-10 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 10%;
-            flex: 1 1 10%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 10%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-sm-column > .flex-sm-10 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 10%;
-            flex: 1 1 10%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 10%;
     box-sizing: border-box; }
   .flex-sm-15 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 15%;
-            flex: 1 1 15%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 15%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-sm-15 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 15%;
-            flex: 1 1 15%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 15%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-sm-15 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 15%;
-            flex: 1 1 15%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 15%;
     box-sizing: border-box; }
@@ -12018,36 +11993,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-sm-row > .flex-sm-15 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 15%;
-            flex: 1 1 15%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 15%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-sm-column > .flex-sm-15 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 15%;
-            flex: 1 1 15%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 15%;
     box-sizing: border-box; }
   .flex-sm-20 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 20%;
-            flex: 1 1 20%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 20%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-sm-20 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 20%;
-            flex: 1 1 20%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 20%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-sm-20 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 20%;
-            flex: 1 1 20%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 20%;
     box-sizing: border-box; }
@@ -12081,36 +12056,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-sm-row > .flex-sm-20 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 20%;
-            flex: 1 1 20%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 20%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-sm-column > .flex-sm-20 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 20%;
-            flex: 1 1 20%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 20%;
     box-sizing: border-box; }
   .flex-sm-25 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 25%;
-            flex: 1 1 25%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 25%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-sm-25 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 25%;
-            flex: 1 1 25%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 25%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-sm-25 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 25%;
-            flex: 1 1 25%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 25%;
     box-sizing: border-box; }
@@ -12144,36 +12119,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-sm-row > .flex-sm-25 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 25%;
-            flex: 1 1 25%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 25%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-sm-column > .flex-sm-25 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 25%;
-            flex: 1 1 25%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 25%;
     box-sizing: border-box; }
   .flex-sm-30 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 30%;
-            flex: 1 1 30%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 30%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-sm-30 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 30%;
-            flex: 1 1 30%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 30%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-sm-30 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 30%;
-            flex: 1 1 30%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 30%;
     box-sizing: border-box; }
@@ -12207,36 +12182,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-sm-row > .flex-sm-30 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 30%;
-            flex: 1 1 30%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 30%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-sm-column > .flex-sm-30 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 30%;
-            flex: 1 1 30%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 30%;
     box-sizing: border-box; }
   .flex-sm-35 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 35%;
-            flex: 1 1 35%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 35%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-sm-35 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 35%;
-            flex: 1 1 35%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 35%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-sm-35 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 35%;
-            flex: 1 1 35%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 35%;
     box-sizing: border-box; }
@@ -12270,36 +12245,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-sm-row > .flex-sm-35 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 35%;
-            flex: 1 1 35%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 35%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-sm-column > .flex-sm-35 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 35%;
-            flex: 1 1 35%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 35%;
     box-sizing: border-box; }
   .flex-sm-40 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 40%;
-            flex: 1 1 40%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 40%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-sm-40 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 40%;
-            flex: 1 1 40%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 40%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-sm-40 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 40%;
-            flex: 1 1 40%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 40%;
     box-sizing: border-box; }
@@ -12333,36 +12308,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-sm-row > .flex-sm-40 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 40%;
-            flex: 1 1 40%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 40%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-sm-column > .flex-sm-40 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 40%;
-            flex: 1 1 40%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 40%;
     box-sizing: border-box; }
   .flex-sm-45 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 45%;
-            flex: 1 1 45%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 45%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-sm-45 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 45%;
-            flex: 1 1 45%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 45%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-sm-45 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 45%;
-            flex: 1 1 45%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 45%;
     box-sizing: border-box; }
@@ -12396,36 +12371,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-sm-row > .flex-sm-45 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 45%;
-            flex: 1 1 45%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 45%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-sm-column > .flex-sm-45 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 45%;
-            flex: 1 1 45%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 45%;
     box-sizing: border-box; }
   .flex-sm-50 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 50%;
-            flex: 1 1 50%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 50%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-sm-50 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 50%;
-            flex: 1 1 50%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 50%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-sm-50 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 50%;
-            flex: 1 1 50%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 50%;
     box-sizing: border-box; }
@@ -12459,36 +12434,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-sm-row > .flex-sm-50 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 50%;
-            flex: 1 1 50%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 50%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-sm-column > .flex-sm-50 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 50%;
-            flex: 1 1 50%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 50%;
     box-sizing: border-box; }
   .flex-sm-55 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 55%;
-            flex: 1 1 55%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 55%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-sm-55 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 55%;
-            flex: 1 1 55%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 55%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-sm-55 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 55%;
-            flex: 1 1 55%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 55%;
     box-sizing: border-box; }
@@ -12522,36 +12497,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-sm-row > .flex-sm-55 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 55%;
-            flex: 1 1 55%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 55%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-sm-column > .flex-sm-55 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 55%;
-            flex: 1 1 55%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 55%;
     box-sizing: border-box; }
   .flex-sm-60 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 60%;
-            flex: 1 1 60%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 60%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-sm-60 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 60%;
-            flex: 1 1 60%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 60%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-sm-60 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 60%;
-            flex: 1 1 60%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 60%;
     box-sizing: border-box; }
@@ -12585,36 +12560,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-sm-row > .flex-sm-60 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 60%;
-            flex: 1 1 60%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 60%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-sm-column > .flex-sm-60 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 60%;
-            flex: 1 1 60%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 60%;
     box-sizing: border-box; }
   .flex-sm-65 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 65%;
-            flex: 1 1 65%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 65%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-sm-65 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 65%;
-            flex: 1 1 65%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 65%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-sm-65 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 65%;
-            flex: 1 1 65%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 65%;
     box-sizing: border-box; }
@@ -12648,36 +12623,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-sm-row > .flex-sm-65 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 65%;
-            flex: 1 1 65%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 65%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-sm-column > .flex-sm-65 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 65%;
-            flex: 1 1 65%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 65%;
     box-sizing: border-box; }
   .flex-sm-70 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 70%;
-            flex: 1 1 70%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 70%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-sm-70 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 70%;
-            flex: 1 1 70%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 70%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-sm-70 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 70%;
-            flex: 1 1 70%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 70%;
     box-sizing: border-box; }
@@ -12711,36 +12686,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-sm-row > .flex-sm-70 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 70%;
-            flex: 1 1 70%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 70%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-sm-column > .flex-sm-70 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 70%;
-            flex: 1 1 70%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 70%;
     box-sizing: border-box; }
   .flex-sm-75 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 75%;
-            flex: 1 1 75%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 75%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-sm-75 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 75%;
-            flex: 1 1 75%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 75%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-sm-75 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 75%;
-            flex: 1 1 75%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 75%;
     box-sizing: border-box; }
@@ -12774,36 +12749,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-sm-row > .flex-sm-75 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 75%;
-            flex: 1 1 75%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 75%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-sm-column > .flex-sm-75 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 75%;
-            flex: 1 1 75%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 75%;
     box-sizing: border-box; }
   .flex-sm-80 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 80%;
-            flex: 1 1 80%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 80%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-sm-80 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 80%;
-            flex: 1 1 80%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 80%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-sm-80 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 80%;
-            flex: 1 1 80%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 80%;
     box-sizing: border-box; }
@@ -12837,36 +12812,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-sm-row > .flex-sm-80 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 80%;
-            flex: 1 1 80%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 80%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-sm-column > .flex-sm-80 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 80%;
-            flex: 1 1 80%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 80%;
     box-sizing: border-box; }
   .flex-sm-85 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 85%;
-            flex: 1 1 85%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 85%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-sm-85 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 85%;
-            flex: 1 1 85%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 85%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-sm-85 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 85%;
-            flex: 1 1 85%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 85%;
     box-sizing: border-box; }
@@ -12900,36 +12875,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-sm-row > .flex-sm-85 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 85%;
-            flex: 1 1 85%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 85%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-sm-column > .flex-sm-85 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 85%;
-            flex: 1 1 85%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 85%;
     box-sizing: border-box; }
   .flex-sm-90 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 90%;
-            flex: 1 1 90%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 90%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-sm-90 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 90%;
-            flex: 1 1 90%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 90%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-sm-90 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 90%;
-            flex: 1 1 90%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 90%;
     box-sizing: border-box; }
@@ -12963,36 +12938,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-sm-row > .flex-sm-90 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 90%;
-            flex: 1 1 90%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 90%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-sm-column > .flex-sm-90 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 90%;
-            flex: 1 1 90%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 90%;
     box-sizing: border-box; }
   .flex-sm-95 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 95%;
-            flex: 1 1 95%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 95%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-sm-95 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 95%;
-            flex: 1 1 95%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 95%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-sm-95 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 95%;
-            flex: 1 1 95%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 95%;
     box-sizing: border-box; }
@@ -13026,15 +13001,15 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-sm-row > .flex-sm-95 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 95%;
-            flex: 1 1 95%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 95%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-sm-column > .flex-sm-95 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 95%;
-            flex: 1 1 95%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 95%;
     box-sizing: border-box; }
@@ -13103,15 +13078,15 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-sm-row > .flex-sm-33, .layout-sm-row > .flex-sm-33 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 33.33%;
-            flex: 1 1 33.33%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 33.33%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-sm-row > .flex-sm-66, .layout-sm-row > .flex-sm-66 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 66.66%;
-            flex: 1 1 66.66%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 66.66%;
     max-height: 100%;
     box-sizing: border-box; }
@@ -13119,15 +13094,15 @@ md-tooltip {
     min-width: 0; }
   .layout-sm-column > .flex-sm-33, .layout-sm-column > .flex-sm-33 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 33.33%;
-            flex: 1 1 33.33%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 33.33%;
     box-sizing: border-box; }
   .layout-sm-column > .flex-sm-66, .layout-sm-column > .flex-sm-66 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 66.66%;
-            flex: 1 1 66.66%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 66.66%;
     box-sizing: border-box; }
@@ -13430,7 +13405,6 @@ md-tooltip {
             align-content: stretch;
     -webkit-box-align: stretch;
     -webkit-align-items: stretch;
-                -ms-grid-row-align: stretch;
             align-items: stretch; }
   .layout-align-gt-sm-start,
   .layout-align-gt-sm-start-start,
@@ -13478,7 +13452,6 @@ md-tooltip {
   .layout-align-gt-sm-space-around-start {
     -webkit-box-align: start;
     -webkit-align-items: flex-start;
-                -ms-grid-row-align: flex-start;
             align-items: flex-start;
     -webkit-align-content: flex-start;
             align-content: flex-start; }
@@ -13489,7 +13462,6 @@ md-tooltip {
   .layout-align-gt-sm-space-around-center {
     -webkit-box-align: center;
     -webkit-align-items: center;
-                -ms-grid-row-align: center;
             align-items: center;
     -webkit-align-content: center;
             align-content: center;
@@ -13508,7 +13480,6 @@ md-tooltip {
   .layout-align-gt-sm-space-around-end {
     -webkit-box-align: end;
     -webkit-align-items: flex-end;
-                -ms-grid-row-align: flex-end;
             align-items: flex-end;
     -webkit-align-content: flex-end;
             align-content: flex-end; }
@@ -13519,7 +13490,6 @@ md-tooltip {
   .layout-align-gt-sm-space-around-stretch {
     -webkit-box-align: stretch;
     -webkit-align-items: stretch;
-                -ms-grid-row-align: stretch;
             align-items: stretch;
     -webkit-align-content: stretch;
             align-content: stretch; }
@@ -13560,23 +13530,23 @@ md-tooltip {
     box-sizing: border-box; }
   .flex-gt-sm-0 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 0%;
-            flex: 1 1 0%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 0%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-gt-sm-0 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 0%;
-            flex: 1 1 0%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 0%;
     max-height: 100%;
     box-sizing: border-box;
     min-width: 0; }
   .layout-column > .flex-gt-sm-0 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 0%;
-            flex: 1 1 0%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 0%;
     box-sizing: border-box; }
@@ -13610,38 +13580,38 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-gt-sm-row > .flex-gt-sm-0 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 0%;
-            flex: 1 1 0%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 0%;
     max-height: 100%;
     box-sizing: border-box;
     min-width: 0; }
   .layout-gt-sm-column > .flex-gt-sm-0 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 0%;
-            flex: 1 1 0%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 0%;
     box-sizing: border-box;
     min-height: 0; }
   .flex-gt-sm-5 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 5%;
-            flex: 1 1 5%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 5%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-gt-sm-5 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 5%;
-            flex: 1 1 5%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 5%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-gt-sm-5 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 5%;
-            flex: 1 1 5%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 5%;
     box-sizing: border-box; }
@@ -13675,36 +13645,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-gt-sm-row > .flex-gt-sm-5 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 5%;
-            flex: 1 1 5%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 5%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-gt-sm-column > .flex-gt-sm-5 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 5%;
-            flex: 1 1 5%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 5%;
     box-sizing: border-box; }
   .flex-gt-sm-10 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 10%;
-            flex: 1 1 10%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 10%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-gt-sm-10 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 10%;
-            flex: 1 1 10%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 10%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-gt-sm-10 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 10%;
-            flex: 1 1 10%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 10%;
     box-sizing: border-box; }
@@ -13738,36 +13708,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-gt-sm-row > .flex-gt-sm-10 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 10%;
-            flex: 1 1 10%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 10%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-gt-sm-column > .flex-gt-sm-10 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 10%;
-            flex: 1 1 10%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 10%;
     box-sizing: border-box; }
   .flex-gt-sm-15 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 15%;
-            flex: 1 1 15%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 15%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-gt-sm-15 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 15%;
-            flex: 1 1 15%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 15%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-gt-sm-15 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 15%;
-            flex: 1 1 15%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 15%;
     box-sizing: border-box; }
@@ -13801,36 +13771,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-gt-sm-row > .flex-gt-sm-15 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 15%;
-            flex: 1 1 15%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 15%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-gt-sm-column > .flex-gt-sm-15 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 15%;
-            flex: 1 1 15%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 15%;
     box-sizing: border-box; }
   .flex-gt-sm-20 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 20%;
-            flex: 1 1 20%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 20%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-gt-sm-20 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 20%;
-            flex: 1 1 20%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 20%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-gt-sm-20 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 20%;
-            flex: 1 1 20%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 20%;
     box-sizing: border-box; }
@@ -13864,36 +13834,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-gt-sm-row > .flex-gt-sm-20 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 20%;
-            flex: 1 1 20%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 20%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-gt-sm-column > .flex-gt-sm-20 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 20%;
-            flex: 1 1 20%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 20%;
     box-sizing: border-box; }
   .flex-gt-sm-25 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 25%;
-            flex: 1 1 25%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 25%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-gt-sm-25 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 25%;
-            flex: 1 1 25%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 25%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-gt-sm-25 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 25%;
-            flex: 1 1 25%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 25%;
     box-sizing: border-box; }
@@ -13927,36 +13897,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-gt-sm-row > .flex-gt-sm-25 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 25%;
-            flex: 1 1 25%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 25%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-gt-sm-column > .flex-gt-sm-25 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 25%;
-            flex: 1 1 25%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 25%;
     box-sizing: border-box; }
   .flex-gt-sm-30 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 30%;
-            flex: 1 1 30%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 30%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-gt-sm-30 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 30%;
-            flex: 1 1 30%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 30%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-gt-sm-30 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 30%;
-            flex: 1 1 30%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 30%;
     box-sizing: border-box; }
@@ -13990,36 +13960,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-gt-sm-row > .flex-gt-sm-30 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 30%;
-            flex: 1 1 30%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 30%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-gt-sm-column > .flex-gt-sm-30 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 30%;
-            flex: 1 1 30%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 30%;
     box-sizing: border-box; }
   .flex-gt-sm-35 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 35%;
-            flex: 1 1 35%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 35%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-gt-sm-35 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 35%;
-            flex: 1 1 35%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 35%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-gt-sm-35 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 35%;
-            flex: 1 1 35%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 35%;
     box-sizing: border-box; }
@@ -14053,36 +14023,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-gt-sm-row > .flex-gt-sm-35 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 35%;
-            flex: 1 1 35%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 35%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-gt-sm-column > .flex-gt-sm-35 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 35%;
-            flex: 1 1 35%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 35%;
     box-sizing: border-box; }
   .flex-gt-sm-40 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 40%;
-            flex: 1 1 40%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 40%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-gt-sm-40 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 40%;
-            flex: 1 1 40%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 40%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-gt-sm-40 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 40%;
-            flex: 1 1 40%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 40%;
     box-sizing: border-box; }
@@ -14116,36 +14086,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-gt-sm-row > .flex-gt-sm-40 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 40%;
-            flex: 1 1 40%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 40%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-gt-sm-column > .flex-gt-sm-40 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 40%;
-            flex: 1 1 40%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 40%;
     box-sizing: border-box; }
   .flex-gt-sm-45 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 45%;
-            flex: 1 1 45%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 45%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-gt-sm-45 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 45%;
-            flex: 1 1 45%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 45%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-gt-sm-45 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 45%;
-            flex: 1 1 45%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 45%;
     box-sizing: border-box; }
@@ -14179,36 +14149,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-gt-sm-row > .flex-gt-sm-45 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 45%;
-            flex: 1 1 45%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 45%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-gt-sm-column > .flex-gt-sm-45 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 45%;
-            flex: 1 1 45%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 45%;
     box-sizing: border-box; }
   .flex-gt-sm-50 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 50%;
-            flex: 1 1 50%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 50%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-gt-sm-50 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 50%;
-            flex: 1 1 50%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 50%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-gt-sm-50 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 50%;
-            flex: 1 1 50%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 50%;
     box-sizing: border-box; }
@@ -14242,36 +14212,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-gt-sm-row > .flex-gt-sm-50 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 50%;
-            flex: 1 1 50%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 50%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-gt-sm-column > .flex-gt-sm-50 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 50%;
-            flex: 1 1 50%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 50%;
     box-sizing: border-box; }
   .flex-gt-sm-55 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 55%;
-            flex: 1 1 55%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 55%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-gt-sm-55 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 55%;
-            flex: 1 1 55%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 55%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-gt-sm-55 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 55%;
-            flex: 1 1 55%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 55%;
     box-sizing: border-box; }
@@ -14305,36 +14275,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-gt-sm-row > .flex-gt-sm-55 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 55%;
-            flex: 1 1 55%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 55%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-gt-sm-column > .flex-gt-sm-55 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 55%;
-            flex: 1 1 55%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 55%;
     box-sizing: border-box; }
   .flex-gt-sm-60 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 60%;
-            flex: 1 1 60%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 60%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-gt-sm-60 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 60%;
-            flex: 1 1 60%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 60%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-gt-sm-60 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 60%;
-            flex: 1 1 60%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 60%;
     box-sizing: border-box; }
@@ -14368,36 +14338,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-gt-sm-row > .flex-gt-sm-60 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 60%;
-            flex: 1 1 60%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 60%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-gt-sm-column > .flex-gt-sm-60 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 60%;
-            flex: 1 1 60%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 60%;
     box-sizing: border-box; }
   .flex-gt-sm-65 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 65%;
-            flex: 1 1 65%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 65%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-gt-sm-65 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 65%;
-            flex: 1 1 65%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 65%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-gt-sm-65 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 65%;
-            flex: 1 1 65%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 65%;
     box-sizing: border-box; }
@@ -14431,36 +14401,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-gt-sm-row > .flex-gt-sm-65 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 65%;
-            flex: 1 1 65%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 65%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-gt-sm-column > .flex-gt-sm-65 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 65%;
-            flex: 1 1 65%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 65%;
     box-sizing: border-box; }
   .flex-gt-sm-70 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 70%;
-            flex: 1 1 70%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 70%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-gt-sm-70 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 70%;
-            flex: 1 1 70%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 70%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-gt-sm-70 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 70%;
-            flex: 1 1 70%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 70%;
     box-sizing: border-box; }
@@ -14494,36 +14464,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-gt-sm-row > .flex-gt-sm-70 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 70%;
-            flex: 1 1 70%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 70%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-gt-sm-column > .flex-gt-sm-70 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 70%;
-            flex: 1 1 70%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 70%;
     box-sizing: border-box; }
   .flex-gt-sm-75 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 75%;
-            flex: 1 1 75%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 75%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-gt-sm-75 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 75%;
-            flex: 1 1 75%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 75%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-gt-sm-75 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 75%;
-            flex: 1 1 75%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 75%;
     box-sizing: border-box; }
@@ -14557,36 +14527,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-gt-sm-row > .flex-gt-sm-75 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 75%;
-            flex: 1 1 75%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 75%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-gt-sm-column > .flex-gt-sm-75 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 75%;
-            flex: 1 1 75%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 75%;
     box-sizing: border-box; }
   .flex-gt-sm-80 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 80%;
-            flex: 1 1 80%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 80%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-gt-sm-80 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 80%;
-            flex: 1 1 80%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 80%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-gt-sm-80 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 80%;
-            flex: 1 1 80%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 80%;
     box-sizing: border-box; }
@@ -14620,36 +14590,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-gt-sm-row > .flex-gt-sm-80 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 80%;
-            flex: 1 1 80%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 80%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-gt-sm-column > .flex-gt-sm-80 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 80%;
-            flex: 1 1 80%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 80%;
     box-sizing: border-box; }
   .flex-gt-sm-85 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 85%;
-            flex: 1 1 85%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 85%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-gt-sm-85 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 85%;
-            flex: 1 1 85%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 85%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-gt-sm-85 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 85%;
-            flex: 1 1 85%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 85%;
     box-sizing: border-box; }
@@ -14683,36 +14653,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-gt-sm-row > .flex-gt-sm-85 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 85%;
-            flex: 1 1 85%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 85%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-gt-sm-column > .flex-gt-sm-85 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 85%;
-            flex: 1 1 85%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 85%;
     box-sizing: border-box; }
   .flex-gt-sm-90 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 90%;
-            flex: 1 1 90%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 90%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-gt-sm-90 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 90%;
-            flex: 1 1 90%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 90%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-gt-sm-90 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 90%;
-            flex: 1 1 90%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 90%;
     box-sizing: border-box; }
@@ -14746,36 +14716,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-gt-sm-row > .flex-gt-sm-90 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 90%;
-            flex: 1 1 90%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 90%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-gt-sm-column > .flex-gt-sm-90 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 90%;
-            flex: 1 1 90%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 90%;
     box-sizing: border-box; }
   .flex-gt-sm-95 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 95%;
-            flex: 1 1 95%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 95%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-gt-sm-95 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 95%;
-            flex: 1 1 95%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 95%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-gt-sm-95 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 95%;
-            flex: 1 1 95%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 95%;
     box-sizing: border-box; }
@@ -14809,15 +14779,15 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-gt-sm-row > .flex-gt-sm-95 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 95%;
-            flex: 1 1 95%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 95%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-gt-sm-column > .flex-gt-sm-95 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 95%;
-            flex: 1 1 95%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 95%;
     box-sizing: border-box; }
@@ -14886,15 +14856,15 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-gt-sm-row > .flex-gt-sm-33, .layout-gt-sm-row > .flex-gt-sm-33 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 33.33%;
-            flex: 1 1 33.33%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 33.33%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-gt-sm-row > .flex-gt-sm-66, .layout-gt-sm-row > .flex-gt-sm-66 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 66.66%;
-            flex: 1 1 66.66%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 66.66%;
     max-height: 100%;
     box-sizing: border-box; }
@@ -14902,15 +14872,15 @@ md-tooltip {
     min-width: 0; }
   .layout-gt-sm-column > .flex-gt-sm-33, .layout-gt-sm-column > .flex-gt-sm-33 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 33.33%;
-            flex: 1 1 33.33%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 33.33%;
     box-sizing: border-box; }
   .layout-gt-sm-column > .flex-gt-sm-66, .layout-gt-sm-column > .flex-gt-sm-66 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 66.66%;
-            flex: 1 1 66.66%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 66.66%;
     box-sizing: border-box; }
@@ -15217,7 +15187,6 @@ md-tooltip {
             align-content: stretch;
     -webkit-box-align: stretch;
     -webkit-align-items: stretch;
-                -ms-grid-row-align: stretch;
             align-items: stretch; }
   .layout-align-md-start,
   .layout-align-md-start-start,
@@ -15265,7 +15234,6 @@ md-tooltip {
   .layout-align-md-space-around-start {
     -webkit-box-align: start;
     -webkit-align-items: flex-start;
-                -ms-grid-row-align: flex-start;
             align-items: flex-start;
     -webkit-align-content: flex-start;
             align-content: flex-start; }
@@ -15276,7 +15244,6 @@ md-tooltip {
   .layout-align-md-space-around-center {
     -webkit-box-align: center;
     -webkit-align-items: center;
-                -ms-grid-row-align: center;
             align-items: center;
     -webkit-align-content: center;
             align-content: center;
@@ -15295,7 +15262,6 @@ md-tooltip {
   .layout-align-md-space-around-end {
     -webkit-box-align: end;
     -webkit-align-items: flex-end;
-                -ms-grid-row-align: flex-end;
             align-items: flex-end;
     -webkit-align-content: flex-end;
             align-content: flex-end; }
@@ -15306,7 +15272,6 @@ md-tooltip {
   .layout-align-md-space-around-stretch {
     -webkit-box-align: stretch;
     -webkit-align-items: stretch;
-                -ms-grid-row-align: stretch;
             align-items: stretch;
     -webkit-align-content: stretch;
             align-content: stretch; }
@@ -15347,23 +15312,23 @@ md-tooltip {
     box-sizing: border-box; }
   .flex-md-0 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 0%;
-            flex: 1 1 0%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 0%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-md-0 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 0%;
-            flex: 1 1 0%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 0%;
     max-height: 100%;
     box-sizing: border-box;
     min-width: 0; }
   .layout-column > .flex-md-0 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 0%;
-            flex: 1 1 0%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 0%;
     box-sizing: border-box; }
@@ -15397,38 +15362,38 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-md-row > .flex-md-0 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 0%;
-            flex: 1 1 0%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 0%;
     max-height: 100%;
     box-sizing: border-box;
     min-width: 0; }
   .layout-md-column > .flex-md-0 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 0%;
-            flex: 1 1 0%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 0%;
     box-sizing: border-box;
     min-height: 0; }
   .flex-md-5 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 5%;
-            flex: 1 1 5%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 5%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-md-5 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 5%;
-            flex: 1 1 5%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 5%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-md-5 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 5%;
-            flex: 1 1 5%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 5%;
     box-sizing: border-box; }
@@ -15462,36 +15427,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-md-row > .flex-md-5 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 5%;
-            flex: 1 1 5%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 5%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-md-column > .flex-md-5 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 5%;
-            flex: 1 1 5%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 5%;
     box-sizing: border-box; }
   .flex-md-10 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 10%;
-            flex: 1 1 10%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 10%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-md-10 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 10%;
-            flex: 1 1 10%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 10%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-md-10 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 10%;
-            flex: 1 1 10%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 10%;
     box-sizing: border-box; }
@@ -15525,36 +15490,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-md-row > .flex-md-10 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 10%;
-            flex: 1 1 10%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 10%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-md-column > .flex-md-10 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 10%;
-            flex: 1 1 10%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 10%;
     box-sizing: border-box; }
   .flex-md-15 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 15%;
-            flex: 1 1 15%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 15%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-md-15 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 15%;
-            flex: 1 1 15%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 15%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-md-15 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 15%;
-            flex: 1 1 15%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 15%;
     box-sizing: border-box; }
@@ -15588,36 +15553,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-md-row > .flex-md-15 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 15%;
-            flex: 1 1 15%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 15%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-md-column > .flex-md-15 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 15%;
-            flex: 1 1 15%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 15%;
     box-sizing: border-box; }
   .flex-md-20 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 20%;
-            flex: 1 1 20%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 20%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-md-20 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 20%;
-            flex: 1 1 20%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 20%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-md-20 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 20%;
-            flex: 1 1 20%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 20%;
     box-sizing: border-box; }
@@ -15651,36 +15616,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-md-row > .flex-md-20 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 20%;
-            flex: 1 1 20%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 20%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-md-column > .flex-md-20 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 20%;
-            flex: 1 1 20%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 20%;
     box-sizing: border-box; }
   .flex-md-25 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 25%;
-            flex: 1 1 25%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 25%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-md-25 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 25%;
-            flex: 1 1 25%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 25%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-md-25 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 25%;
-            flex: 1 1 25%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 25%;
     box-sizing: border-box; }
@@ -15714,36 +15679,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-md-row > .flex-md-25 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 25%;
-            flex: 1 1 25%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 25%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-md-column > .flex-md-25 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 25%;
-            flex: 1 1 25%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 25%;
     box-sizing: border-box; }
   .flex-md-30 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 30%;
-            flex: 1 1 30%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 30%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-md-30 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 30%;
-            flex: 1 1 30%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 30%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-md-30 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 30%;
-            flex: 1 1 30%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 30%;
     box-sizing: border-box; }
@@ -15777,36 +15742,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-md-row > .flex-md-30 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 30%;
-            flex: 1 1 30%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 30%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-md-column > .flex-md-30 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 30%;
-            flex: 1 1 30%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 30%;
     box-sizing: border-box; }
   .flex-md-35 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 35%;
-            flex: 1 1 35%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 35%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-md-35 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 35%;
-            flex: 1 1 35%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 35%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-md-35 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 35%;
-            flex: 1 1 35%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 35%;
     box-sizing: border-box; }
@@ -15840,36 +15805,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-md-row > .flex-md-35 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 35%;
-            flex: 1 1 35%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 35%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-md-column > .flex-md-35 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 35%;
-            flex: 1 1 35%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 35%;
     box-sizing: border-box; }
   .flex-md-40 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 40%;
-            flex: 1 1 40%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 40%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-md-40 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 40%;
-            flex: 1 1 40%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 40%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-md-40 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 40%;
-            flex: 1 1 40%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 40%;
     box-sizing: border-box; }
@@ -15903,36 +15868,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-md-row > .flex-md-40 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 40%;
-            flex: 1 1 40%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 40%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-md-column > .flex-md-40 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 40%;
-            flex: 1 1 40%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 40%;
     box-sizing: border-box; }
   .flex-md-45 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 45%;
-            flex: 1 1 45%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 45%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-md-45 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 45%;
-            flex: 1 1 45%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 45%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-md-45 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 45%;
-            flex: 1 1 45%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 45%;
     box-sizing: border-box; }
@@ -15966,36 +15931,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-md-row > .flex-md-45 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 45%;
-            flex: 1 1 45%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 45%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-md-column > .flex-md-45 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 45%;
-            flex: 1 1 45%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 45%;
     box-sizing: border-box; }
   .flex-md-50 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 50%;
-            flex: 1 1 50%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 50%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-md-50 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 50%;
-            flex: 1 1 50%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 50%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-md-50 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 50%;
-            flex: 1 1 50%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 50%;
     box-sizing: border-box; }
@@ -16029,36 +15994,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-md-row > .flex-md-50 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 50%;
-            flex: 1 1 50%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 50%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-md-column > .flex-md-50 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 50%;
-            flex: 1 1 50%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 50%;
     box-sizing: border-box; }
   .flex-md-55 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 55%;
-            flex: 1 1 55%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 55%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-md-55 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 55%;
-            flex: 1 1 55%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 55%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-md-55 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 55%;
-            flex: 1 1 55%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 55%;
     box-sizing: border-box; }
@@ -16092,36 +16057,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-md-row > .flex-md-55 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 55%;
-            flex: 1 1 55%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 55%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-md-column > .flex-md-55 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 55%;
-            flex: 1 1 55%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 55%;
     box-sizing: border-box; }
   .flex-md-60 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 60%;
-            flex: 1 1 60%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 60%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-md-60 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 60%;
-            flex: 1 1 60%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 60%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-md-60 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 60%;
-            flex: 1 1 60%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 60%;
     box-sizing: border-box; }
@@ -16155,36 +16120,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-md-row > .flex-md-60 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 60%;
-            flex: 1 1 60%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 60%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-md-column > .flex-md-60 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 60%;
-            flex: 1 1 60%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 60%;
     box-sizing: border-box; }
   .flex-md-65 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 65%;
-            flex: 1 1 65%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 65%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-md-65 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 65%;
-            flex: 1 1 65%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 65%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-md-65 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 65%;
-            flex: 1 1 65%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 65%;
     box-sizing: border-box; }
@@ -16218,36 +16183,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-md-row > .flex-md-65 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 65%;
-            flex: 1 1 65%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 65%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-md-column > .flex-md-65 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 65%;
-            flex: 1 1 65%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 65%;
     box-sizing: border-box; }
   .flex-md-70 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 70%;
-            flex: 1 1 70%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 70%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-md-70 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 70%;
-            flex: 1 1 70%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 70%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-md-70 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 70%;
-            flex: 1 1 70%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 70%;
     box-sizing: border-box; }
@@ -16281,36 +16246,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-md-row > .flex-md-70 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 70%;
-            flex: 1 1 70%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 70%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-md-column > .flex-md-70 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 70%;
-            flex: 1 1 70%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 70%;
     box-sizing: border-box; }
   .flex-md-75 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 75%;
-            flex: 1 1 75%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 75%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-md-75 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 75%;
-            flex: 1 1 75%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 75%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-md-75 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 75%;
-            flex: 1 1 75%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 75%;
     box-sizing: border-box; }
@@ -16344,36 +16309,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-md-row > .flex-md-75 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 75%;
-            flex: 1 1 75%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 75%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-md-column > .flex-md-75 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 75%;
-            flex: 1 1 75%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 75%;
     box-sizing: border-box; }
   .flex-md-80 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 80%;
-            flex: 1 1 80%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 80%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-md-80 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 80%;
-            flex: 1 1 80%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 80%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-md-80 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 80%;
-            flex: 1 1 80%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 80%;
     box-sizing: border-box; }
@@ -16407,36 +16372,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-md-row > .flex-md-80 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 80%;
-            flex: 1 1 80%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 80%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-md-column > .flex-md-80 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 80%;
-            flex: 1 1 80%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 80%;
     box-sizing: border-box; }
   .flex-md-85 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 85%;
-            flex: 1 1 85%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 85%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-md-85 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 85%;
-            flex: 1 1 85%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 85%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-md-85 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 85%;
-            flex: 1 1 85%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 85%;
     box-sizing: border-box; }
@@ -16470,36 +16435,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-md-row > .flex-md-85 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 85%;
-            flex: 1 1 85%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 85%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-md-column > .flex-md-85 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 85%;
-            flex: 1 1 85%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 85%;
     box-sizing: border-box; }
   .flex-md-90 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 90%;
-            flex: 1 1 90%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 90%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-md-90 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 90%;
-            flex: 1 1 90%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 90%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-md-90 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 90%;
-            flex: 1 1 90%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 90%;
     box-sizing: border-box; }
@@ -16533,36 +16498,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-md-row > .flex-md-90 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 90%;
-            flex: 1 1 90%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 90%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-md-column > .flex-md-90 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 90%;
-            flex: 1 1 90%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 90%;
     box-sizing: border-box; }
   .flex-md-95 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 95%;
-            flex: 1 1 95%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 95%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-md-95 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 95%;
-            flex: 1 1 95%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 95%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-md-95 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 95%;
-            flex: 1 1 95%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 95%;
     box-sizing: border-box; }
@@ -16596,15 +16561,15 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-md-row > .flex-md-95 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 95%;
-            flex: 1 1 95%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 95%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-md-column > .flex-md-95 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 95%;
-            flex: 1 1 95%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 95%;
     box-sizing: border-box; }
@@ -16673,15 +16638,15 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-md-row > .flex-md-33, .layout-md-row > .flex-md-33 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 33.33%;
-            flex: 1 1 33.33%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 33.33%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-md-row > .flex-md-66, .layout-md-row > .flex-md-66 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 66.66%;
-            flex: 1 1 66.66%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 66.66%;
     max-height: 100%;
     box-sizing: border-box; }
@@ -16689,15 +16654,15 @@ md-tooltip {
     min-width: 0; }
   .layout-md-column > .flex-md-33, .layout-md-column > .flex-md-33 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 33.33%;
-            flex: 1 1 33.33%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 33.33%;
     box-sizing: border-box; }
   .layout-md-column > .flex-md-66, .layout-md-column > .flex-md-66 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 66.66%;
-            flex: 1 1 66.66%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 66.66%;
     box-sizing: border-box; }
@@ -17000,7 +16965,6 @@ md-tooltip {
             align-content: stretch;
     -webkit-box-align: stretch;
     -webkit-align-items: stretch;
-                -ms-grid-row-align: stretch;
             align-items: stretch; }
   .layout-align-gt-md-start,
   .layout-align-gt-md-start-start,
@@ -17048,7 +17012,6 @@ md-tooltip {
   .layout-align-gt-md-space-around-start {
     -webkit-box-align: start;
     -webkit-align-items: flex-start;
-                -ms-grid-row-align: flex-start;
             align-items: flex-start;
     -webkit-align-content: flex-start;
             align-content: flex-start; }
@@ -17059,7 +17022,6 @@ md-tooltip {
   .layout-align-gt-md-space-around-center {
     -webkit-box-align: center;
     -webkit-align-items: center;
-                -ms-grid-row-align: center;
             align-items: center;
     -webkit-align-content: center;
             align-content: center;
@@ -17078,7 +17040,6 @@ md-tooltip {
   .layout-align-gt-md-space-around-end {
     -webkit-box-align: end;
     -webkit-align-items: flex-end;
-                -ms-grid-row-align: flex-end;
             align-items: flex-end;
     -webkit-align-content: flex-end;
             align-content: flex-end; }
@@ -17089,7 +17050,6 @@ md-tooltip {
   .layout-align-gt-md-space-around-stretch {
     -webkit-box-align: stretch;
     -webkit-align-items: stretch;
-                -ms-grid-row-align: stretch;
             align-items: stretch;
     -webkit-align-content: stretch;
             align-content: stretch; }
@@ -17130,23 +17090,23 @@ md-tooltip {
     box-sizing: border-box; }
   .flex-gt-md-0 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 0%;
-            flex: 1 1 0%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 0%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-gt-md-0 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 0%;
-            flex: 1 1 0%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 0%;
     max-height: 100%;
     box-sizing: border-box;
     min-width: 0; }
   .layout-column > .flex-gt-md-0 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 0%;
-            flex: 1 1 0%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 0%;
     box-sizing: border-box; }
@@ -17180,38 +17140,38 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-gt-md-row > .flex-gt-md-0 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 0%;
-            flex: 1 1 0%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 0%;
     max-height: 100%;
     box-sizing: border-box;
     min-width: 0; }
   .layout-gt-md-column > .flex-gt-md-0 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 0%;
-            flex: 1 1 0%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 0%;
     box-sizing: border-box;
     min-height: 0; }
   .flex-gt-md-5 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 5%;
-            flex: 1 1 5%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 5%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-gt-md-5 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 5%;
-            flex: 1 1 5%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 5%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-gt-md-5 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 5%;
-            flex: 1 1 5%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 5%;
     box-sizing: border-box; }
@@ -17245,36 +17205,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-gt-md-row > .flex-gt-md-5 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 5%;
-            flex: 1 1 5%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 5%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-gt-md-column > .flex-gt-md-5 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 5%;
-            flex: 1 1 5%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 5%;
     box-sizing: border-box; }
   .flex-gt-md-10 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 10%;
-            flex: 1 1 10%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 10%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-gt-md-10 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 10%;
-            flex: 1 1 10%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 10%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-gt-md-10 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 10%;
-            flex: 1 1 10%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 10%;
     box-sizing: border-box; }
@@ -17308,36 +17268,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-gt-md-row > .flex-gt-md-10 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 10%;
-            flex: 1 1 10%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 10%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-gt-md-column > .flex-gt-md-10 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 10%;
-            flex: 1 1 10%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 10%;
     box-sizing: border-box; }
   .flex-gt-md-15 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 15%;
-            flex: 1 1 15%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 15%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-gt-md-15 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 15%;
-            flex: 1 1 15%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 15%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-gt-md-15 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 15%;
-            flex: 1 1 15%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 15%;
     box-sizing: border-box; }
@@ -17371,36 +17331,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-gt-md-row > .flex-gt-md-15 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 15%;
-            flex: 1 1 15%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 15%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-gt-md-column > .flex-gt-md-15 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 15%;
-            flex: 1 1 15%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 15%;
     box-sizing: border-box; }
   .flex-gt-md-20 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 20%;
-            flex: 1 1 20%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 20%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-gt-md-20 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 20%;
-            flex: 1 1 20%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 20%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-gt-md-20 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 20%;
-            flex: 1 1 20%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 20%;
     box-sizing: border-box; }
@@ -17434,36 +17394,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-gt-md-row > .flex-gt-md-20 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 20%;
-            flex: 1 1 20%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 20%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-gt-md-column > .flex-gt-md-20 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 20%;
-            flex: 1 1 20%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 20%;
     box-sizing: border-box; }
   .flex-gt-md-25 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 25%;
-            flex: 1 1 25%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 25%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-gt-md-25 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 25%;
-            flex: 1 1 25%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 25%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-gt-md-25 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 25%;
-            flex: 1 1 25%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 25%;
     box-sizing: border-box; }
@@ -17497,36 +17457,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-gt-md-row > .flex-gt-md-25 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 25%;
-            flex: 1 1 25%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 25%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-gt-md-column > .flex-gt-md-25 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 25%;
-            flex: 1 1 25%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 25%;
     box-sizing: border-box; }
   .flex-gt-md-30 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 30%;
-            flex: 1 1 30%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 30%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-gt-md-30 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 30%;
-            flex: 1 1 30%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 30%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-gt-md-30 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 30%;
-            flex: 1 1 30%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 30%;
     box-sizing: border-box; }
@@ -17560,36 +17520,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-gt-md-row > .flex-gt-md-30 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 30%;
-            flex: 1 1 30%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 30%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-gt-md-column > .flex-gt-md-30 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 30%;
-            flex: 1 1 30%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 30%;
     box-sizing: border-box; }
   .flex-gt-md-35 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 35%;
-            flex: 1 1 35%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 35%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-gt-md-35 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 35%;
-            flex: 1 1 35%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 35%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-gt-md-35 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 35%;
-            flex: 1 1 35%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 35%;
     box-sizing: border-box; }
@@ -17623,36 +17583,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-gt-md-row > .flex-gt-md-35 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 35%;
-            flex: 1 1 35%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 35%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-gt-md-column > .flex-gt-md-35 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 35%;
-            flex: 1 1 35%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 35%;
     box-sizing: border-box; }
   .flex-gt-md-40 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 40%;
-            flex: 1 1 40%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 40%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-gt-md-40 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 40%;
-            flex: 1 1 40%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 40%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-gt-md-40 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 40%;
-            flex: 1 1 40%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 40%;
     box-sizing: border-box; }
@@ -17686,36 +17646,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-gt-md-row > .flex-gt-md-40 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 40%;
-            flex: 1 1 40%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 40%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-gt-md-column > .flex-gt-md-40 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 40%;
-            flex: 1 1 40%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 40%;
     box-sizing: border-box; }
   .flex-gt-md-45 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 45%;
-            flex: 1 1 45%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 45%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-gt-md-45 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 45%;
-            flex: 1 1 45%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 45%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-gt-md-45 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 45%;
-            flex: 1 1 45%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 45%;
     box-sizing: border-box; }
@@ -17749,36 +17709,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-gt-md-row > .flex-gt-md-45 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 45%;
-            flex: 1 1 45%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 45%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-gt-md-column > .flex-gt-md-45 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 45%;
-            flex: 1 1 45%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 45%;
     box-sizing: border-box; }
   .flex-gt-md-50 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 50%;
-            flex: 1 1 50%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 50%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-gt-md-50 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 50%;
-            flex: 1 1 50%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 50%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-gt-md-50 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 50%;
-            flex: 1 1 50%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 50%;
     box-sizing: border-box; }
@@ -17812,36 +17772,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-gt-md-row > .flex-gt-md-50 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 50%;
-            flex: 1 1 50%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 50%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-gt-md-column > .flex-gt-md-50 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 50%;
-            flex: 1 1 50%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 50%;
     box-sizing: border-box; }
   .flex-gt-md-55 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 55%;
-            flex: 1 1 55%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 55%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-gt-md-55 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 55%;
-            flex: 1 1 55%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 55%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-gt-md-55 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 55%;
-            flex: 1 1 55%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 55%;
     box-sizing: border-box; }
@@ -17875,36 +17835,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-gt-md-row > .flex-gt-md-55 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 55%;
-            flex: 1 1 55%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 55%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-gt-md-column > .flex-gt-md-55 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 55%;
-            flex: 1 1 55%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 55%;
     box-sizing: border-box; }
   .flex-gt-md-60 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 60%;
-            flex: 1 1 60%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 60%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-gt-md-60 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 60%;
-            flex: 1 1 60%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 60%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-gt-md-60 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 60%;
-            flex: 1 1 60%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 60%;
     box-sizing: border-box; }
@@ -17938,36 +17898,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-gt-md-row > .flex-gt-md-60 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 60%;
-            flex: 1 1 60%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 60%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-gt-md-column > .flex-gt-md-60 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 60%;
-            flex: 1 1 60%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 60%;
     box-sizing: border-box; }
   .flex-gt-md-65 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 65%;
-            flex: 1 1 65%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 65%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-gt-md-65 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 65%;
-            flex: 1 1 65%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 65%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-gt-md-65 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 65%;
-            flex: 1 1 65%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 65%;
     box-sizing: border-box; }
@@ -18001,36 +17961,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-gt-md-row > .flex-gt-md-65 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 65%;
-            flex: 1 1 65%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 65%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-gt-md-column > .flex-gt-md-65 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 65%;
-            flex: 1 1 65%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 65%;
     box-sizing: border-box; }
   .flex-gt-md-70 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 70%;
-            flex: 1 1 70%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 70%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-gt-md-70 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 70%;
-            flex: 1 1 70%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 70%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-gt-md-70 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 70%;
-            flex: 1 1 70%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 70%;
     box-sizing: border-box; }
@@ -18064,36 +18024,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-gt-md-row > .flex-gt-md-70 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 70%;
-            flex: 1 1 70%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 70%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-gt-md-column > .flex-gt-md-70 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 70%;
-            flex: 1 1 70%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 70%;
     box-sizing: border-box; }
   .flex-gt-md-75 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 75%;
-            flex: 1 1 75%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 75%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-gt-md-75 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 75%;
-            flex: 1 1 75%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 75%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-gt-md-75 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 75%;
-            flex: 1 1 75%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 75%;
     box-sizing: border-box; }
@@ -18127,36 +18087,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-gt-md-row > .flex-gt-md-75 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 75%;
-            flex: 1 1 75%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 75%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-gt-md-column > .flex-gt-md-75 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 75%;
-            flex: 1 1 75%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 75%;
     box-sizing: border-box; }
   .flex-gt-md-80 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 80%;
-            flex: 1 1 80%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 80%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-gt-md-80 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 80%;
-            flex: 1 1 80%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 80%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-gt-md-80 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 80%;
-            flex: 1 1 80%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 80%;
     box-sizing: border-box; }
@@ -18190,36 +18150,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-gt-md-row > .flex-gt-md-80 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 80%;
-            flex: 1 1 80%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 80%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-gt-md-column > .flex-gt-md-80 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 80%;
-            flex: 1 1 80%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 80%;
     box-sizing: border-box; }
   .flex-gt-md-85 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 85%;
-            flex: 1 1 85%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 85%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-gt-md-85 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 85%;
-            flex: 1 1 85%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 85%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-gt-md-85 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 85%;
-            flex: 1 1 85%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 85%;
     box-sizing: border-box; }
@@ -18253,36 +18213,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-gt-md-row > .flex-gt-md-85 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 85%;
-            flex: 1 1 85%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 85%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-gt-md-column > .flex-gt-md-85 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 85%;
-            flex: 1 1 85%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 85%;
     box-sizing: border-box; }
   .flex-gt-md-90 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 90%;
-            flex: 1 1 90%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 90%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-gt-md-90 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 90%;
-            flex: 1 1 90%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 90%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-gt-md-90 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 90%;
-            flex: 1 1 90%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 90%;
     box-sizing: border-box; }
@@ -18316,36 +18276,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-gt-md-row > .flex-gt-md-90 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 90%;
-            flex: 1 1 90%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 90%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-gt-md-column > .flex-gt-md-90 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 90%;
-            flex: 1 1 90%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 90%;
     box-sizing: border-box; }
   .flex-gt-md-95 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 95%;
-            flex: 1 1 95%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 95%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-gt-md-95 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 95%;
-            flex: 1 1 95%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 95%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-gt-md-95 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 95%;
-            flex: 1 1 95%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 95%;
     box-sizing: border-box; }
@@ -18379,15 +18339,15 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-gt-md-row > .flex-gt-md-95 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 95%;
-            flex: 1 1 95%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 95%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-gt-md-column > .flex-gt-md-95 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 95%;
-            flex: 1 1 95%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 95%;
     box-sizing: border-box; }
@@ -18456,15 +18416,15 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-gt-md-row > .flex-gt-md-33, .layout-gt-md-row > .flex-gt-md-33 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 33.33%;
-            flex: 1 1 33.33%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 33.33%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-gt-md-row > .flex-gt-md-66, .layout-gt-md-row > .flex-gt-md-66 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 66.66%;
-            flex: 1 1 66.66%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 66.66%;
     max-height: 100%;
     box-sizing: border-box; }
@@ -18472,15 +18432,15 @@ md-tooltip {
     min-width: 0; }
   .layout-gt-md-column > .flex-gt-md-33, .layout-gt-md-column > .flex-gt-md-33 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 33.33%;
-            flex: 1 1 33.33%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 33.33%;
     box-sizing: border-box; }
   .layout-gt-md-column > .flex-gt-md-66, .layout-gt-md-column > .flex-gt-md-66 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 66.66%;
-            flex: 1 1 66.66%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 66.66%;
     box-sizing: border-box; }
@@ -18787,7 +18747,6 @@ md-tooltip {
             align-content: stretch;
     -webkit-box-align: stretch;
     -webkit-align-items: stretch;
-                -ms-grid-row-align: stretch;
             align-items: stretch; }
   .layout-align-lg-start,
   .layout-align-lg-start-start,
@@ -18835,7 +18794,6 @@ md-tooltip {
   .layout-align-lg-space-around-start {
     -webkit-box-align: start;
     -webkit-align-items: flex-start;
-                -ms-grid-row-align: flex-start;
             align-items: flex-start;
     -webkit-align-content: flex-start;
             align-content: flex-start; }
@@ -18846,7 +18804,6 @@ md-tooltip {
   .layout-align-lg-space-around-center {
     -webkit-box-align: center;
     -webkit-align-items: center;
-                -ms-grid-row-align: center;
             align-items: center;
     -webkit-align-content: center;
             align-content: center;
@@ -18865,7 +18822,6 @@ md-tooltip {
   .layout-align-lg-space-around-end {
     -webkit-box-align: end;
     -webkit-align-items: flex-end;
-                -ms-grid-row-align: flex-end;
             align-items: flex-end;
     -webkit-align-content: flex-end;
             align-content: flex-end; }
@@ -18876,7 +18832,6 @@ md-tooltip {
   .layout-align-lg-space-around-stretch {
     -webkit-box-align: stretch;
     -webkit-align-items: stretch;
-                -ms-grid-row-align: stretch;
             align-items: stretch;
     -webkit-align-content: stretch;
             align-content: stretch; }
@@ -18917,23 +18872,23 @@ md-tooltip {
     box-sizing: border-box; }
   .flex-lg-0 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 0%;
-            flex: 1 1 0%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 0%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-lg-0 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 0%;
-            flex: 1 1 0%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 0%;
     max-height: 100%;
     box-sizing: border-box;
     min-width: 0; }
   .layout-column > .flex-lg-0 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 0%;
-            flex: 1 1 0%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 0%;
     box-sizing: border-box; }
@@ -18967,38 +18922,38 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-lg-row > .flex-lg-0 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 0%;
-            flex: 1 1 0%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 0%;
     max-height: 100%;
     box-sizing: border-box;
     min-width: 0; }
   .layout-lg-column > .flex-lg-0 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 0%;
-            flex: 1 1 0%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 0%;
     box-sizing: border-box;
     min-height: 0; }
   .flex-lg-5 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 5%;
-            flex: 1 1 5%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 5%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-lg-5 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 5%;
-            flex: 1 1 5%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 5%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-lg-5 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 5%;
-            flex: 1 1 5%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 5%;
     box-sizing: border-box; }
@@ -19032,36 +18987,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-lg-row > .flex-lg-5 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 5%;
-            flex: 1 1 5%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 5%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-lg-column > .flex-lg-5 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 5%;
-            flex: 1 1 5%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 5%;
     box-sizing: border-box; }
   .flex-lg-10 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 10%;
-            flex: 1 1 10%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 10%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-lg-10 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 10%;
-            flex: 1 1 10%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 10%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-lg-10 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 10%;
-            flex: 1 1 10%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 10%;
     box-sizing: border-box; }
@@ -19095,36 +19050,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-lg-row > .flex-lg-10 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 10%;
-            flex: 1 1 10%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 10%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-lg-column > .flex-lg-10 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 10%;
-            flex: 1 1 10%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 10%;
     box-sizing: border-box; }
   .flex-lg-15 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 15%;
-            flex: 1 1 15%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 15%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-lg-15 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 15%;
-            flex: 1 1 15%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 15%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-lg-15 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 15%;
-            flex: 1 1 15%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 15%;
     box-sizing: border-box; }
@@ -19158,36 +19113,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-lg-row > .flex-lg-15 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 15%;
-            flex: 1 1 15%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 15%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-lg-column > .flex-lg-15 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 15%;
-            flex: 1 1 15%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 15%;
     box-sizing: border-box; }
   .flex-lg-20 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 20%;
-            flex: 1 1 20%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 20%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-lg-20 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 20%;
-            flex: 1 1 20%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 20%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-lg-20 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 20%;
-            flex: 1 1 20%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 20%;
     box-sizing: border-box; }
@@ -19221,36 +19176,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-lg-row > .flex-lg-20 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 20%;
-            flex: 1 1 20%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 20%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-lg-column > .flex-lg-20 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 20%;
-            flex: 1 1 20%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 20%;
     box-sizing: border-box; }
   .flex-lg-25 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 25%;
-            flex: 1 1 25%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 25%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-lg-25 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 25%;
-            flex: 1 1 25%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 25%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-lg-25 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 25%;
-            flex: 1 1 25%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 25%;
     box-sizing: border-box; }
@@ -19284,36 +19239,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-lg-row > .flex-lg-25 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 25%;
-            flex: 1 1 25%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 25%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-lg-column > .flex-lg-25 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 25%;
-            flex: 1 1 25%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 25%;
     box-sizing: border-box; }
   .flex-lg-30 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 30%;
-            flex: 1 1 30%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 30%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-lg-30 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 30%;
-            flex: 1 1 30%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 30%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-lg-30 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 30%;
-            flex: 1 1 30%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 30%;
     box-sizing: border-box; }
@@ -19347,36 +19302,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-lg-row > .flex-lg-30 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 30%;
-            flex: 1 1 30%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 30%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-lg-column > .flex-lg-30 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 30%;
-            flex: 1 1 30%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 30%;
     box-sizing: border-box; }
   .flex-lg-35 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 35%;
-            flex: 1 1 35%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 35%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-lg-35 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 35%;
-            flex: 1 1 35%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 35%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-lg-35 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 35%;
-            flex: 1 1 35%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 35%;
     box-sizing: border-box; }
@@ -19410,36 +19365,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-lg-row > .flex-lg-35 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 35%;
-            flex: 1 1 35%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 35%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-lg-column > .flex-lg-35 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 35%;
-            flex: 1 1 35%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 35%;
     box-sizing: border-box; }
   .flex-lg-40 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 40%;
-            flex: 1 1 40%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 40%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-lg-40 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 40%;
-            flex: 1 1 40%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 40%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-lg-40 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 40%;
-            flex: 1 1 40%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 40%;
     box-sizing: border-box; }
@@ -19473,36 +19428,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-lg-row > .flex-lg-40 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 40%;
-            flex: 1 1 40%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 40%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-lg-column > .flex-lg-40 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 40%;
-            flex: 1 1 40%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 40%;
     box-sizing: border-box; }
   .flex-lg-45 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 45%;
-            flex: 1 1 45%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 45%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-lg-45 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 45%;
-            flex: 1 1 45%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 45%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-lg-45 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 45%;
-            flex: 1 1 45%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 45%;
     box-sizing: border-box; }
@@ -19536,36 +19491,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-lg-row > .flex-lg-45 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 45%;
-            flex: 1 1 45%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 45%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-lg-column > .flex-lg-45 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 45%;
-            flex: 1 1 45%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 45%;
     box-sizing: border-box; }
   .flex-lg-50 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 50%;
-            flex: 1 1 50%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 50%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-lg-50 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 50%;
-            flex: 1 1 50%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 50%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-lg-50 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 50%;
-            flex: 1 1 50%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 50%;
     box-sizing: border-box; }
@@ -19599,36 +19554,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-lg-row > .flex-lg-50 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 50%;
-            flex: 1 1 50%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 50%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-lg-column > .flex-lg-50 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 50%;
-            flex: 1 1 50%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 50%;
     box-sizing: border-box; }
   .flex-lg-55 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 55%;
-            flex: 1 1 55%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 55%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-lg-55 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 55%;
-            flex: 1 1 55%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 55%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-lg-55 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 55%;
-            flex: 1 1 55%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 55%;
     box-sizing: border-box; }
@@ -19662,36 +19617,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-lg-row > .flex-lg-55 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 55%;
-            flex: 1 1 55%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 55%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-lg-column > .flex-lg-55 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 55%;
-            flex: 1 1 55%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 55%;
     box-sizing: border-box; }
   .flex-lg-60 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 60%;
-            flex: 1 1 60%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 60%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-lg-60 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 60%;
-            flex: 1 1 60%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 60%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-lg-60 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 60%;
-            flex: 1 1 60%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 60%;
     box-sizing: border-box; }
@@ -19725,36 +19680,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-lg-row > .flex-lg-60 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 60%;
-            flex: 1 1 60%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 60%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-lg-column > .flex-lg-60 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 60%;
-            flex: 1 1 60%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 60%;
     box-sizing: border-box; }
   .flex-lg-65 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 65%;
-            flex: 1 1 65%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 65%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-lg-65 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 65%;
-            flex: 1 1 65%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 65%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-lg-65 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 65%;
-            flex: 1 1 65%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 65%;
     box-sizing: border-box; }
@@ -19788,36 +19743,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-lg-row > .flex-lg-65 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 65%;
-            flex: 1 1 65%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 65%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-lg-column > .flex-lg-65 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 65%;
-            flex: 1 1 65%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 65%;
     box-sizing: border-box; }
   .flex-lg-70 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 70%;
-            flex: 1 1 70%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 70%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-lg-70 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 70%;
-            flex: 1 1 70%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 70%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-lg-70 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 70%;
-            flex: 1 1 70%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 70%;
     box-sizing: border-box; }
@@ -19851,36 +19806,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-lg-row > .flex-lg-70 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 70%;
-            flex: 1 1 70%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 70%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-lg-column > .flex-lg-70 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 70%;
-            flex: 1 1 70%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 70%;
     box-sizing: border-box; }
   .flex-lg-75 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 75%;
-            flex: 1 1 75%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 75%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-lg-75 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 75%;
-            flex: 1 1 75%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 75%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-lg-75 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 75%;
-            flex: 1 1 75%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 75%;
     box-sizing: border-box; }
@@ -19914,36 +19869,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-lg-row > .flex-lg-75 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 75%;
-            flex: 1 1 75%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 75%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-lg-column > .flex-lg-75 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 75%;
-            flex: 1 1 75%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 75%;
     box-sizing: border-box; }
   .flex-lg-80 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 80%;
-            flex: 1 1 80%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 80%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-lg-80 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 80%;
-            flex: 1 1 80%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 80%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-lg-80 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 80%;
-            flex: 1 1 80%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 80%;
     box-sizing: border-box; }
@@ -19977,36 +19932,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-lg-row > .flex-lg-80 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 80%;
-            flex: 1 1 80%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 80%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-lg-column > .flex-lg-80 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 80%;
-            flex: 1 1 80%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 80%;
     box-sizing: border-box; }
   .flex-lg-85 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 85%;
-            flex: 1 1 85%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 85%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-lg-85 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 85%;
-            flex: 1 1 85%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 85%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-lg-85 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 85%;
-            flex: 1 1 85%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 85%;
     box-sizing: border-box; }
@@ -20040,36 +19995,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-lg-row > .flex-lg-85 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 85%;
-            flex: 1 1 85%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 85%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-lg-column > .flex-lg-85 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 85%;
-            flex: 1 1 85%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 85%;
     box-sizing: border-box; }
   .flex-lg-90 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 90%;
-            flex: 1 1 90%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 90%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-lg-90 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 90%;
-            flex: 1 1 90%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 90%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-lg-90 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 90%;
-            flex: 1 1 90%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 90%;
     box-sizing: border-box; }
@@ -20103,36 +20058,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-lg-row > .flex-lg-90 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 90%;
-            flex: 1 1 90%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 90%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-lg-column > .flex-lg-90 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 90%;
-            flex: 1 1 90%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 90%;
     box-sizing: border-box; }
   .flex-lg-95 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 95%;
-            flex: 1 1 95%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 95%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-lg-95 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 95%;
-            flex: 1 1 95%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 95%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-lg-95 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 95%;
-            flex: 1 1 95%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 95%;
     box-sizing: border-box; }
@@ -20166,15 +20121,15 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-lg-row > .flex-lg-95 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 95%;
-            flex: 1 1 95%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 95%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-lg-column > .flex-lg-95 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 95%;
-            flex: 1 1 95%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 95%;
     box-sizing: border-box; }
@@ -20243,15 +20198,15 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-lg-row > .flex-lg-33, .layout-lg-row > .flex-lg-33 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 33.33%;
-            flex: 1 1 33.33%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 33.33%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-lg-row > .flex-lg-66, .layout-lg-row > .flex-lg-66 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 66.66%;
-            flex: 1 1 66.66%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 66.66%;
     max-height: 100%;
     box-sizing: border-box; }
@@ -20259,15 +20214,15 @@ md-tooltip {
     min-width: 0; }
   .layout-lg-column > .flex-lg-33, .layout-lg-column > .flex-lg-33 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 33.33%;
-            flex: 1 1 33.33%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 33.33%;
     box-sizing: border-box; }
   .layout-lg-column > .flex-lg-66, .layout-lg-column > .flex-lg-66 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 66.66%;
-            flex: 1 1 66.66%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 66.66%;
     box-sizing: border-box; }
@@ -20570,7 +20525,6 @@ md-tooltip {
             align-content: stretch;
     -webkit-box-align: stretch;
     -webkit-align-items: stretch;
-                -ms-grid-row-align: stretch;
             align-items: stretch; }
   .layout-align-gt-lg-start,
   .layout-align-gt-lg-start-start,
@@ -20618,7 +20572,6 @@ md-tooltip {
   .layout-align-gt-lg-space-around-start {
     -webkit-box-align: start;
     -webkit-align-items: flex-start;
-                -ms-grid-row-align: flex-start;
             align-items: flex-start;
     -webkit-align-content: flex-start;
             align-content: flex-start; }
@@ -20629,7 +20582,6 @@ md-tooltip {
   .layout-align-gt-lg-space-around-center {
     -webkit-box-align: center;
     -webkit-align-items: center;
-                -ms-grid-row-align: center;
             align-items: center;
     -webkit-align-content: center;
             align-content: center;
@@ -20648,7 +20600,6 @@ md-tooltip {
   .layout-align-gt-lg-space-around-end {
     -webkit-box-align: end;
     -webkit-align-items: flex-end;
-                -ms-grid-row-align: flex-end;
             align-items: flex-end;
     -webkit-align-content: flex-end;
             align-content: flex-end; }
@@ -20659,7 +20610,6 @@ md-tooltip {
   .layout-align-gt-lg-space-around-stretch {
     -webkit-box-align: stretch;
     -webkit-align-items: stretch;
-                -ms-grid-row-align: stretch;
             align-items: stretch;
     -webkit-align-content: stretch;
             align-content: stretch; }
@@ -20700,23 +20650,23 @@ md-tooltip {
     box-sizing: border-box; }
   .flex-gt-lg-0 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 0%;
-            flex: 1 1 0%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 0%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-gt-lg-0 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 0%;
-            flex: 1 1 0%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 0%;
     max-height: 100%;
     box-sizing: border-box;
     min-width: 0; }
   .layout-column > .flex-gt-lg-0 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 0%;
-            flex: 1 1 0%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 0%;
     box-sizing: border-box; }
@@ -20750,38 +20700,38 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-gt-lg-row > .flex-gt-lg-0 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 0%;
-            flex: 1 1 0%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 0%;
     max-height: 100%;
     box-sizing: border-box;
     min-width: 0; }
   .layout-gt-lg-column > .flex-gt-lg-0 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 0%;
-            flex: 1 1 0%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 0%;
     box-sizing: border-box;
     min-height: 0; }
   .flex-gt-lg-5 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 5%;
-            flex: 1 1 5%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 5%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-gt-lg-5 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 5%;
-            flex: 1 1 5%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 5%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-gt-lg-5 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 5%;
-            flex: 1 1 5%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 5%;
     box-sizing: border-box; }
@@ -20815,36 +20765,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-gt-lg-row > .flex-gt-lg-5 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 5%;
-            flex: 1 1 5%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 5%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-gt-lg-column > .flex-gt-lg-5 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 5%;
-            flex: 1 1 5%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 5%;
     box-sizing: border-box; }
   .flex-gt-lg-10 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 10%;
-            flex: 1 1 10%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 10%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-gt-lg-10 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 10%;
-            flex: 1 1 10%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 10%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-gt-lg-10 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 10%;
-            flex: 1 1 10%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 10%;
     box-sizing: border-box; }
@@ -20878,36 +20828,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-gt-lg-row > .flex-gt-lg-10 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 10%;
-            flex: 1 1 10%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 10%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-gt-lg-column > .flex-gt-lg-10 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 10%;
-            flex: 1 1 10%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 10%;
     box-sizing: border-box; }
   .flex-gt-lg-15 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 15%;
-            flex: 1 1 15%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 15%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-gt-lg-15 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 15%;
-            flex: 1 1 15%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 15%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-gt-lg-15 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 15%;
-            flex: 1 1 15%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 15%;
     box-sizing: border-box; }
@@ -20941,36 +20891,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-gt-lg-row > .flex-gt-lg-15 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 15%;
-            flex: 1 1 15%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 15%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-gt-lg-column > .flex-gt-lg-15 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 15%;
-            flex: 1 1 15%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 15%;
     box-sizing: border-box; }
   .flex-gt-lg-20 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 20%;
-            flex: 1 1 20%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 20%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-gt-lg-20 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 20%;
-            flex: 1 1 20%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 20%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-gt-lg-20 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 20%;
-            flex: 1 1 20%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 20%;
     box-sizing: border-box; }
@@ -21004,36 +20954,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-gt-lg-row > .flex-gt-lg-20 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 20%;
-            flex: 1 1 20%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 20%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-gt-lg-column > .flex-gt-lg-20 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 20%;
-            flex: 1 1 20%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 20%;
     box-sizing: border-box; }
   .flex-gt-lg-25 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 25%;
-            flex: 1 1 25%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 25%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-gt-lg-25 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 25%;
-            flex: 1 1 25%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 25%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-gt-lg-25 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 25%;
-            flex: 1 1 25%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 25%;
     box-sizing: border-box; }
@@ -21067,36 +21017,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-gt-lg-row > .flex-gt-lg-25 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 25%;
-            flex: 1 1 25%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 25%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-gt-lg-column > .flex-gt-lg-25 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 25%;
-            flex: 1 1 25%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 25%;
     box-sizing: border-box; }
   .flex-gt-lg-30 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 30%;
-            flex: 1 1 30%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 30%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-gt-lg-30 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 30%;
-            flex: 1 1 30%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 30%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-gt-lg-30 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 30%;
-            flex: 1 1 30%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 30%;
     box-sizing: border-box; }
@@ -21130,36 +21080,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-gt-lg-row > .flex-gt-lg-30 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 30%;
-            flex: 1 1 30%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 30%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-gt-lg-column > .flex-gt-lg-30 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 30%;
-            flex: 1 1 30%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 30%;
     box-sizing: border-box; }
   .flex-gt-lg-35 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 35%;
-            flex: 1 1 35%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 35%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-gt-lg-35 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 35%;
-            flex: 1 1 35%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 35%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-gt-lg-35 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 35%;
-            flex: 1 1 35%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 35%;
     box-sizing: border-box; }
@@ -21193,36 +21143,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-gt-lg-row > .flex-gt-lg-35 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 35%;
-            flex: 1 1 35%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 35%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-gt-lg-column > .flex-gt-lg-35 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 35%;
-            flex: 1 1 35%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 35%;
     box-sizing: border-box; }
   .flex-gt-lg-40 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 40%;
-            flex: 1 1 40%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 40%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-gt-lg-40 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 40%;
-            flex: 1 1 40%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 40%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-gt-lg-40 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 40%;
-            flex: 1 1 40%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 40%;
     box-sizing: border-box; }
@@ -21256,36 +21206,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-gt-lg-row > .flex-gt-lg-40 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 40%;
-            flex: 1 1 40%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 40%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-gt-lg-column > .flex-gt-lg-40 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 40%;
-            flex: 1 1 40%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 40%;
     box-sizing: border-box; }
   .flex-gt-lg-45 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 45%;
-            flex: 1 1 45%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 45%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-gt-lg-45 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 45%;
-            flex: 1 1 45%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 45%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-gt-lg-45 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 45%;
-            flex: 1 1 45%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 45%;
     box-sizing: border-box; }
@@ -21319,36 +21269,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-gt-lg-row > .flex-gt-lg-45 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 45%;
-            flex: 1 1 45%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 45%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-gt-lg-column > .flex-gt-lg-45 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 45%;
-            flex: 1 1 45%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 45%;
     box-sizing: border-box; }
   .flex-gt-lg-50 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 50%;
-            flex: 1 1 50%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 50%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-gt-lg-50 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 50%;
-            flex: 1 1 50%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 50%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-gt-lg-50 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 50%;
-            flex: 1 1 50%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 50%;
     box-sizing: border-box; }
@@ -21382,36 +21332,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-gt-lg-row > .flex-gt-lg-50 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 50%;
-            flex: 1 1 50%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 50%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-gt-lg-column > .flex-gt-lg-50 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 50%;
-            flex: 1 1 50%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 50%;
     box-sizing: border-box; }
   .flex-gt-lg-55 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 55%;
-            flex: 1 1 55%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 55%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-gt-lg-55 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 55%;
-            flex: 1 1 55%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 55%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-gt-lg-55 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 55%;
-            flex: 1 1 55%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 55%;
     box-sizing: border-box; }
@@ -21445,36 +21395,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-gt-lg-row > .flex-gt-lg-55 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 55%;
-            flex: 1 1 55%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 55%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-gt-lg-column > .flex-gt-lg-55 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 55%;
-            flex: 1 1 55%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 55%;
     box-sizing: border-box; }
   .flex-gt-lg-60 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 60%;
-            flex: 1 1 60%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 60%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-gt-lg-60 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 60%;
-            flex: 1 1 60%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 60%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-gt-lg-60 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 60%;
-            flex: 1 1 60%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 60%;
     box-sizing: border-box; }
@@ -21508,36 +21458,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-gt-lg-row > .flex-gt-lg-60 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 60%;
-            flex: 1 1 60%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 60%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-gt-lg-column > .flex-gt-lg-60 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 60%;
-            flex: 1 1 60%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 60%;
     box-sizing: border-box; }
   .flex-gt-lg-65 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 65%;
-            flex: 1 1 65%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 65%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-gt-lg-65 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 65%;
-            flex: 1 1 65%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 65%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-gt-lg-65 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 65%;
-            flex: 1 1 65%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 65%;
     box-sizing: border-box; }
@@ -21571,36 +21521,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-gt-lg-row > .flex-gt-lg-65 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 65%;
-            flex: 1 1 65%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 65%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-gt-lg-column > .flex-gt-lg-65 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 65%;
-            flex: 1 1 65%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 65%;
     box-sizing: border-box; }
   .flex-gt-lg-70 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 70%;
-            flex: 1 1 70%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 70%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-gt-lg-70 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 70%;
-            flex: 1 1 70%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 70%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-gt-lg-70 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 70%;
-            flex: 1 1 70%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 70%;
     box-sizing: border-box; }
@@ -21634,36 +21584,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-gt-lg-row > .flex-gt-lg-70 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 70%;
-            flex: 1 1 70%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 70%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-gt-lg-column > .flex-gt-lg-70 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 70%;
-            flex: 1 1 70%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 70%;
     box-sizing: border-box; }
   .flex-gt-lg-75 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 75%;
-            flex: 1 1 75%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 75%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-gt-lg-75 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 75%;
-            flex: 1 1 75%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 75%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-gt-lg-75 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 75%;
-            flex: 1 1 75%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 75%;
     box-sizing: border-box; }
@@ -21697,36 +21647,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-gt-lg-row > .flex-gt-lg-75 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 75%;
-            flex: 1 1 75%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 75%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-gt-lg-column > .flex-gt-lg-75 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 75%;
-            flex: 1 1 75%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 75%;
     box-sizing: border-box; }
   .flex-gt-lg-80 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 80%;
-            flex: 1 1 80%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 80%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-gt-lg-80 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 80%;
-            flex: 1 1 80%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 80%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-gt-lg-80 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 80%;
-            flex: 1 1 80%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 80%;
     box-sizing: border-box; }
@@ -21760,36 +21710,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-gt-lg-row > .flex-gt-lg-80 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 80%;
-            flex: 1 1 80%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 80%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-gt-lg-column > .flex-gt-lg-80 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 80%;
-            flex: 1 1 80%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 80%;
     box-sizing: border-box; }
   .flex-gt-lg-85 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 85%;
-            flex: 1 1 85%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 85%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-gt-lg-85 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 85%;
-            flex: 1 1 85%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 85%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-gt-lg-85 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 85%;
-            flex: 1 1 85%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 85%;
     box-sizing: border-box; }
@@ -21823,36 +21773,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-gt-lg-row > .flex-gt-lg-85 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 85%;
-            flex: 1 1 85%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 85%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-gt-lg-column > .flex-gt-lg-85 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 85%;
-            flex: 1 1 85%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 85%;
     box-sizing: border-box; }
   .flex-gt-lg-90 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 90%;
-            flex: 1 1 90%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 90%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-gt-lg-90 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 90%;
-            flex: 1 1 90%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 90%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-gt-lg-90 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 90%;
-            flex: 1 1 90%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 90%;
     box-sizing: border-box; }
@@ -21886,36 +21836,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-gt-lg-row > .flex-gt-lg-90 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 90%;
-            flex: 1 1 90%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 90%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-gt-lg-column > .flex-gt-lg-90 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 90%;
-            flex: 1 1 90%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 90%;
     box-sizing: border-box; }
   .flex-gt-lg-95 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 95%;
-            flex: 1 1 95%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 95%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-gt-lg-95 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 95%;
-            flex: 1 1 95%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 95%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-gt-lg-95 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 95%;
-            flex: 1 1 95%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 95%;
     box-sizing: border-box; }
@@ -21949,15 +21899,15 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-gt-lg-row > .flex-gt-lg-95 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 95%;
-            flex: 1 1 95%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 95%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-gt-lg-column > .flex-gt-lg-95 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 95%;
-            flex: 1 1 95%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 95%;
     box-sizing: border-box; }
@@ -22026,15 +21976,15 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-gt-lg-row > .flex-gt-lg-33, .layout-gt-lg-row > .flex-gt-lg-33 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 33.33%;
-            flex: 1 1 33.33%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 33.33%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-gt-lg-row > .flex-gt-lg-66, .layout-gt-lg-row > .flex-gt-lg-66 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 66.66%;
-            flex: 1 1 66.66%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 66.66%;
     max-height: 100%;
     box-sizing: border-box; }
@@ -22042,15 +21992,15 @@ md-tooltip {
     min-width: 0; }
   .layout-gt-lg-column > .flex-gt-lg-33, .layout-gt-lg-column > .flex-gt-lg-33 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 33.33%;
-            flex: 1 1 33.33%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 33.33%;
     box-sizing: border-box; }
   .layout-gt-lg-column > .flex-gt-lg-66, .layout-gt-lg-column > .flex-gt-lg-66 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 66.66%;
-            flex: 1 1 66.66%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 66.66%;
     box-sizing: border-box; }
@@ -22351,7 +22301,6 @@ md-tooltip {
             align-content: stretch;
     -webkit-box-align: stretch;
     -webkit-align-items: stretch;
-                -ms-grid-row-align: stretch;
             align-items: stretch; }
   .layout-align-xl-start,
   .layout-align-xl-start-start,
@@ -22399,7 +22348,6 @@ md-tooltip {
   .layout-align-xl-space-around-start {
     -webkit-box-align: start;
     -webkit-align-items: flex-start;
-                -ms-grid-row-align: flex-start;
             align-items: flex-start;
     -webkit-align-content: flex-start;
             align-content: flex-start; }
@@ -22410,7 +22358,6 @@ md-tooltip {
   .layout-align-xl-space-around-center {
     -webkit-box-align: center;
     -webkit-align-items: center;
-                -ms-grid-row-align: center;
             align-items: center;
     -webkit-align-content: center;
             align-content: center;
@@ -22429,7 +22376,6 @@ md-tooltip {
   .layout-align-xl-space-around-end {
     -webkit-box-align: end;
     -webkit-align-items: flex-end;
-                -ms-grid-row-align: flex-end;
             align-items: flex-end;
     -webkit-align-content: flex-end;
             align-content: flex-end; }
@@ -22440,7 +22386,6 @@ md-tooltip {
   .layout-align-xl-space-around-stretch {
     -webkit-box-align: stretch;
     -webkit-align-items: stretch;
-                -ms-grid-row-align: stretch;
             align-items: stretch;
     -webkit-align-content: stretch;
             align-content: stretch; }
@@ -22481,23 +22426,23 @@ md-tooltip {
     box-sizing: border-box; }
   .flex-xl-0 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 0%;
-            flex: 1 1 0%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 0%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-xl-0 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 0%;
-            flex: 1 1 0%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 0%;
     max-height: 100%;
     box-sizing: border-box;
     min-width: 0; }
   .layout-column > .flex-xl-0 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 0%;
-            flex: 1 1 0%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 0%;
     box-sizing: border-box; }
@@ -22531,38 +22476,38 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-xl-row > .flex-xl-0 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 0%;
-            flex: 1 1 0%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 0%;
     max-height: 100%;
     box-sizing: border-box;
     min-width: 0; }
   .layout-xl-column > .flex-xl-0 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 0%;
-            flex: 1 1 0%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 0%;
     box-sizing: border-box;
     min-height: 0; }
   .flex-xl-5 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 5%;
-            flex: 1 1 5%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 5%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-xl-5 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 5%;
-            flex: 1 1 5%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 5%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-xl-5 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 5%;
-            flex: 1 1 5%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 5%;
     box-sizing: border-box; }
@@ -22596,36 +22541,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-xl-row > .flex-xl-5 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 5%;
-            flex: 1 1 5%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 5%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-xl-column > .flex-xl-5 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 5%;
-            flex: 1 1 5%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 5%;
     box-sizing: border-box; }
   .flex-xl-10 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 10%;
-            flex: 1 1 10%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 10%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-xl-10 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 10%;
-            flex: 1 1 10%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 10%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-xl-10 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 10%;
-            flex: 1 1 10%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 10%;
     box-sizing: border-box; }
@@ -22659,36 +22604,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-xl-row > .flex-xl-10 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 10%;
-            flex: 1 1 10%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 10%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-xl-column > .flex-xl-10 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 10%;
-            flex: 1 1 10%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 10%;
     box-sizing: border-box; }
   .flex-xl-15 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 15%;
-            flex: 1 1 15%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 15%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-xl-15 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 15%;
-            flex: 1 1 15%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 15%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-xl-15 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 15%;
-            flex: 1 1 15%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 15%;
     box-sizing: border-box; }
@@ -22722,36 +22667,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-xl-row > .flex-xl-15 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 15%;
-            flex: 1 1 15%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 15%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-xl-column > .flex-xl-15 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 15%;
-            flex: 1 1 15%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 15%;
     box-sizing: border-box; }
   .flex-xl-20 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 20%;
-            flex: 1 1 20%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 20%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-xl-20 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 20%;
-            flex: 1 1 20%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 20%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-xl-20 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 20%;
-            flex: 1 1 20%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 20%;
     box-sizing: border-box; }
@@ -22785,36 +22730,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-xl-row > .flex-xl-20 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 20%;
-            flex: 1 1 20%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 20%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-xl-column > .flex-xl-20 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 20%;
-            flex: 1 1 20%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 20%;
     box-sizing: border-box; }
   .flex-xl-25 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 25%;
-            flex: 1 1 25%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 25%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-xl-25 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 25%;
-            flex: 1 1 25%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 25%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-xl-25 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 25%;
-            flex: 1 1 25%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 25%;
     box-sizing: border-box; }
@@ -22848,36 +22793,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-xl-row > .flex-xl-25 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 25%;
-            flex: 1 1 25%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 25%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-xl-column > .flex-xl-25 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 25%;
-            flex: 1 1 25%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 25%;
     box-sizing: border-box; }
   .flex-xl-30 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 30%;
-            flex: 1 1 30%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 30%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-xl-30 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 30%;
-            flex: 1 1 30%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 30%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-xl-30 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 30%;
-            flex: 1 1 30%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 30%;
     box-sizing: border-box; }
@@ -22911,36 +22856,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-xl-row > .flex-xl-30 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 30%;
-            flex: 1 1 30%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 30%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-xl-column > .flex-xl-30 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 30%;
-            flex: 1 1 30%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 30%;
     box-sizing: border-box; }
   .flex-xl-35 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 35%;
-            flex: 1 1 35%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 35%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-xl-35 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 35%;
-            flex: 1 1 35%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 35%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-xl-35 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 35%;
-            flex: 1 1 35%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 35%;
     box-sizing: border-box; }
@@ -22974,36 +22919,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-xl-row > .flex-xl-35 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 35%;
-            flex: 1 1 35%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 35%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-xl-column > .flex-xl-35 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 35%;
-            flex: 1 1 35%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 35%;
     box-sizing: border-box; }
   .flex-xl-40 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 40%;
-            flex: 1 1 40%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 40%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-xl-40 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 40%;
-            flex: 1 1 40%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 40%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-xl-40 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 40%;
-            flex: 1 1 40%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 40%;
     box-sizing: border-box; }
@@ -23037,36 +22982,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-xl-row > .flex-xl-40 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 40%;
-            flex: 1 1 40%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 40%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-xl-column > .flex-xl-40 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 40%;
-            flex: 1 1 40%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 40%;
     box-sizing: border-box; }
   .flex-xl-45 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 45%;
-            flex: 1 1 45%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 45%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-xl-45 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 45%;
-            flex: 1 1 45%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 45%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-xl-45 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 45%;
-            flex: 1 1 45%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 45%;
     box-sizing: border-box; }
@@ -23100,36 +23045,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-xl-row > .flex-xl-45 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 45%;
-            flex: 1 1 45%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 45%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-xl-column > .flex-xl-45 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 45%;
-            flex: 1 1 45%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 45%;
     box-sizing: border-box; }
   .flex-xl-50 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 50%;
-            flex: 1 1 50%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 50%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-xl-50 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 50%;
-            flex: 1 1 50%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 50%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-xl-50 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 50%;
-            flex: 1 1 50%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 50%;
     box-sizing: border-box; }
@@ -23163,36 +23108,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-xl-row > .flex-xl-50 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 50%;
-            flex: 1 1 50%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 50%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-xl-column > .flex-xl-50 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 50%;
-            flex: 1 1 50%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 50%;
     box-sizing: border-box; }
   .flex-xl-55 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 55%;
-            flex: 1 1 55%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 55%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-xl-55 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 55%;
-            flex: 1 1 55%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 55%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-xl-55 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 55%;
-            flex: 1 1 55%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 55%;
     box-sizing: border-box; }
@@ -23226,36 +23171,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-xl-row > .flex-xl-55 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 55%;
-            flex: 1 1 55%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 55%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-xl-column > .flex-xl-55 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 55%;
-            flex: 1 1 55%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 55%;
     box-sizing: border-box; }
   .flex-xl-60 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 60%;
-            flex: 1 1 60%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 60%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-xl-60 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 60%;
-            flex: 1 1 60%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 60%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-xl-60 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 60%;
-            flex: 1 1 60%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 60%;
     box-sizing: border-box; }
@@ -23289,36 +23234,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-xl-row > .flex-xl-60 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 60%;
-            flex: 1 1 60%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 60%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-xl-column > .flex-xl-60 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 60%;
-            flex: 1 1 60%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 60%;
     box-sizing: border-box; }
   .flex-xl-65 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 65%;
-            flex: 1 1 65%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 65%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-xl-65 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 65%;
-            flex: 1 1 65%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 65%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-xl-65 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 65%;
-            flex: 1 1 65%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 65%;
     box-sizing: border-box; }
@@ -23352,36 +23297,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-xl-row > .flex-xl-65 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 65%;
-            flex: 1 1 65%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 65%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-xl-column > .flex-xl-65 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 65%;
-            flex: 1 1 65%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 65%;
     box-sizing: border-box; }
   .flex-xl-70 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 70%;
-            flex: 1 1 70%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 70%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-xl-70 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 70%;
-            flex: 1 1 70%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 70%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-xl-70 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 70%;
-            flex: 1 1 70%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 70%;
     box-sizing: border-box; }
@@ -23415,36 +23360,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-xl-row > .flex-xl-70 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 70%;
-            flex: 1 1 70%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 70%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-xl-column > .flex-xl-70 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 70%;
-            flex: 1 1 70%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 70%;
     box-sizing: border-box; }
   .flex-xl-75 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 75%;
-            flex: 1 1 75%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 75%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-xl-75 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 75%;
-            flex: 1 1 75%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 75%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-xl-75 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 75%;
-            flex: 1 1 75%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 75%;
     box-sizing: border-box; }
@@ -23478,36 +23423,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-xl-row > .flex-xl-75 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 75%;
-            flex: 1 1 75%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 75%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-xl-column > .flex-xl-75 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 75%;
-            flex: 1 1 75%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 75%;
     box-sizing: border-box; }
   .flex-xl-80 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 80%;
-            flex: 1 1 80%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 80%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-xl-80 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 80%;
-            flex: 1 1 80%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 80%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-xl-80 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 80%;
-            flex: 1 1 80%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 80%;
     box-sizing: border-box; }
@@ -23541,36 +23486,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-xl-row > .flex-xl-80 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 80%;
-            flex: 1 1 80%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 80%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-xl-column > .flex-xl-80 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 80%;
-            flex: 1 1 80%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 80%;
     box-sizing: border-box; }
   .flex-xl-85 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 85%;
-            flex: 1 1 85%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 85%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-xl-85 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 85%;
-            flex: 1 1 85%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 85%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-xl-85 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 85%;
-            flex: 1 1 85%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 85%;
     box-sizing: border-box; }
@@ -23604,36 +23549,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-xl-row > .flex-xl-85 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 85%;
-            flex: 1 1 85%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 85%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-xl-column > .flex-xl-85 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 85%;
-            flex: 1 1 85%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 85%;
     box-sizing: border-box; }
   .flex-xl-90 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 90%;
-            flex: 1 1 90%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 90%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-xl-90 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 90%;
-            flex: 1 1 90%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 90%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-xl-90 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 90%;
-            flex: 1 1 90%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 90%;
     box-sizing: border-box; }
@@ -23667,36 +23612,36 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-xl-row > .flex-xl-90 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 90%;
-            flex: 1 1 90%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 90%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-xl-column > .flex-xl-90 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 90%;
-            flex: 1 1 90%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 90%;
     box-sizing: border-box; }
   .flex-xl-95 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 95%;
-            flex: 1 1 95%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 95%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-row > .flex-xl-95 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 95%;
-            flex: 1 1 95%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 95%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-column > .flex-xl-95 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 95%;
-            flex: 1 1 95%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 95%;
     box-sizing: border-box; }
@@ -23730,15 +23675,15 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-xl-row > .flex-xl-95 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 95%;
-            flex: 1 1 95%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 95%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-xl-column > .flex-xl-95 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 95%;
-            flex: 1 1 95%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 95%;
     box-sizing: border-box; }
@@ -23807,15 +23752,15 @@ md-tooltip {
     box-sizing: border-box; }
   .layout-xl-row > .flex-xl-33, .layout-xl-row > .flex-xl-33 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 33.33%;
-            flex: 1 1 33.33%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 33.33%;
     max-height: 100%;
     box-sizing: border-box; }
   .layout-xl-row > .flex-xl-66, .layout-xl-row > .flex-xl-66 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 66.66%;
-            flex: 1 1 66.66%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 66.66%;
     max-height: 100%;
     box-sizing: border-box; }
@@ -23823,15 +23768,15 @@ md-tooltip {
     min-width: 0; }
   .layout-xl-column > .flex-xl-33, .layout-xl-column > .flex-xl-33 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 33.33%;
-            flex: 1 1 33.33%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 33.33%;
     box-sizing: border-box; }
   .layout-xl-column > .flex-xl-66, .layout-xl-column > .flex-xl-66 {
     -webkit-box-flex: 1;
-    -webkit-flex: 1 1 66.66%;
-            flex: 1 1 66.66%;
+    -webkit-flex: 1 1 100%;
+            flex: 1 1 100%;
     max-width: 100%;
     max-height: 66.66%;
     box-sizing: border-box; }

--- a/src/picker.js
+++ b/src/picker.js
@@ -1166,38 +1166,38 @@ function picker(){
     var rangeDefaultList = [
         {
             label:'Today',
-            startDate:moment().startOf('day'),
-            endDate:moment().endOf('day')
+            startDate:moment().utc().startOf('day'),
+            endDate:moment().utc().endOf('day')
         },
         {
             label:'Last 7 Days',
-            startDate: moment().subtract(7, 'd'),
-            endDate:moment()
+            startDate: moment().utc().subtract(7, 'd').startOf('day'),
+            endDate:moment().utc().endOf('day')
         },
         {
             label:'This Month',
-            startDate:moment().startOf('month'),
-            endDate: moment().endOf('month')
+            startDate:moment().utc().startOf('month'),
+            endDate: moment().utc().endOf('month')
         },
         {
             label:'Last Month',
-            startDate:moment().subtract(1, 'month').startOf('month'),
-            endDate: moment().subtract(1, 'month').endOf('month')
+            startDate:moment().utc().subtract(1, 'month').startOf('month'),
+            endDate: moment().utc().subtract(1, 'month').endOf('month')
         },
         {
             label: 'This Quarter',
-            startDate: moment().startOf('quarter'),
-            endDate: moment().endOf('quarter')
+            startDate: moment().utc().startOf('quarter'),
+            endDate: moment().utc().endOf('quarter')
         },
         {
             label:  'Year To Date',
-            startDate:  moment().startOf('year'),
-            endDate:  moment()
+            startDate:  moment().utc().startOf('year'),
+            endDate:  moment().utc().endOf('day')
         },
         {
             label:  'This Year',
-            startDate:  moment().startOf('year'),
-            endDate:  moment().endOf('year')
+            startDate:  moment().utc().startOf('year'),
+            endDate:  moment().utc().endOf('year')
         }
     ];
 


### PR DESCRIPTION
There is a problem with UTC for endDate. See an example:

In sm-range-picker-input, selecte **TODAY**
![untitled-1 fw](https://cloud.githubusercontent.com/assets/6631277/23916041/a4725a56-08c9-11e7-8925-2d7b4fff0a85.png)

Result:
![untitled-2 fw](https://cloud.githubusercontent.com/assets/6631277/23916093/d76b2ece-08c9-11e7-962b-44ff6343da22.png)

This happens because of UTC. 

**Solution:**
> change endDate:moment().endOf('day') by  endDate:moment().**utc()**.endOf('day')

![untitled-3 fw](https://cloud.githubusercontent.com/assets/6631277/23916347/9fdd8794-08ca-11e7-97e1-efbd816df8f1.png)







